### PR TITLE
rename top_k in py and rs -> topk 

### DIFF
--- a/docs/concepts/semantic-search.mdx
+++ b/docs/concepts/semantic-search.mdx
@@ -60,7 +60,7 @@ docs = client.collection("books").query(
         "title",
         title_similarity=fn.semantic_similarity("title", "catcher in the rye")
     )
-    .top_k(field("title_similarity"), 10)
+    .topk(field("title_similarity"), 10)
     .rerank()
 )
 ```
@@ -106,7 +106,7 @@ docs = client.collection("books").query(
         text_score=fn.bm25_score()  # Keyword-based relevance
     )
     .filter(match("classic"))  # Ensure the book title contains "classic" keyword
-    .top_k(field("title_similarity") * 0.7 + field("text_score") * 0.3, 10)
+    .topk(field("title_similarity") * 0.7 + field("text_score") * 0.3, 10)
 )
 ```
 
@@ -180,7 +180,7 @@ docs = client.collection("books").query(
         "title",
         title_similarity=fn.vector_distance("title_embedding", [0.1, 0.2, 0.3, ...])
     )
-    .top_k(field("title_similarity"), 10)
+    .topk(field("title_similarity"), 10)
 )
 ```
 
@@ -217,7 +217,7 @@ docs = client.collection("books").query(
         "title",
         title_similarity=fn.vector_distance("title_embedding", [0.1, 0.2, 0.3, ...])
     )
-    .top_k(field("title_similarity"), 10)
+    .topk(field("title_similarity"), 10)
     .rerank(
         query="catcher in the rye",
         fields=["title"]
@@ -259,7 +259,7 @@ docs = client.collection("books").query(
         text_score=fn.bm25_score(),
     )
     .filter(match("catcher in the rye"))
-    .top_k(field("text_score"), 10)
+    .topk(field("text_score"), 10)
     .rerank(
         query="catcher in the rye",
         fields=["title"]

--- a/docs/concepts/unified-retrieval.mdx
+++ b/docs/concepts/unified-retrieval.mdx
@@ -94,7 +94,7 @@ const docs = await client.collection("papers").query(
 **Explanation**
 
 - We retrieve documents based on both the full paper summary and the paragraph summary.
-- The `top_k()` function blends the two scores, giving 70% weight to the full paper and 30% weight to the paragraph.
+- The `topk()` function blends the two scores, giving 70% weight to the full paper and 30% weight to the paragraph.
 - This method ensures that entirely relevant papers rank higher while also considering specific paragraph relevance.
 
 ---
@@ -176,7 +176,7 @@ const docs = await client.collection("articles").query(
 
 - We retrieve documents based on semantic meaning (`content_score`) and keyword matching (`keyword_match`).
 - The `filter()` ensures that documents must contain at least one relevant keyword.
-- The `top_k()` function weights the scores, prioritizing semantic meaning (60%) while still considering keyword matches (40%).
+- The `topk()` function weights the scores, prioritizing semantic meaning (60%) while still considering keyword matches (40%).
 
 This **balances precision and recall**, capturing both **exact keyword matches** and **meaningful context**.
 
@@ -254,5 +254,5 @@ const docs = await client.collection("documents").query(
 **Explanation**
 
 - We retrieve documents based on both semantic similarity (`content_score`) and precomputed importance (`importance_score`).
-- The `top_k()` function gives 80% weight to content relevance and 20% weight to document importance.
+- The `topk()` function gives 80% weight to content relevance and 20% weight to document importance.
 - This method allows you to boost more critical documents, ensuring that highly relevant but less "important" content doesn't dominate.

--- a/docs/concepts/unified-retrieval.mdx
+++ b/docs/concepts/unified-retrieval.mdx
@@ -63,7 +63,7 @@ docs = client.collection("papers").query(
         paper_score=fn.semantic_similarity("paper_summary", "deep learning optimization"),
         paragraph_score=fn.semantic_similarity("paragraph_summary", "stochastic gradient descent")
     )
-    .top_k(field("paper_score") * 0.7 + field("paragraph_score") * 0.3, 10)
+    .topk(field("paper_score") * 0.7 + field("paragraph_score") * 0.3, 10)
 )
 ```
 
@@ -145,7 +145,7 @@ docs = client.collection("articles").query(
         text_score=fn.bm25_score()
     )
     .filter(match("carbon tax") | match("renewable energy"))  # Ensure keyword relevance
-    .top_k(field("content_similarity") * 0.6 + field("text_score") * 0.4, 10)
+    .topk(field("content_similarity") * 0.6 + field("text_score") * 0.4, 10)
 )
 ```
 
@@ -225,7 +225,7 @@ docs = client.collection("documents").query(
     select(
         content_score=fn.semantic_similarity("content", "machine learning applications"),
     )
-    .top_k(0.8 * field("importance") + 0.2 * field("content_score"), 10)
+    .topk(0.8 * field("importance") + 0.2 * field("content_score"), 10)
 )
 ```
 

--- a/docs/documents/query.mdx
+++ b/docs/documents/query.mdx
@@ -24,7 +24,7 @@ docs = client.collection("books").query(
         "title",
         title_similarity=fn.semantic_similarity("title", "catcher")
     )
-    .top_k(field("title_similarity"), 10)
+    .topk(field("title_similarity"), 10)
 )
 ```
 
@@ -66,7 +66,7 @@ docs = client.collection("books").query(
     # or the `catcher` in any of the text-indexed fields.
     .filter(match("great", field="title") | match("catcher"))
     # Return top 10 documents with the highest text score
-    .top_k(field("text_score"), 10)
+    .topk(field("text_score"), 10)
 )
 ```
 
