### PR TITLE
Better error handling & formatting

### DIFF
--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.1.19-alpha.5",
+  "version": "0.1.19-alpha.6",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-js/src/error.rs
+++ b/topk-js/src/error.rs
@@ -18,6 +18,12 @@ impl From<TopkError> for napi::Error {
             topk_rs::Error::CollectionNotFound => {
                 napi::Error::new(napi::Status::GenericFailure, "collection not found")
             }
+            topk_rs::Error::DocumentValidationError(e) => {
+                napi::Error::new(napi::Status::InvalidArg, format!("{:?}", e))
+            }
+            topk_rs::Error::SchemaValidationError(e) => {
+                napi::Error::new(napi::Status::InvalidArg, format!("{:?}", e))
+            }
             topk_rs::Error::InvalidArgument(msg) => napi::Error::new(
                 napi::Status::InvalidArg,
                 format!("invalid argument: {}", msg),
@@ -38,9 +44,13 @@ impl From<TopkError> for napi::Error {
                 napi::Status::GenericFailure,
                 format!("malformed response: {}", msg),
             ),
-            _ => napi::Error::new(
+            topk_rs::Error::Unexpected(status) => napi::Error::new(
                 napi::Status::GenericFailure,
-                format!("{:?}", error.0.to_string()),
+                format!("unexpected error: {:?}", status),
+            ),
+            topk_rs::Error::TransportError(e) => napi::Error::new(
+                napi::Status::GenericFailure,
+                format!("transport error: {:?}", e),
             ),
         }
     }

--- a/topk-js/tests/collection.spec.ts
+++ b/topk-js/tests/collection.spec.ts
@@ -27,6 +27,16 @@ describe("Collections", () => {
     expect(collections).toContainEqual(collection);
   });
 
+  test("create collection with invalid schema", async () => {
+    const ctx = getContext();
+
+    await expect(
+      ctx.createCollection("books", {
+        title: "invalid",
+      })
+    ).rejects.toThrow("Value must be a FieldSpec");
+  });
+
   test("create duplicate collection", async () => {
     const ctx = getContext();
     await ctx.createCollection("test", {});

--- a/topk-js/tests/collections.spec.ts
+++ b/topk-js/tests/collections.spec.ts
@@ -135,7 +135,7 @@ describe("Collections", () => {
       ctx.client.collections().create(ctx.scope("books"), {
         name: text().index(vectorIndex({ metric: "cosine" })),
       })
-    ).rejects.toThrow("invalid collection schema");
+    ).rejects.toThrow(/InvalidIndex { field: \"name\", index: \"vector\", data_type: \"text\" }/);
   });
 
   test("list collections", async () => {


### PR DESCRIPTION
When playing around with `topk-js` I came across some cryptic `invalid argument` errors while upserting some documents. I was unable to pinpoint the exact validation issue with my documents due to lack of proper error display.

For example, when upserting documents for a schema where my vector had less dimensions than specified in the schema, I got `Error: invalid argument` error instead of `InvalidVectorDimension { doc_id: \"doc1\", field: \"f32_embedding\", expected_dimension: 3, got_dimension: 2 }`

This PR:
* handles all of topk error types and displays additional error info(status, message) if applicable
* adds tests
* bumps alpha version