### PR TITLE
change `lsn` from `u64` to `string`

### DIFF
--- a/topk-js/index.d.ts
+++ b/topk-js/index.d.ts
@@ -10,8 +10,8 @@ export declare class CollectionClient {
   get(ids: Array<string>, fields?: Array<string> | undefined | null, options?: QueryOptions | undefined | null): Promise<Record<string, Record<string, any>>>
   count(options?: QueryOptions | undefined | null): Promise<number>
   query(query: query.Query, options?: QueryOptions | undefined | null): Promise<Array<Record<string, any>>>
-  upsert(docs: Array<Record<string, any>>): Promise<number>
-  delete(ids: Array<string>): Promise<number>
+  upsert(docs: Array<Record<string, any>>): Promise<string>
+  delete(ids: Array<string>): Promise<string>
 }
 
 export declare class CollectionsClient {
@@ -51,7 +51,7 @@ export interface CreateCollectionOptions {
 }
 
 export interface QueryOptions {
-  lsn?: number
+  lsn?: string
   consistency?: ConsistencyLevel
 }
 

--- a/topk-js/tests/delete.spec.ts
+++ b/topk-js/tests/delete.spec.ts
@@ -1,5 +1,5 @@
-import { newProjectContext, ProjectContext } from "./setup";
 import { field, select } from "../lib/query";
+import { newProjectContext, ProjectContext } from "./setup";
 
 describe("delete", () => {
   const contexts: ProjectContext[] = [];
@@ -33,7 +33,7 @@ describe("delete", () => {
     ]);
 
     const lsn = await ctx.client.collection(collection.name).delete(["doc1"]);
-    expect(lsn).toBe(2);
+    expect(lsn).toBe("2");
 
     const remaining = await ctx.client
       .collection(collection.name)
@@ -50,6 +50,6 @@ describe("delete", () => {
     const lsn = await ctx.client
       .collection(collection.name)
       .delete(["non-existent"]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
   });
 });

--- a/topk-js/tests/documents.spec.ts
+++ b/topk-js/tests/documents.spec.ts
@@ -36,7 +36,7 @@ describe("Documents", () => {
     const lsn = await ctx.client
       .collection(ctx.scope("books"))
       .upsert([{ _id: "one", name: "one", rank: 1 }]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     // get document
     const doc = await ctx.client.collection(ctx.scope("books")).get(["one"]);
@@ -62,7 +62,7 @@ describe("Documents", () => {
       { _id: "one", name: "one", rank: 1 },
       { _id: "two", name: "two", extra: 1, rank: 2 },
     ]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     const docs = await ctx.client.collection(ctx.scope("books")).query(
       select({ name: field("name") })
@@ -93,7 +93,7 @@ describe("Documents", () => {
       { _id: "doc9", title: "yellow purple pink" },
       { _id: "doc10", title: "orange red blue" },
     ]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     const docs = await ctx.client.collection(ctx.scope("books")).query(
       select({
@@ -122,7 +122,7 @@ describe("Documents", () => {
       { _id: "doc2", f32_embedding: [4.0, 5.0, 6.0] },
       { _id: "doc3", f32_embedding: [7.0, 8.0, 9.0] },
     ]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     let docs = await ctx.client.collection(ctx.scope("books")).query(
       select({
@@ -149,7 +149,7 @@ describe("Documents", () => {
       { _id: "doc2", u8_embedding: u8VectorValue([4, 5, 6]) },
       { _id: "doc3", u8_embedding: u8VectorValue([7, 8, 9]) },
     ]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     let docs = await ctx.client.collection(ctx.scope("books")).query(
       select({
@@ -179,7 +179,7 @@ describe("Documents", () => {
       { _id: "doc2", binary_embedding: binaryVectorValue([0, 1, 1]) },
       { _id: "doc3", binary_embedding: binaryVectorValue([1, 1, 1]) },
     ]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     let docs = await ctx.client.collection(ctx.scope("books")).query(
       select({
@@ -215,7 +215,7 @@ describe("Documents", () => {
       { _id: "doc8", title: "green yello green" },
       { _id: "doc9", title: "yellow purple pink" },
     ]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     const docs = await ctx.client
       .collection(ctx.scope("books"))
@@ -239,10 +239,10 @@ describe("Documents", () => {
     let lsn = await ctx.client
       .collection(ctx.scope("books"))
       .upsert([{ _id: "doc1", name: "one" }]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     lsn = await ctx.client.collection(ctx.scope("books")).delete(["doc1"]);
-    expect(lsn).toBe(2);
+    expect(lsn).toBe("2");
 
     const docs = await ctx.client.collection(ctx.scope("books")).query(
       select({ name: field("name") })
@@ -262,13 +262,13 @@ describe("Documents", () => {
       { _id: "doc1", name: "one" },
       { _id: "doc2", name: "two" },
     ]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     let count = await ctx.client.collection(ctx.scope("books")).count({ lsn });
     expect(count).toBe(2);
 
     lsn = await ctx.client.collection(ctx.scope("books")).delete(["doc1"]);
-    expect(lsn).toBe(2);
+    expect(lsn).toBe("2");
 
     count = await ctx.client.collection(ctx.scope("books")).count({ lsn });
     expect(count).toBe(1);

--- a/topk-js/tests/upsert.spec.ts
+++ b/topk-js/tests/upsert.spec.ts
@@ -28,7 +28,7 @@ describe("Upsert", () => {
     const lsn = await ctx.client
       .collection(collection.name)
       .upsert([{ _id: "one" }]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
   });
 
   test("upsert batch", async () => {
@@ -38,7 +38,7 @@ describe("Upsert", () => {
     const lsn = await ctx.client
       .collection(collection.name)
       .upsert([{ _id: "one" }, { _id: "two" }]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
   });
 
   test("upsert sequential", async () => {
@@ -48,15 +48,15 @@ describe("Upsert", () => {
     let lsn = await ctx.client
       .collection(collection.name)
       .upsert([{ _id: "one" }]);
-    expect(lsn).toBe(1);
+    expect(lsn).toBe("1");
 
     lsn = await ctx.client.collection(collection.name).upsert([{ _id: "two" }]);
-    expect(lsn).toBe(2);
+    expect(lsn).toBe("2");
 
     lsn = await ctx.client
       .collection(collection.name)
       .upsert([{ _id: "three" }]);
-    expect(lsn).toBe(3);
+    expect(lsn).toBe("3");
   });
 
   test("upsert no documents", async () => {

--- a/topk-protos/protos/topk/data/v1/query_service.proto
+++ b/topk-protos/protos/topk/data/v1/query_service.proto
@@ -22,7 +22,7 @@ enum ConsistencyLevel {
 message QueryRequest {
   string collection = 1;
   Query query = 2;
-  optional uint64 required_lsn = 3;
+  optional string required_lsn = 3;
   optional ConsistencyLevel consistency_level = 4;
 }
 
@@ -34,7 +34,7 @@ message QueryResponse {
 message GetRequest {
   repeated string ids = 1;
   repeated string fields = 2;
-  optional uint64 required_lsn = 3;
+  optional string required_lsn = 3;
   optional ConsistencyLevel consistency_level = 4;
 }
 message GetResponse {

--- a/topk-protos/protos/topk/data/v1/write_service.proto
+++ b/topk-protos/protos/topk/data/v1/write_service.proto
@@ -16,7 +16,7 @@ message UpsertDocumentsRequest {
   repeated Document docs = 1;
 }
 message UpsertDocumentsResponse {
-  uint64 lsn = 1;
+  string lsn = 1;
 }
 
 // Delete
@@ -24,5 +24,5 @@ message DeleteDocumentsRequest {
   repeated string ids = 1;
 }
 message DeleteDocumentsResponse {
-  uint64 lsn = 1;
+  string lsn = 1;
 }

--- a/topk-py/src/client/collection.rs
+++ b/topk-py/src/client/collection.rs
@@ -30,7 +30,7 @@ impl CollectionClient {
         py: Python<'_>,
         ids: Vec<String>,
         fields: Option<Vec<String>>,
-        lsn: Option<u64>,
+        lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> PyResult<HashMap<String, HashMap<String, RawValue>>> {
         let docs = self
@@ -63,7 +63,7 @@ impl CollectionClient {
     pub fn count(
         &self,
         py: Python<'_>,
-        lsn: Option<u64>,
+        lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> PyResult<u64> {
         let count = self
@@ -84,7 +84,7 @@ impl CollectionClient {
         &self,
         py: Python<'_>,
         query: Query,
-        lsn: Option<u64>,
+        lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> PyResult<Vec<HashMap<String, RawValue>>> {
         let docs = self
@@ -114,7 +114,7 @@ impl CollectionClient {
         &self,
         py: Python<'_>,
         documents: Vec<HashMap<String, RawValue>>,
-    ) -> PyResult<u64> {
+    ) -> PyResult<String> {
         let documents = documents
             .into_iter()
             .map(|d| topk_protos::v1::data::Document {
@@ -131,7 +131,7 @@ impl CollectionClient {
             .map_err(RustError)?)
     }
 
-    pub fn delete(&self, py: Python<'_>, ids: Vec<String>) -> PyResult<u64> {
+    pub fn delete(&self, py: Python<'_>, ids: Vec<String>) -> PyResult<String> {
         Ok(self
             .runtime
             .block_on(py, self.client.collection(&self.collection).delete(ids))

--- a/topk-py/tests/test_delete.py
+++ b/topk-py/tests/test_delete.py
@@ -20,13 +20,13 @@ def test_delete_document(ctx: ProjectContext):
             {"_id": "two", "rank": 2},
         ]
     )
-    assert lsn == 1
+    assert lsn == "1"
 
     # wait for write to be flushed
     ctx.client.collection(collection.name).count()
 
     lsn = ctx.client.collection(collection.name).delete(["one"])
-    assert lsn == 2
+    assert lsn == "2"
 
     docs = ctx.client.collection(collection.name).query(
         select("title").top_k(field("rank"), 100, True), lsn=lsn
@@ -40,4 +40,4 @@ def test_delete_non_existent_document(ctx: ProjectContext):
 
     # we can delete a non-existent document, and it will be ignored
     lsn = ctx.client.collection(collection.name).delete(["one"])
-    assert lsn == 1
+    assert lsn == "1"

--- a/topk-py/tests/test_upsert.py
+++ b/topk-py/tests/test_upsert.py
@@ -14,7 +14,7 @@ def test_upsert_basic(ctx: ProjectContext):
     collection = ctx.client.collections().create(ctx.scope("test"), schema={})
 
     lsn = ctx.client.collection(collection.name).upsert([{"_id": "one"}])
-    assert lsn == 1
+    assert lsn == "1"
 
 
 def test_upsert_batch(ctx: ProjectContext):
@@ -23,20 +23,20 @@ def test_upsert_batch(ctx: ProjectContext):
     lsn = ctx.client.collection(collection.name).upsert(
         [{"_id": "one"}, {"_id": "two"}]
     )
-    assert lsn == 1
+    assert lsn == "1"
 
 
 def test_upsert_sequential(ctx: ProjectContext):
     collection = ctx.client.collections().create(ctx.scope("test"), schema={})
 
     lsn = ctx.client.collection(collection.name).upsert([{"_id": "one"}])
-    assert lsn == 1
+    assert lsn == "1"
 
     lsn = ctx.client.collection(collection.name).upsert([{"_id": "two"}])
-    assert lsn == 2
+    assert lsn == "2"
 
     lsn = ctx.client.collection(collection.name).upsert([{"_id": "three"}])
-    assert lsn == 3
+    assert lsn == "3"
 
 
 def test_upsert_no_documents(ctx: ProjectContext):

--- a/topk-rs/src/client/collection.rs
+++ b/topk-rs/src/client/collection.rs
@@ -36,7 +36,7 @@ impl CollectionClient {
         &self,
         ids: impl IntoIterator<Item = impl Into<String>>,
         fields: Option<Vec<String>>,
-        lsn: Option<u64>,
+        lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> Result<HashMap<String, HashMap<String, Value>>, Error> {
         let mut tries = 0;
@@ -56,7 +56,7 @@ impl CollectionClient {
                 .get(GetRequest {
                     ids: ids.clone(),
                     fields: fields.unwrap_or_default(),
-                    required_lsn: lsn,
+                    required_lsn: lsn.clone(),
                     consistency_level: consistency.map(|c| c.into()),
                 })
                 .await;
@@ -97,7 +97,7 @@ impl CollectionClient {
 
     pub async fn count(
         &self,
-        lsn: Option<u64>,
+        lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> Result<u64, Error> {
         let query = Query::new(vec![Stage::Count {}]);
@@ -130,7 +130,7 @@ impl CollectionClient {
     pub async fn query(
         &self,
         query: Query,
-        lsn: Option<u64>,
+        lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> Result<Vec<Document>, Error> {
         let mut tries = 0;
@@ -148,7 +148,7 @@ impl CollectionClient {
                 .query(QueryRequest {
                     collection: self.collection.clone(),
                     query: Some(query.into()),
-                    required_lsn: lsn,
+                    required_lsn: lsn.clone(),
                     consistency_level: consistency.map(|c| c.into()),
                 })
                 .await;
@@ -182,7 +182,7 @@ impl CollectionClient {
         }
     }
 
-    pub async fn upsert(&self, docs: Vec<Document>) -> Result<u64, Error> {
+    pub async fn upsert(&self, docs: Vec<Document>) -> Result<String, Error> {
         let mut client = self.write_client().await?;
 
         let response = client
@@ -201,7 +201,7 @@ impl CollectionClient {
         Ok(response.into_inner().lsn)
     }
 
-    pub async fn delete(&self, ids: Vec<String>) -> Result<u64, Error> {
+    pub async fn delete(&self, ids: Vec<String>) -> Result<String, Error> {
         let mut client = self.write_client().await?;
 
         let response = client

--- a/topk-rs/tests/test_delete.rs
+++ b/topk-rs/tests/test_delete.rs
@@ -39,7 +39,7 @@ async fn test_delete_document(ctx: &mut ProjectTestContext) {
         ])
         .await
         .expect("could not upsert document");
-    assert_eq!(lsn, 1);
+    assert_eq!(&lsn, "1");
 
     // wait for write to be flushed
     ctx.client
@@ -54,7 +54,7 @@ async fn test_delete_document(ctx: &mut ProjectTestContext) {
         .delete(vec!["one".to_string()])
         .await
         .expect("could not delete document");
-    assert_eq!(lsn, 2);
+    assert_eq!(&lsn, "2");
 
     let docs = ctx
         .client
@@ -87,5 +87,5 @@ async fn test_delete_non_existent_document(ctx: &mut ProjectTestContext) {
         .delete(vec!["one".to_string()])
         .await
         .expect("could not delete document");
-    assert_eq!(lsn, 1);
+    assert_eq!(&lsn, "1");
 }

--- a/topk-rs/tests/test_upsert.rs
+++ b/topk-rs/tests/test_upsert.rs
@@ -41,7 +41,7 @@ async fn test_upsert_basic(ctx: &mut ProjectTestContext) {
         .await
         .expect("could not upsert document");
 
-    assert_eq!(lsn, 1);
+    assert_eq!(&lsn, "1");
 }
 
 #[test_context(ProjectTestContext)]
@@ -61,7 +61,7 @@ async fn test_upsert_batch(ctx: &mut ProjectTestContext) {
         .await
         .expect("could not upsert document");
 
-    assert_eq!(lsn, 1);
+    assert_eq!(&lsn, "1");
 }
 
 #[test_context(ProjectTestContext)]
@@ -80,7 +80,7 @@ async fn test_upsert_sequential(ctx: &mut ProjectTestContext) {
         .upsert(vec![doc!("_id" => "one")])
         .await
         .expect("could not upsert document");
-    assert_eq!(lsn, 1);
+    assert_eq!(&lsn, "1");
 
     let lsn = ctx
         .client
@@ -88,7 +88,7 @@ async fn test_upsert_sequential(ctx: &mut ProjectTestContext) {
         .upsert(vec![doc!("_id" => "two")])
         .await
         .expect("could not upsert document");
-    assert_eq!(lsn, 2);
+    assert_eq!(&lsn, "2");
 
     let lsn = ctx
         .client
@@ -96,7 +96,7 @@ async fn test_upsert_sequential(ctx: &mut ProjectTestContext) {
         .upsert(vec![doc!("_id" => "three")])
         .await
         .expect("could not upsert document");
-    assert_eq!(lsn, 3);
+    assert_eq!(&lsn, "3");
 }
 
 #[test_context(ProjectTestContext)]


### PR DESCRIPTION
javascript doesn't have u64s, so `lsn: u64` was problematic. simply encoding this value as str works in all languages (client doesn't manipulate it, just passes along to `query()`/`count()`)