@@ -111,7 +111,7 @@ docs = client.collection("books").query(
         title_similarity=fn.vector_distance("title_embedding", [0.1, 0.2, 0.3, ...])
     )
     # Return top 10 results with the highest similarity
-    .top_k(field("title_similarity"), 10)
+    .topk(field("title_similarity"), 10)
 )
 ```
 
@@ -257,7 +257,7 @@ You can use the `top_k` method to return the top `k` results. The `top_k` method
 
 ```python Python
 # Return top 10 results order by `published_year` ascending
-.top_k(field("title_similarity"), 10, asc=True)
+.topk(field("title_similarity"), 10, asc=True)
 ```
 
 
@@ -305,7 +305,7 @@ Supported models:
 ```python Python
 .rerank()
 
-# or 
+# or
 
 .rerank(
     model="cohere/rerank-v3.5",
@@ -319,7 +319,7 @@ Supported models:
 ```typescript JavaScript
 .rerank()
 
-// or 
+// or
 
 .rerank({
   model: "cohere/rerank-v3.5",
@@ -353,7 +353,7 @@ docs = client.collection("books").query(
     # Filtering by metadata
     .filter(field("published_year") > 1980)
     # Return top 10 documents with the highest combined score
-    .top_k(field("text_score") * 0.2 + field("title_similarity") * 0.8, 10)
+    .topk(field("text_score") * 0.2 + field("title_similarity") * 0.8, 10)
     # Rerank the documents
     .rerank()
 )

--- a/docs/documents/query.mdx
+++ b/docs/documents/query.mdx
@@ -247,11 +247,11 @@ The `contains` operator can be used on string fields to match documents that inc
 
 ## Results collection
 
-All queries are required to have a collection stage. Currently, we only support `top_k` and `count` collectors.
+All queries are required to have a collection stage. Currently, we only support `topk` and `count` collectors.
 
-### top_k
+### topk
 
-You can use the `top_k` method to return the top `k` results. The `top_k` method takes a field, the number of results to return, and an optional `asc` parameter to sort the results in ascending order.
+You can use the `topk` method to return the top `k` results. The `topk` method takes a field, the number of results to return, and an optional `asc` parameter to sort the results in ascending order.
 
 <CodeGroup>
 
@@ -294,7 +294,7 @@ You can rerank the results of a query using the `rerank` method. The `rerank` me
 - `model` (optional): The model to use for reranking. If not specified, uses the default model.
 - `query` (optional): The query text to rerank against. Uses arguments from `semantic_similarity` if not specified.
 - `fields` (optional): List of fields to use for reranking. Uses fields from `semantic_similarity` if not specified.
-- `topk_multiple` (optional): Multiple of top-k to rerank. For example, if `top_k=10` and `topk_multiple=2`, reranker takes 20 results from the original query and returns the top 10 results.
+- `topk_multiple` (optional): Multiple of top-k to rerank. For example, if `topk=10` and `topk_multiple=2`, reranker takes 20 results from the original query and returns the top 10 results.
 
 Supported models:
 
@@ -383,7 +383,7 @@ const docs = await client.collection("books").query(
 
 ## Notes on writing queries
 
-When writing queries, remember that they all require the `top_k` or `count` method at the end.
+When writing queries, remember that they all require the `topk` or `count` method at the end.
 
 ## Next steps
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -176,7 +176,7 @@ results = client.collection("books").query(
         title_similarity=fn.semantic_similarity("title", "classic American novel"),
     )
     # Sort results by the `title_similarity` field, selecting the top 10 results
-    .top_k(field("title_similarity"), 10)
+    .topk(field("title_similarity"), 10)
 )
 ```
 

--- a/topk-protos/protos/topk/data/v1/query.proto
+++ b/topk-protos/protos/topk/data/v1/query.proto
@@ -54,7 +54,7 @@ message Stage {
   oneof stage {
     SelectStage select = 1;
     FilterStage filter = 2;
-    TopKStage topk = 3;
+    TopKStage top_k = 3;
     CountStage count = 4;
     RerankStage rerank = 5;
   }

--- a/topk-protos/protos/topk/data/v1/query.proto
+++ b/topk-protos/protos/topk/data/v1/query.proto
@@ -54,7 +54,7 @@ message Stage {
   oneof stage {
     SelectStage select = 1;
     FilterStage filter = 2;
-    TopKStage top_k = 3;
+    TopKStage topk = 3;
     CountStage count = 4;
     RerankStage rerank = 5;
   }

--- a/topk-protos/src/data/v1/query_ext.rs
+++ b/topk-protos/src/data/v1/query_ext.rs
@@ -28,7 +28,7 @@ impl Stage {
         }
     }
 
-    pub fn top_k(expr: LogicalExpr, k: u64, asc: bool) -> Self {
+    pub fn topk(expr: LogicalExpr, k: u64, asc: bool) -> Self {
         Stage {
             stage: Some(stage::Stage::TopK(stage::TopKStage {
                 expr: Some(expr),

--- a/topk-py/README.md
+++ b/topk-py/README.md
@@ -90,7 +90,7 @@ results = client.collection("books").query(
     "title",
     title_similarity=fn.semantic_similarity("title", "classic American novel"), # Semantic search
   )
-  .top_k(field("title_similarity"), 10) # Return top 10 most relevant results
+  .topk(field("title_similarity"), 10) # Return top 10 most relevant results
 )
 ```
 

--- a/topk-py/src/query/query.rs
+++ b/topk-py/src/query/query.rs
@@ -105,7 +105,7 @@ impl Query {
     }
 
     #[pyo3(signature = (expr, k, asc=false))]
-    pub fn top_k(&self, expr: LogicalExpr, k: u64, asc: bool) -> PyResult<Self> {
+    pub fn topk(&self, expr: LogicalExpr, k: u64, asc: bool) -> PyResult<Self> {
         Ok(Self {
             stages: [
                 self.stages.clone(),

--- a/topk-py/tests/test_delete.py
+++ b/topk-py/tests/test_delete.py
@@ -29,7 +29,7 @@ def test_delete_document(ctx: ProjectContext):
     assert lsn == "2"
 
     docs = ctx.client.collection(collection.name).query(
-        select("title").top_k(field("rank"), 100, True), lsn=lsn
+        select("title").topk(field("rank"), 100, True), lsn=lsn
     )
 
     assert doc_ids(docs) == {"two"}

--- a/topk-py/tests/test_query_filter_contains.py
+++ b/topk-py/tests/test_query_filter_contains.py
@@ -8,7 +8,7 @@ def test_query_contains(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(field("_id").contains("atch")).top_k(field("published_year"), 100, False)
+        filter(field("_id").contains("atch")).topk(field("published_year"), 100, False)
     )
 
     assert doc_ids(result) == {"catcher"}
@@ -18,7 +18,7 @@ def test_query_contains_empty(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(field("_id").contains("")).top_k(field("published_year"), 100, False)
+        filter(field("_id").contains("")).topk(field("published_year"), 100, False)
     )
 
     assert doc_ids(result) == {
@@ -39,7 +39,7 @@ def test_query_contains_no_match(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(field("_id").contains("rubbish")).top_k(
+        filter(field("_id").contains("rubbish")).topk(
             field("published_year"), 100, False
         )
     )

--- a/topk-py/tests/test_query_filter_not.py
+++ b/topk-py/tests/test_query_filter_not.py
@@ -8,7 +8,7 @@ def test_query_not(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(not_(field("_id").contains("gatsby"))).top_k(
+        filter(not_(field("_id").contains("gatsby"))).topk(
             field("published_year"), 100, False
         )
     )

--- a/topk-py/tests/test_query_filter_starts_with.py
+++ b/topk-py/tests/test_query_filter_starts_with.py
@@ -8,7 +8,7 @@ def test_query_starts_with(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(field("_id").starts_with("cat")).top_k(
+        filter(field("_id").starts_with("cat")).topk(
             field("published_year"), 100, False
         )
     )
@@ -20,7 +20,7 @@ def test_query_starts_with_empty(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(field("_id").starts_with("")).top_k(field("published_year"), 100, False)
+        filter(field("_id").starts_with("")).topk(field("published_year"), 100, False)
     )
 
     assert doc_ids(result) == {
@@ -41,7 +41,7 @@ def test_query_starts_with_non_existent_prefix(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(field("_id").starts_with("foobarbaz")).top_k(
+        filter(field("_id").starts_with("foobarbaz")).topk(
             field("published_year"), 100, False
         )
     )

--- a/topk-py/tests/test_query_logical.py
+++ b/topk-py/tests/test_query_logical.py
@@ -9,7 +9,7 @@ def test_query_lte(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(field("published_year") <= 1950).top_k(
+        filter(field("published_year") <= 1950).topk(
             field("published_year"), 100, True
         )
     )
@@ -23,7 +23,7 @@ def test_query_and(ctx: ProjectContext):
     result = ctx.client.collection(collection.name).query(
         filter(
             (field("published_year") <= 1950) & (field("published_year") >= 1948)
-        ).top_k(field("published_year"), 100, True)
+        ).topk(field("published_year"), 100, True)
     )
 
     assert doc_ids(result) == {"1984"}

--- a/topk-py/tests/test_query_select.py
+++ b/topk-py/tests/test_query_select.py
@@ -10,7 +10,7 @@ def test_query_select_literal(ctx: ProjectContext):
     results = ctx.client.collection(collection.name).query(
         select(literal=literal(1.0))
         .filter(field("title") == "1984")
-        .top_k(field("published_year"), 100, True)
+        .topk(field("published_year"), 100, True)
     )
 
     assert results == [{"_id": "1984", "literal": 1.0}]
@@ -22,7 +22,7 @@ def test_query_select_non_existing_field(ctx: ProjectContext):
     results = ctx.client.collection(collection.name).query(
         select(literal=field("non_existing_field"))
         .filter(field("title") == "1984")
-        .top_k(field("published_year"), 100, True)
+        .topk(field("published_year"), 100, True)
     )
 
     assert results == [{"_id": "1984"}]
@@ -32,17 +32,17 @@ def test_query_topk_limit(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     results = ctx.client.collection(collection.name).query(
-        select("title").top_k(field("published_year"), 3, True)
+        select("title").topk(field("published_year"), 3, True)
     )
     assert len(results) == 3
 
     results = ctx.client.collection(collection.name).query(
-        select("title").top_k(field("published_year"), 2, True)
+        select("title").topk(field("published_year"), 2, True)
     )
     assert len(results) == 2
 
     results = ctx.client.collection(collection.name).query(
-        select("title").top_k(field("published_year"), 1, True)
+        select("title").topk(field("published_year"), 1, True)
     )
     assert len(results) == 1
 
@@ -51,7 +51,7 @@ def test_query_topk_asc(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     results = ctx.client.collection(collection.name).query(
-        select("published_year").top_k(field("published_year"), 3, True)
+        select("published_year").topk(field("published_year"), 3, True)
     )
 
     assert results == [
@@ -65,7 +65,7 @@ def test_query_topk_desc(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     results = ctx.client.collection(collection.name).query(
-        select("published_year").top_k(field("published_year"), 3, False)
+        select("published_year").topk(field("published_year"), 3, False)
     )
 
     assert results == [
@@ -81,7 +81,7 @@ def test_query_select_bm25_score(ctx: ProjectContext):
     results = ctx.client.collection(collection.name).query(
         select(bm25_score=fn.bm25_score())
         .filter(match("pride"))
-        .top_k(field("bm25_score"), 100, True)
+        .topk(field("bm25_score"), 100, True)
     )
 
     assert doc_ids(results) == {"pride"}
@@ -93,7 +93,7 @@ def test_query_select_vector_distance(ctx: ProjectContext):
     results = ctx.client.collection(collection.name).query(
         select(
             summary_distance=fn.vector_distance("summary_embedding", [2.0] * 16)
-        ).top_k(field("summary_distance"), 3, True)
+        ).topk(field("summary_distance"), 3, True)
     )
 
     assert doc_ids(results) == {"1984", "mockingbird", "pride"}
@@ -107,7 +107,7 @@ def test_query_select_null_field(ctx: ProjectContext):
     )
 
     results = ctx.client.collection(collection.name).query(
-        select(a=field("a"), b=literal(1)).top_k(field("b"), 100, True)
+        select(a=field("a"), b=literal(1)).topk(field("b"), 100, True)
     )
 
     # Assert that `a` is null for all documents, even when not specified when upserting

--- a/topk-py/tests/test_query_select_union.py
+++ b/topk-py/tests/test_query_select_union.py
@@ -33,7 +33,7 @@ def test_query_select_union(ctx: ProjectContext):
     ctx.client.collection(collection.name).count(lsn=lsn)
 
     results = ctx.client.collection(collection.name).query(
-        select("mixed").top_k(field("rank"), 100, True)
+        select("mixed").topk(field("rank"), 100, True)
     )
 
     # Verify we have all the documents

--- a/topk-py/tests/test_query_text.py
+++ b/topk-py/tests/test_query_text.py
@@ -10,7 +10,7 @@ def test_query_text_filter_single_term_disjunctive(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(match("love", field="summary")).top_k(field("published_year"), 100, True)
+        filter(match("love", field="summary")).topk(field("published_year"), 100, True)
     )
 
     assert {doc["_id"] for doc in result} == {"pride", "gatsby"}
@@ -20,7 +20,7 @@ def test_query_text_filter_single_term_conjunctive(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(match("love", field="summary")).top_k(field("published_year"), 100, True)
+        filter(match("love", field="summary")).topk(field("published_year"), 100, True)
     )
 
     assert {doc["_id"] for doc in result} == {"gatsby", "pride"}
@@ -30,7 +30,7 @@ def test_query_text_filter_two_terms_disjunctive(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(match("LOVE", "summary") | match("ring", "title")).top_k(
+        filter(match("LOVE", "summary") | match("ring", "title")).topk(
             field("published_year"), 100, True
         )
     )
@@ -42,7 +42,7 @@ def test_query_text_filter_two_terms_conjunctive(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(match("LOVE", field="summary") & match("class", field="summary")).top_k(
+        filter(match("LOVE", field="summary") & match("class", field="summary")).topk(
             field("published_year"), 100, True
         )
     )
@@ -54,7 +54,7 @@ def test_query_text_filter_stop_word(ctx: ProjectContext):
     collection = dataset.books.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        filter(match("the", field="summary")).top_k(field("published_year"), 100, True)
+        filter(match("the", field="summary")).topk(field("published_year"), 100, True)
     )
 
     assert len(result) == 0
@@ -67,5 +67,5 @@ def test_query_select_bm25_without_text_queries(ctx: ProjectContext):
         ctx.client.collection(collection.name).query(
             select(bm25_score=fn.bm25_score())
             .filter(field("_id") == "pride")
-            .top_k(field("bm25_score"), 100, True)
+            .topk(field("bm25_score"), 100, True)
         )

--- a/topk-py/tests/test_query_validation.py
+++ b/topk-py/tests/test_query_validation.py
@@ -11,7 +11,7 @@ def test_query_topk_by_non_primitive(ctx: ProjectContext):
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
         ctx.client.collection(collection.name).query(
-            select("title").top_k(field("title"), 3, True)
+            select("title").topk(field("title"), 3, True)
         )
     assert "Input to SortWithLimit must produce primitive type, not String" in str(
         exc_info.value
@@ -23,7 +23,7 @@ def test_query_topk_by_non_existing(ctx: ProjectContext):
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
         ctx.client.collection(collection.name).query(
-            select("title").top_k(field("non_existing_field"), 3, True)
+            select("title").topk(field("non_existing_field"), 3, True)
         )
     assert "Input to SortWithLimit must produce primitive type, not Null" in str(
         exc_info.value
@@ -35,7 +35,7 @@ def test_query_topk_limit_zero(ctx: ProjectContext):
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
         ctx.client.collection(collection.name).query(
-            select("title").top_k(field("published_year"), 0, True)
+            select("title").topk(field("published_year"), 0, True)
         )
     assert "Invalid argument: TopK k must be > 0" in str(exc_info.value)
 
@@ -54,6 +54,6 @@ def test_union_u32_and_binary(ctx: ProjectContext):
 
     with pytest.raises(error.InvalidArgumentError) as exc_info:
         ctx.client.collection(collection.name).query(
-            select("title").top_k(field("num"), 100, True)
+            select("title").topk(field("num"), 100, True)
         )
     assert "Input to SortWithLimit must produce primitive type" in str(exc_info.value)

--- a/topk-py/tests/test_query_vector.py
+++ b/topk-py/tests/test_query_vector.py
@@ -18,7 +18,7 @@ def test_query_vector_distance(ctx: ProjectContext):
         select(
             "title",
             summary_distance=fn.vector_distance("summary_embedding", [2.0] * 16),
-        ).top_k(field("summary_distance"), 3, True)
+        ).topk(field("summary_distance"), 3, True)
     )
 
     assert is_sorted(result, "summary_distance")
@@ -34,7 +34,7 @@ def test_query_vector_distance_nullable(ctx: ProjectContext):
             summary_distance=fn.vector_distance(
                 "nullable_embedding", f32_vector([3.0] * 16)
             )
-        ).top_k(field("summary_distance"), 3, True)
+        ).topk(field("summary_distance"), 3, True)
     )
 
     assert is_sorted(result, "summary_distance")
@@ -47,7 +47,7 @@ def test_query_vector_distance_u8_vector(ctx: ProjectContext):
     result = ctx.client.collection(collection.name).query(
         select(
             summary_distance=fn.vector_distance("scalar_embedding", u8_vector([8] * 16))
-        ).top_k(field("summary_distance"), 3, True)
+        ).topk(field("summary_distance"), 3, True)
     )
 
     assert is_sorted(result, "summary_distance")
@@ -62,7 +62,7 @@ def test_query_vector_distance_binary_vector(ctx: ProjectContext):
             summary_distance=fn.vector_distance(
                 "binary_embedding", binary_vector([0, 1])
             )
-        ).top_k(field("summary_distance"), 2, True)
+        ).topk(field("summary_distance"), 2, True)
     )
 
     assert is_sorted(result, "summary_distance")

--- a/topk-py/tests/test_semantic_index.py
+++ b/topk-py/tests/test_semantic_index.py
@@ -36,7 +36,7 @@ def test_semantic_index_query(ctx: ProjectContext):
     collection = dataset.semantic.setup(ctx)
 
     result = ctx.client.collection(collection.name).query(
-        select(sim=fn.semantic_similarity("title", "dummy")).top_k(
+        select(sim=fn.semantic_similarity("title", "dummy")).topk(
             field("sim"), 3, True
         )
     )
@@ -50,7 +50,7 @@ def test_semantic_index_query_with_text_filter(ctx: ProjectContext):
     result = ctx.client.collection(collection.name).query(
         select(sim=fn.semantic_similarity("title", "dummy"))
         .filter(match("love", "summary"))
-        .top_k(field("sim"), 3, True)
+        .topk(field("sim"), 3, True)
     )
 
     # order is not guaranteed, since we're using a "dummy" embedder
@@ -62,7 +62,7 @@ def test_semantic_index_query_with_missing_index(ctx: ProjectContext):
 
     with pytest.raises(error.InvalidArgumentError):
         ctx.client.collection(collection.name).query(
-            select(sim=fn.semantic_similarity("published_year", "dummy")).top_k(
+            select(sim=fn.semantic_similarity("published_year", "dummy")).topk(
                 field("sim"), 3, True
             )
         )
@@ -75,7 +75,7 @@ def test_semantic_index_query_multiple_fields(ctx: ProjectContext):
         select(
             title_sim=fn.semantic_similarity("title", "dummy"),
             summary_sim=fn.semantic_similarity("summary", "query"),
-        ).top_k(field("title_sim") + field("summary_sim"), 5, True)
+        ).topk(field("title_sim") + field("summary_sim"), 5, True)
     )
 
     assert len(result) == 5
@@ -87,7 +87,7 @@ def test_semantic_index_query_and_rerank_with_missing_model(ctx: ProjectContext)
     with pytest.raises(error.InvalidArgumentError):
         ctx.client.collection(collection.name).query(
             select(sim=fn.semantic_similarity("title", "dummy"))
-            .top_k(field("sim"), 3, True)
+            .topk(field("sim"), 3, True)
             .rerank("definitely-does-not-exist")
         )
 
@@ -97,7 +97,7 @@ def test_semantic_index_query_and_rerank(ctx: ProjectContext):
 
     result = ctx.client.collection(collection.name).query(
         select(sim=fn.semantic_similarity("title", "dummy"))
-        .top_k(field("sim"), 3, True)
+        .topk(field("sim"), 3, True)
         .rerank("dummy")
     )
 
@@ -114,7 +114,7 @@ def test_semantic_index_query_and_rerank_multiple_semantic_sim_explicit(
             title_sim=fn.semantic_similarity("title", "dummy"),
             summary_sim=fn.semantic_similarity("summary", "query"),
         )
-        .top_k(field("title_sim") + field("summary_sim"), 5, True)
+        .topk(field("title_sim") + field("summary_sim"), 5, True)
         .rerank("dummy", "query string", ["title", "summary"])
     )
 
@@ -132,6 +132,6 @@ def test_semantic_index_query_and_rerank_multiple_semantic_sim_implicit(
                 title_sim=fn.semantic_similarity("title", "dummy"),
                 summary_sim=fn.semantic_similarity("summary", "query"),
             )
-            .top_k(field("title_sim") + field("summary_sim"), 5, True)
+            .topk(field("title_sim") + field("summary_sim"), 5, True)
             .rerank("dummy")
         )

--- a/topk-rs/src/query/query.rs
+++ b/topk-rs/src/query/query.rs
@@ -34,7 +34,7 @@ impl Query {
         query
     }
 
-    pub fn top_k(&self, expr: impl Into<LogicalExpr>, limit: u64, asc: bool) -> Self {
+    pub fn topk(&self, expr: impl Into<LogicalExpr>, limit: u64, asc: bool) -> Self {
         let mut query = self.clone();
         query.stages.push(Stage::TopK {
             expr: expr.into().into(),

--- a/topk-rs/src/query/stage.rs
+++ b/topk-rs/src/query/stage.rs
@@ -28,9 +28,7 @@ impl From<Stage> for topk_protos::v1::data::Stage {
         match stage {
             Stage::Select { exprs } => topk_protos::v1::data::Stage::select(exprs),
             Stage::Filter { expr } => topk_protos::v1::data::Stage::filter(expr),
-            Stage::TopK { expr, k, asc } => {
-                topk_protos::v1::data::Stage::top_k(expr.into(), k, asc)
-            }
+            Stage::TopK { expr, k, asc } => topk_protos::v1::data::Stage::topk(expr.into(), k, asc),
             Stage::Count {} => topk_protos::v1::data::Stage::count(),
             Stage::Rerank {
                 model,

--- a/topk-rs/tests/test_delete.rs
+++ b/topk-rs/tests/test_delete.rs
@@ -60,7 +60,7 @@ async fn test_delete_document(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("rank"), 100, true),
+            select([("title", field("title"))]).topk(field("rank"), 100, true),
             Some(lsn),
             None,
         )

--- a/topk-rs/tests/test_query_filter_contains.rs
+++ b/topk-rs/tests/test_query_filter_contains.rs
@@ -15,7 +15,7 @@ async fn test_query_contains(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(field("_id").contains("atch")).top_k(field("published_year"), 100, false),
+            filter(field("_id").contains("atch")).topk(field("published_year"), 100, false),
             None,
             None,
         )
@@ -34,7 +34,7 @@ async fn test_query_contains_no_match(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(field("_id").contains("rubbish")).top_k(field("published_year"), 100, false),
+            filter(field("_id").contains("rubbish")).topk(field("published_year"), 100, false),
             None,
             None,
         )
@@ -53,7 +53,7 @@ async fn test_query_contains_empty(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(field("_id").contains("")).top_k(field("published_year"), 100, false),
+            filter(field("_id").contains("")).topk(field("published_year"), 100, false),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_filter_not.rs
+++ b/topk-rs/tests/test_query_filter_not.rs
@@ -16,7 +16,7 @@ async fn test_query_not(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(not(field("_id").contains("gatsby"))).top_k(field("published_year"), 100, false),
+            filter(not(field("_id").contains("gatsby"))).topk(field("published_year"), 100, false),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_filter_starts_with.rs
+++ b/topk-rs/tests/test_query_filter_starts_with.rs
@@ -15,7 +15,7 @@ async fn test_query_starts_with(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(field("_id").starts_with("cat")).top_k(field("published_year"), 100, false),
+            filter(field("_id").starts_with("cat")).topk(field("published_year"), 100, false),
             None,
             None,
         )
@@ -34,7 +34,7 @@ async fn test_query_starts_with_empty(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(field("_id").starts_with("")).top_k(field("published_year"), 100, false),
+            filter(field("_id").starts_with("")).topk(field("published_year"), 100, false),
             None,
             None,
         )
@@ -67,11 +67,7 @@ async fn test_query_starts_with_non_existent_prefix(ctx: &mut ProjectTestContext
         .client
         .collection(&collection.name)
         .query(
-            filter(field("_id").starts_with("foobarbaz")).top_k(
-                field("published_year"),
-                100,
-                false,
-            ),
+            filter(field("_id").starts_with("foobarbaz")).topk(field("published_year"), 100, false),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_logical.rs
+++ b/topk-rs/tests/test_query_logical.rs
@@ -15,7 +15,7 @@ async fn test_query_lte(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(field("published_year").lte(1950 as u32)).top_k(
+            filter(field("published_year").lte(1950 as u32)).topk(
                 field("published_year"),
                 100,
                 true,
@@ -43,7 +43,7 @@ async fn test_query_and(ctx: &mut ProjectTestContext) {
                     .lte(1950 as u32)
                     .and(field("published_year").gte(1948 as u32)),
             )
-            .top_k(field("published_year"), 100, true),
+            .topk(field("published_year"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_select.rs
+++ b/topk-rs/tests/test_query_select.rs
@@ -20,7 +20,7 @@ async fn test_query_select_literal(ctx: &mut ProjectTestContext) {
         .query(
             select([("literal", literal(1.0))])
                 .filter(field("title").eq("1984"))
-                .top_k(field("published_year"), 100, true),
+                .topk(field("published_year"), 100, true),
             None,
             None,
         )
@@ -41,7 +41,7 @@ async fn test_query_select_non_existing_field(ctx: &mut ProjectTestContext) {
         .query(
             select([("literal", field("non_existing_field"))])
                 .filter(field("title").eq("1984"))
-                .top_k(field("published_year"), 100, true),
+                .topk(field("published_year"), 100, true),
             None,
             None,
         )
@@ -60,7 +60,7 @@ async fn test_query_topk_limit(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("published_year"), 3, true),
+            select([("title", field("title"))]).topk(field("published_year"), 3, true),
             None,
             None,
         )
@@ -72,7 +72,7 @@ async fn test_query_topk_limit(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("published_year"), 2, true),
+            select([("title", field("title"))]).topk(field("published_year"), 2, true),
             None,
             None,
         )
@@ -84,7 +84,7 @@ async fn test_query_topk_limit(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("published_year"), 1, true),
+            select([("title", field("title"))]).topk(field("published_year"), 1, true),
             None,
             None,
         )
@@ -102,7 +102,7 @@ async fn test_query_topk_asc(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("published_year", field("published_year"))]).top_k(
+            select([("published_year", field("published_year"))]).topk(
                 field("published_year"),
                 3,
                 true,
@@ -132,7 +132,7 @@ async fn test_query_topk_desc(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("published_year", field("published_year"))]).top_k(
+            select([("published_year", field("published_year"))]).topk(
                 field("published_year"),
                 3,
                 false,
@@ -164,7 +164,7 @@ async fn test_query_select_bm25_score(ctx: &mut ProjectTestContext) {
         .query(
             select([("bm25_score", fns::bm25_score())])
                 .filter(r#match("pride", None, None))
-                .top_k(field("bm25_score"), 100, true),
+                .topk(field("bm25_score"), 100, true),
             None,
             None,
         )
@@ -190,7 +190,7 @@ async fn test_query_select_vector_distance(ctx: &mut ProjectTestContext) {
                 "summary_distance",
                 fns::vector_distance("summary_embedding", Vector::F32(vec![2.0; 16])),
             )])
-            .top_k(field("summary_distance"), 3, true),
+            .topk(field("summary_distance"), 3, true),
             None,
             None,
         )
@@ -223,7 +223,7 @@ async fn test_query_select_null_field(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("a", field("a")), ("b", literal(1 as u32))]).top_k(field("b"), 100, true),
+            select([("a", field("a")), ("b", literal(1 as u32))]).topk(field("b"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_select_union.rs
+++ b/topk-rs/tests/test_query_select_union.rs
@@ -50,7 +50,7 @@ async fn test_query_select_union(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("mixed", field("mixed"))]).top_k(field("rank"), 100, true),
+            select([("mixed", field("mixed"))]).topk(field("rank"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_text.rs
+++ b/topk-rs/tests/test_query_text.rs
@@ -16,7 +16,7 @@ async fn test_query_text_filter_single_term_disjunctive(ctx: &mut ProjectTestCon
         .client
         .collection(&collection.name)
         .query(
-            filter(r#match("love", Some("summary"), None)).top_k(
+            filter(r#match("love", Some("summary"), None)).topk(
                 field("published_year"),
                 100,
                 true,
@@ -39,7 +39,7 @@ async fn test_query_text_filter_single_term_conjunctive(ctx: &mut ProjectTestCon
         .client
         .collection(&collection.name)
         .query(
-            filter(r#match("love", Some("summary"), None)).top_k(
+            filter(r#match("love", Some("summary"), None)).topk(
                 field("published_year"),
                 100,
                 true,
@@ -63,7 +63,7 @@ async fn test_query_text_filter_two_terms_disjunctive(ctx: &mut ProjectTestConte
         .collection(&collection.name)
         .query(
             filter(r#match("LOVE", Some("summary"), None).or(r#match("ring", Some("title"), None)))
-                .top_k(field("published_year"), 100, true),
+                .topk(field("published_year"), 100, true),
             None,
             None,
         )
@@ -87,7 +87,7 @@ async fn test_query_text_filter_two_terms_conjunctive(ctx: &mut ProjectTestConte
                 Some("summary"),
                 None,
             )))
-            .top_k(field("published_year"), 100, true),
+            .topk(field("published_year"), 100, true),
             None,
             None,
         )
@@ -106,7 +106,7 @@ async fn test_query_text_filter_stop_word(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            filter(r#match("the", Some("summary"), None)).top_k(field("published_year"), 100, true),
+            filter(r#match("the", Some("summary"), None)).topk(field("published_year"), 100, true),
             None,
             None,
         )
@@ -127,7 +127,7 @@ async fn test_query_select_bm25_without_text_queries(ctx: &mut ProjectTestContex
         .query(
             select([("bm25_score", fns::bm25_score())])
                 .filter(field("_id").eq("pride"))
-                .top_k(field("bm25_score"), 100, true),
+                .topk(field("bm25_score"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_unified.rs
+++ b/topk-rs/tests/test_query_unified.rs
@@ -25,7 +25,7 @@ async fn test_query_unified(ctx: &mut ProjectTestContext) {
                 ("bm25_score", fns::bm25_score()),
             ])
             .filter(r#match("love", None, Some(30.0)).or(r#match("young", None, Some(10.0))))
-            .top_k(
+            .topk(
                 field("bm25_score") + (field("summary_distance") * literal(100)),
                 2,
                 true,

--- a/topk-rs/tests/test_query_validation.rs
+++ b/topk-rs/tests/test_query_validation.rs
@@ -17,7 +17,7 @@ async fn test_query_topk_by_non_primitive(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("title"), 3, true),
+            select([("title", field("title"))]).topk(field("title"), 3, true),
             None,
             None,
         )
@@ -38,7 +38,7 @@ async fn test_query_topk_by_non_existing(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("non_existing_field"), 3, true),
+            select([("title", field("title"))]).topk(field("non_existing_field"), 3, true),
             None,
             None,
         )
@@ -60,7 +60,7 @@ async fn test_query_topk_limit_zero(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("published_year"), 0, true),
+            select([("title", field("title"))]).topk(field("published_year"), 0, true),
             None,
             None,
         )
@@ -107,7 +107,7 @@ async fn test_union_u32_and_binary(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("title", field("title"))]).top_k(field("num"), 100, true),
+            select([("title", field("title"))]).topk(field("num"), 100, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_query_vector.rs
+++ b/topk-rs/tests/test_query_vector.rs
@@ -33,7 +33,7 @@ async fn test_query_vector_distance(ctx: &mut ProjectTestContext) {
                     "summary_distance",
                     fns::vector_distance("summary_embedding", vec![2.0; 16]),
                 )])
-                .top_k(field("summary_distance"), 3, true),
+                .topk(field("summary_distance"), 3, true),
             None,
             None,
         )
@@ -58,7 +58,7 @@ async fn test_query_vector_distance_nullable(ctx: &mut ProjectTestContext) {
                 "summary_distance",
                 fns::vector_distance("nullable_embedding", Vector::F32(vec![3.0; 16])),
             )])
-            .top_k(field("summary_distance"), 3, true),
+            .topk(field("summary_distance"), 3, true),
             None,
             None,
         )
@@ -82,7 +82,7 @@ async fn test_query_vector_distance_u8_vector(ctx: &mut ProjectTestContext) {
                 "summary_distance",
                 fns::vector_distance("scalar_embedding", Vector::U8(vec![8; 16])),
             )])
-            .top_k(field("summary_distance"), 3, true),
+            .topk(field("summary_distance"), 3, true),
             None,
             None,
         )
@@ -106,7 +106,7 @@ async fn test_query_vector_distance_binary_vector(ctx: &mut ProjectTestContext) 
                 "summary_distance",
                 fns::vector_distance("binary_embedding", Vector::U8(vec![0, 1])),
             )])
-            .top_k(field("summary_distance"), 2, true),
+            .topk(field("summary_distance"), 2, true),
             None,
             None,
         )

--- a/topk-rs/tests/test_semantic_index.rs
+++ b/topk-rs/tests/test_semantic_index.rs
@@ -64,7 +64,7 @@ async fn test_semantic_index_query(ctx: &mut ProjectTestContext) {
         .client
         .collection(&collection.name)
         .query(
-            select([("sim", fns::semantic_similarity("title", "dummy"))]).top_k(
+            select([("sim", fns::semantic_similarity("title", "dummy"))]).topk(
                 field("sim"),
                 3,
                 true,
@@ -89,7 +89,7 @@ async fn test_semantic_index_query_with_text_filter(ctx: &mut ProjectTestContext
         .query(
             select([("sim", fns::semantic_similarity("title", "dummy"))])
                 .filter(r#match("love", Some("summary"), None))
-                .top_k(field("sim"), 3, true),
+                .topk(field("sim"), 3, true),
             None,
             None,
         )
@@ -108,7 +108,7 @@ async fn test_semantic_index_query_with_missing_index(ctx: &mut ProjectTestConte
         .client
         .collection(&collection.name)
         .query(
-            select([("sim", fns::semantic_similarity("published_year", "dummy"))]).top_k(
+            select([("sim", fns::semantic_similarity("published_year", "dummy"))]).topk(
                 field("sim"),
                 3,
                 true,
@@ -135,7 +135,7 @@ async fn test_semantic_index_query_multiple_fields(ctx: &mut ProjectTestContext)
                 ("title_sim", fns::semantic_similarity("title", "dummy")),
                 ("summary_sim", fns::semantic_similarity("summary", "query")),
             ])
-            .top_k(field("title_sim").add(field("summary_sim")), 5, true),
+            .topk(field("title_sim").add(field("summary_sim")), 5, true),
             None,
             None,
         )
@@ -155,7 +155,7 @@ async fn test_semantic_index_query_and_rerank_with_missing_model(ctx: &mut Proje
         .collection(&collection.name)
         .query(
             select([("sim", fns::semantic_similarity("title", "dummy"))])
-                .top_k(field("sim"), 3, true)
+                .topk(field("sim"), 3, true)
                 .rerank(Some("definitely-does-not-exist".into()), None, vec![], None),
             None,
             None,
@@ -176,7 +176,7 @@ async fn test_semantic_index_query_and_rerank(ctx: &mut ProjectTestContext) {
         .collection(&collection.name)
         .query(
             select([("sim", fns::semantic_similarity("title", "dummy"))])
-                .top_k(field("sim"), 3, true)
+                .topk(field("sim"), 3, true)
                 .rerank(Some("dummy".into()), None, vec![], None),
             None,
             None,
@@ -202,7 +202,7 @@ async fn test_semantic_index_query_and_rerank_multiple_semantic_sim_explicit(
                 ("title_sim", fns::semantic_similarity("title", "dummy")),
                 ("summary_sim", fns::semantic_similarity("summary", "query")),
             ])
-            .top_k(field("title_sim").add(field("summary_sim")), 5, true)
+            .topk(field("title_sim").add(field("summary_sim")), 5, true)
             .rerank(
                 Some("dummy".into()),
                 Some("query string".into()),
@@ -233,7 +233,7 @@ async fn test_semantic_index_query_and_rerank_multiple_semantic_sim_implicit(
                 ("title_sim", fns::semantic_similarity("title", "dummy")),
                 ("summary_sim", fns::semantic_similarity("summary", "query")),
             ])
-            .top_k(field("title_sim").add(field("summary_sim")), 5, true)
+            .topk(field("title_sim").add(field("summary_sim")), 5, true)
             .rerank(Some("dummy".into()), None, vec![], None),
             None,
             None,


### PR DESCRIPTION
Fixes https://github.com/fafolabs/topk-sdk/issues/40

* rename `Query.top_k` method to `Query.topk` in py sdk
* rename `Query.top_k` method to `Query.topk` in rs sdk
* update tests
* update docs
* bump sdks versions