### PR TITLE
add `PermissionDenied` error, fix stack overflow

### DIFF
--- a/topk-js/Cargo.toml
+++ b/topk-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-js"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "TopK JavaScript SDK with TypeScript support"
 license-file = "LICENSE"

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-js/src/error.rs
+++ b/topk-js/src/error.rs
@@ -39,6 +39,9 @@ impl From<TopkError> for napi::Error {
                 napi::Status::InvalidArg,
                 format!("request too large: {}", error.0),
             ),
+            topk_rs::Error::PermissionDenied => {
+                napi::Error::new(napi::Status::GenericFailure, "permission denied")
+            }
             // Other errors
             _ => napi::Error::new(napi::Status::GenericFailure, format!("{:?}", error)),
         }

--- a/topk-py/Cargo.toml
+++ b/topk-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-py"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "TopK Python SDK"
 license-file = "LICENSE"

--- a/topk-py/src/error.rs
+++ b/topk-py/src/error.rs
@@ -32,6 +32,7 @@ impl From<RustError> for PyErr {
             topk_rs::Error::RequestTooLarge(e) => RequestTooLargeError::new_err(e),
             topk_rs::Error::QuotaExceeded(e) => QuotaExceededError::new_err(e),
             topk_rs::Error::SlowDown(e) => SlowDownError::new_err(e),
+            topk_rs::Error::PermissionDenied => PermissionDeniedError::new_err(value.0.to_string()),
             // Other errors
             _ => PyException::new_err(format!("topk returned error: {:?}", value.0)),
         }
@@ -48,6 +49,7 @@ create_exception!(error, QueryLsnTimeoutError, PyException);
 create_exception!(error, RequestTooLargeError, PyException);
 create_exception!(error, QuotaExceededError, PyException);
 create_exception!(error, SlowDownError, PyException);
+create_exception!(error, PermissionDeniedError, PyException);
 
 ////////////////////////////////////////////////////////////
 /// Error

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-rs"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "TopK Rust SDK"
 license = "MIT"

--- a/topk-rs/src/error.rs
+++ b/topk-rs/src/error.rs
@@ -39,6 +39,9 @@ pub enum Error {
     #[error("request too large: {0}")]
     RequestTooLarge(String),
 
+    #[error("unexpected error: {0}")]
+    Unexpected(String),
+
     #[error("slow down: {0}")]
     SlowDown(String),
 
@@ -68,7 +71,8 @@ impl From<Status> for Error {
                     Err(_) => Error::InvalidArgument(e.message().into()),
                 },
                 tonic::Code::OutOfRange => Error::RequestTooLarge(e.message().into()),
-                _ => e.into(),
+                tonic::Code::PermissionDenied => Error::PermissionDenied,
+                _ => Error::Unexpected(format!("unexpected error: {:?}", e)),
             },
         }
     }


### PR DESCRIPTION
Doing `_ => e.into()` introduces infinite recursion and crashes the client.