### PR TITLE
implement retries

### DIFF
--- a/topk-js/Cargo.toml
+++ b/topk-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-js"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "TopK JavaScript SDK with TypeScript support"
 license-file = "LICENSE"

--- a/topk-js/index.d.ts
+++ b/topk-js/index.d.ts
@@ -21,11 +21,21 @@ export declare class CollectionsClient {
   delete(name: string): Promise<void>
 }
 
+export interface BackoffConfig {
+  /** Base for the backoff */
+  base?: number
+  /** Initial backoff (milliseconds) */
+  initBackoff?: number
+  /** Maximum backoff (milliseconds) */
+  maxBackoff?: number
+}
+
 export interface ClientConfig {
   apiKey: string
   region: string
   host?: string
   https?: boolean
+  retryConfig?: RetryConfig
 }
 
 export interface Collection {
@@ -66,6 +76,15 @@ export interface RerankOptions {
   query?: string
   fields?: Array<string>
   topkMultiple?: number
+}
+
+export interface RetryConfig {
+  /** Maximum number of retries */
+  maxRetries?: number
+  /** Total timeout for the retry chain (milliseconds) */
+  timeout?: number
+  /** Backoff configuration */
+  backoff?: BackoffConfig
 }
 
 export declare namespace data {

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-py/Cargo.toml
+++ b/topk-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-py"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "TopK Python SDK"
 license-file = "LICENSE"

--- a/topk-py/src/client/mod.rs
+++ b/topk-py/src/client/mod.rs
@@ -1,5 +1,5 @@
-use pyo3::prelude::*;
-use std::sync::Arc;
+use pyo3::{exceptions::PyTypeError, prelude::*, types::PyDict};
+use std::{sync::Arc, time::Duration};
 use topk_rs::ClientConfig;
 
 mod collection;
@@ -20,15 +20,27 @@ pub struct Client {
 #[pymethods]
 impl Client {
     #[new]
-    #[pyo3(signature = (api_key, region, host="topk.io".into(), https=true))]
-    pub fn new(api_key: String, region: String, host: String, https: bool) -> Self {
+    #[pyo3(signature = (api_key, region, host="topk.io".into(), https=true, retry_config=None))]
+    pub fn new(
+        api_key: String,
+        region: String,
+        host: String,
+        https: bool,
+        retry_config: Option<RetryConfig>,
+    ) -> Self {
         let runtime = Arc::new(Runtime::new().expect("failed to create runtime"));
 
-        let client = Arc::new(topk_rs::Client::new(
-            ClientConfig::new(api_key, region)
+        let client = Arc::new(topk_rs::Client::new({
+            let mut client = ClientConfig::new(api_key, region)
                 .with_https(https)
-                .with_host(host),
-        ));
+                .with_host(host);
+
+            if let Some(retry_config) = retry_config {
+                client = client.with_retry_config(retry_config.into());
+            }
+
+            client
+        }));
 
         Self { runtime, client }
     }
@@ -46,5 +58,120 @@ impl Client {
             self.runtime.clone(),
             self.client.clone(),
         ))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RetryConfig {
+    /// Maximum number of retries
+    pub max_retries: Option<usize>,
+
+    /// Total timeout for the retry chain (milliseconds)
+    pub timeout: Option<u64>,
+
+    /// Backoff configuration
+    pub backoff: Option<BackoffConfig>,
+}
+
+impl<'py> FromPyObject<'py> for RetryConfig {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let obj = ob.as_ref();
+
+        match obj.downcast::<PyDict>() {
+            Ok(dict) => {
+                let max_retries = dict
+                    .get_item("max_retries")?
+                    .map(|v| v.extract::<usize>())
+                    .transpose()?;
+
+                let timeout = dict
+                    .get_item("timeout")?
+                    .map(|v| v.extract::<u64>())
+                    .transpose()?;
+
+                let backoff = dict
+                    .get_item("backoff")?
+                    .map(|v| v.extract::<BackoffConfig>())
+                    .transpose()?;
+
+                Ok(RetryConfig {
+                    max_retries,
+                    timeout,
+                    backoff,
+                })
+            }
+            _ => Err(PyTypeError::new_err("`RetryConfig` must be a dict")),
+        }
+    }
+}
+
+impl Into<topk_rs::retry::RetryConfig> for RetryConfig {
+    fn into(self) -> topk_rs::retry::RetryConfig {
+        topk_rs::retry::RetryConfig {
+            max_retries: self
+                .max_retries
+                .unwrap_or(topk_rs::retry::DEFAULT_MAX_RETRIES) as usize,
+            timeout: Duration::from_millis(self.timeout.unwrap_or(topk_rs::retry::DEFAULT_TIMEOUT)),
+            backoff: self.backoff.map(|b| b.into()).unwrap_or_default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BackoffConfig {
+    /// Base for the backoff
+    pub base: Option<u32>,
+
+    /// Initial backoff (milliseconds)
+    pub init_backoff: Option<u64>,
+
+    /// Maximum backoff (milliseconds)
+    pub max_backoff: Option<u64>,
+}
+
+impl<'py> FromPyObject<'py> for BackoffConfig {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let obj = ob.as_ref();
+
+        match obj.downcast::<PyDict>() {
+            Ok(dict) => {
+                let base = dict
+                    .get_item("base")?
+                    .map(|v| v.extract::<u32>())
+                    .transpose()?;
+
+                let init_backoff = dict
+                    .get_item("init_backoff")?
+                    .map(|v| v.extract::<u64>())
+                    .transpose()?;
+
+                let max_backoff = dict
+                    .get_item("max_backoff")?
+                    .map(|v| v.extract::<u64>())
+                    .transpose()?;
+
+                Ok(BackoffConfig {
+                    base,
+                    init_backoff,
+                    max_backoff,
+                })
+            }
+            _ => Err(PyTypeError::new_err("`BackoffConfig` must be a dict")),
+        }
+    }
+}
+impl Into<topk_rs::retry::BackoffConfig> for BackoffConfig {
+    fn into(self) -> topk_rs::retry::BackoffConfig {
+        topk_rs::retry::BackoffConfig {
+            base: self.base.unwrap_or(topk_rs::retry::DEFAULT_BASE),
+            init_backoff: Duration::from_millis(
+                self.init_backoff
+                    .unwrap_or(topk_rs::retry::DEFAULT_INIT_BACKOFF),
+            ),
+            max_backoff: Duration::from_millis(
+                self.max_backoff
+                    .unwrap_or(topk_rs::retry::DEFAULT_MAX_BACKOFF),
+            ),
+        }
     }
 }

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-rs"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "TopK Rust SDK"
 license = "MIT"

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -21,6 +21,8 @@ thiserror = { version = "1.0.65" }
 tracing = { version = "0.1.40" }
 serde_json = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
+rand = { version = "0.8.5" }
+futures-util = { version = "0.3.31" }
 
 [dev-dependencies]
 test-context = { version = "0.3.0" }

--- a/topk-rs/src/client/collection.rs
+++ b/topk-rs/src/client/collection.rs
@@ -1,12 +1,13 @@
-use super::client_config::ClientConfig;
+use super::config::ClientConfig;
 use super::create_query_client;
 use super::create_write_client;
+use super::retry::call_with_retry;
 use crate::error::Error;
 use crate::query::Query;
 use crate::query::Stage;
+use futures_util::future::TryFutureExt;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::OnceCell;
 use tonic::transport::Channel;
 use topk_protos::v1::data::{ConsistencyLevel, GetRequest};
@@ -46,54 +47,42 @@ impl CollectionClient {
         lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> Result<HashMap<String, HashMap<String, Value>>, Error> {
-        let mut client =
+        let client =
             create_query_client(&self.config, &self.collection_name, &self.channel).await?;
-
-        let mut tries = 0;
-        let max_tries = 120;
-        let retry_after = Duration::from_secs(1);
-
         let ids: Vec<String> = ids.into_iter().map(|id| id.into()).collect();
 
-        loop {
-            tries += 1;
-
+        let response = call_with_retry(&self.config.retry_config, || {
+            let mut client = client.clone();
+            let ids = ids.clone();
             let fields = fields.clone();
+            let lsn = lsn.clone();
+            let consistency = consistency.clone();
 
-            let response = client
-                .get(GetRequest {
-                    ids: ids.clone(),
-                    fields: fields.unwrap_or_default(),
-                    required_lsn: lsn.clone(),
-                    consistency_level: consistency.map(|c| c.into()),
-                })
-                .await;
-
-            match response {
-                Ok(response) => {
-                    return Ok(response
-                        .into_inner()
-                        .docs
-                        .into_iter()
-                        .map(|(id, doc)| (id, doc.fields))
-                        .collect())
-                }
-                Err(e) => match e.code() {
-                    tonic::Code::NotFound => return Err(Error::CollectionNotFound),
-                    _ => match e.into() {
-                        Error::QueryLsnTimeout => {
-                            if tries < max_tries {
-                                tokio::time::sleep(retry_after).await;
-                                continue;
-                            } else {
-                                return Err(Error::QueryLsnTimeout);
-                            }
-                        }
-                        e => return Err(e),
-                    },
-                },
+            async move {
+                client
+                    .get(GetRequest {
+                        ids: ids,
+                        fields: fields.unwrap_or_default(),
+                        required_lsn: lsn,
+                        consistency_level: consistency.map(|c| c.into()),
+                    })
+                    .map_err(|e| match e.code() {
+                        // Collection not found
+                        tonic::Code::NotFound => Error::CollectionNotFound,
+                        // Delegate other errors
+                        _ => e.into(),
+                    })
+                    .await
             }
-        }
+        })
+        .await?;
+
+        Ok(response
+            .into_inner()
+            .docs
+            .into_iter()
+            .map(|(id, doc)| (id, doc.fields))
+            .collect())
     }
 
     pub async fn count(
@@ -103,7 +92,14 @@ impl CollectionClient {
     ) -> Result<u64, Error> {
         let query = Query::new(vec![Stage::Count {}]);
 
-        let docs = self.query(query, lsn, consistency).await?;
+        let docs = call_with_retry(&self.config.retry_config, || {
+            let query = query.clone();
+            let lsn = lsn.clone();
+            let consistency = consistency.clone();
+
+            async move { self.query(query, lsn, consistency).await }
+        })
+        .await?;
 
         for doc in docs {
             match doc.fields.get("_count") {
@@ -134,82 +130,82 @@ impl CollectionClient {
         lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> Result<Vec<Document>, Error> {
-        // Initialize the client
-        let mut client =
+        let client =
             create_query_client(&self.config, &self.collection_name, &self.channel).await?;
 
-        // Retry logic
-        // TODO: refactor to use a retry policy
-        let mut tries = 0;
-        let max_tries = 120;
-        let retry_after = Duration::from_secs(1);
-
-        loop {
-            tries += 1;
-
+        let response = call_with_retry(&self.config.retry_config, || {
+            let mut client = client.clone();
             let query = query.clone();
+            let lsn = lsn.clone();
 
-            let response = client
-                .query(QueryRequest {
-                    collection: self.collection_name.clone(),
-                    query: Some(query.into()),
-                    required_lsn: lsn.clone(),
-                    consistency_level: consistency.map(|c| c.into()),
-                })
-                .await;
-
-            match response {
-                Ok(response) => return Ok(response.into_inner().results),
-                Err(e) => match e.code() {
-                    // Explicitly map `NotFound` to `CollectionNotFound` error
-                    tonic::Code::NotFound => return Err(Error::CollectionNotFound),
-                    // Delegate other errors
-                    _ => match e.into() {
-                        Error::QueryLsnTimeout => {
-                            if tries < max_tries {
-                                tokio::time::sleep(retry_after).await;
-                                continue;
-                            } else {
-                                return Err(Error::QueryLsnTimeout);
-                            }
-                        }
-                        e => return Err(e),
-                    },
-                },
+            async move {
+                client
+                    .query(QueryRequest {
+                        collection: self.collection_name.clone(),
+                        query: Some(query.into()),
+                        required_lsn: lsn.clone(),
+                        consistency_level: consistency.map(|c| c.into()),
+                    })
+                    .map_err(|e| match e.code() {
+                        // Explicitly map `NotFound` to `CollectionNotFound` error
+                        tonic::Code::NotFound => Error::CollectionNotFound,
+                        // Delegate other errors
+                        _ => e.into(),
+                    })
+                    .await
             }
-        }
+        })
+        .await?;
+
+        Ok(response.into_inner().results)
     }
 
     pub async fn upsert(&self, docs: Vec<Document>) -> Result<String, Error> {
-        let mut client =
+        let client =
             create_write_client(&self.config, &self.collection_name, &self.channel).await?;
 
-        let response = client
-            .upsert_documents(UpsertDocumentsRequest { docs })
-            .await
-            .map_err(|e| match e.code() {
-                // Explicitly map `NotFound` to `CollectionNotFound` error
-                tonic::Code::NotFound => Error::CollectionNotFound,
-                // Delegate other errors
-                _ => e.into(),
-            })?;
+        let response = call_with_retry(&self.config.retry_config, || {
+            let mut client = client.clone();
+            let docs = docs.clone();
+
+            async move {
+                client
+                    .upsert_documents(UpsertDocumentsRequest { docs })
+                    .await
+                    .map_err(|e| match e.code() {
+                        // Explicitly map `NotFound` to `CollectionNotFound` error
+                        tonic::Code::NotFound => Error::CollectionNotFound,
+                        // Delegate other errors
+                        _ => e.into(),
+                    })
+            }
+        })
+        .await?;
 
         Ok(response.into_inner().lsn)
     }
 
     pub async fn delete(&self, ids: Vec<String>) -> Result<String, Error> {
-        let mut client =
+        let client =
             create_write_client(&self.config, &self.collection_name, &self.channel).await?;
 
-        let response = client
-            .delete_documents(DeleteDocumentsRequest { ids })
-            .await
-            .map_err(|e| match e.code() {
-                // Explicitly map `NotFound` to `CollectionNotFound` error
-                tonic::Code::NotFound => Error::CollectionNotFound,
-                // Delegate other errors
-                _ => e.into(),
-            })?;
+        let response = call_with_retry(&self.config.retry_config, || {
+            let mut client = client.clone();
+            let ids = ids.clone();
+
+            async move {
+                client
+                    .delete_documents(DeleteDocumentsRequest { ids })
+                    .await
+                    .map_err(|e| match e.code() {
+                        // Explicitly map `NotFound` to `CollectionNotFound` error
+                        tonic::Code::NotFound => Error::CollectionNotFound,
+                        // Delegate other errors
+                        _ => e.into(),
+                    })
+            }
+        })
+        .await?;
 
         Ok(response.into_inner().lsn)
     }

--- a/topk-rs/src/client/config.rs
+++ b/topk-rs/src/client/config.rs
@@ -1,18 +1,23 @@
 use std::collections::HashMap;
 
+use super::retry::RetryConfig;
+
 #[derive(Clone)]
 pub struct ClientConfig {
     /// Topk region
-    region: String,
+    pub(crate) region: String,
 
     /// Topk host (e.g. "topk.io")
-    host: String,
+    pub(crate) host: String,
 
     /// Whether to use HTTPS
-    https: bool,
+    pub(crate) https: bool,
 
     /// Headers
-    headers: HashMap<&'static str, String>,
+    pub(crate) headers: HashMap<&'static str, String>,
+
+    /// Retry config
+    pub(crate) retry_config: RetryConfig,
 }
 
 impl ClientConfig {
@@ -22,6 +27,7 @@ impl ClientConfig {
             host: "topk.io".to_string(),
             https: true,
             headers: HashMap::from([("authorization", format!("Bearer {}", api_key.into()))]),
+            retry_config: RetryConfig::default(),
         }
     }
 
@@ -49,6 +55,11 @@ impl ClientConfig {
 
     pub fn with_headers(mut self, headers: impl Into<HashMap<&'static str, String>>) -> Self {
         self.headers.extend(headers.into());
+        self
+    }
+
+    pub fn with_retry_config(mut self, retry_config: RetryConfig) -> Self {
+        self.retry_config = retry_config;
         self
     }
 }

--- a/topk-rs/src/client/mod.rs
+++ b/topk-rs/src/client/mod.rs
@@ -13,8 +13,10 @@ pub use collections::CollectionsClient;
 mod collection;
 pub use collection::CollectionClient;
 
-mod client_config;
-pub use client_config::ClientConfig;
+mod config;
+pub use config::ClientConfig;
+
+pub mod retry;
 
 mod interceptor;
 pub use interceptor::AppendHeadersInterceptor;
@@ -74,6 +76,9 @@ macro_rules! create_client {
                         .keep_alive_while_idle(true)
                         // Set max header list size to 64KB
                         .http2_max_header_list_size(1024 * 64)
+                        // Set timeout to 60 seconds
+                        .timeout(std::time::Duration::from_secs(60))
+                        // Connect
                         .connect()
                         .await?)
                 })

--- a/topk-rs/src/client/retry.rs
+++ b/topk-rs/src/client/retry.rs
@@ -1,0 +1,96 @@
+use rand::prelude::*;
+use std::{future::Future, time::Duration};
+
+pub const DEFAULT_MAX_RETRIES: usize = 3; // 3 retries
+pub const DEFAULT_TIMEOUT: u64 = 30_000; // 30 seconds
+pub const DEFAULT_INIT_BACKOFF: u64 = 100; // 100 milliseconds
+pub const DEFAULT_MAX_BACKOFF: u64 = 10_000; // 10 seconds
+pub const DEFAULT_BASE: u32 = 2; // 2x backoff
+
+#[derive(Clone, Debug)]
+pub struct RetryConfig {
+    /// Maximum number of retries
+    pub max_retries: usize,
+
+    /// Total timeout for the retry chain
+    pub timeout: Duration,
+
+    /// Backoff configuration
+    pub backoff: BackoffConfig,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: DEFAULT_MAX_RETRIES,
+            timeout: Duration::from_millis(DEFAULT_TIMEOUT),
+            backoff: BackoffConfig::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BackoffConfig {
+    /// Base for the backoff
+    pub base: u32,
+
+    /// Initial backoff
+    pub init_backoff: Duration,
+
+    /// Maximum backoff
+    pub max_backoff: Duration,
+}
+
+impl Default for BackoffConfig {
+    fn default() -> Self {
+        Self {
+            base: DEFAULT_BASE,
+            init_backoff: Duration::from_millis(DEFAULT_INIT_BACKOFF),
+            max_backoff: Duration::from_millis(DEFAULT_MAX_BACKOFF),
+        }
+    }
+}
+
+pub async fn call_with_retry<F, T>(
+    retry_config: &RetryConfig,
+    f: impl Fn() -> F,
+) -> Result<T, crate::Error>
+where
+    F: Future<Output = Result<T, crate::Error>>,
+{
+    // Max backoff starts at `init_backoff` and is multiplied by `base` for each retry
+    let mut next_backoff = retry_config.backoff.init_backoff;
+
+    // Retry chain
+    let retry_chain = async {
+        for i in 0..retry_config.max_retries + 1 {
+            match f().await {
+                Ok(result) => return Ok(result),
+                Err(e) => {
+                    if !e.is_retryable() || i == retry_config.max_retries {
+                        return Err(e);
+                    }
+
+                    // Generate random backoff between `init_backoff` and `next_backoff`
+                    let backoff = rand::thread_rng()
+                        .gen_range(retry_config.backoff.init_backoff..=next_backoff);
+
+                    // Sleep for backoff
+                    tokio::time::sleep(backoff).await;
+
+                    // Calculate next backoff
+                    next_backoff = (next_backoff * retry_config.backoff.base)
+                        .min(retry_config.backoff.max_backoff);
+                }
+            }
+        }
+
+        unreachable!()
+    };
+
+    // Enfore total timeout
+    match tokio::time::timeout(retry_config.timeout, retry_chain).await {
+        Ok(result) => result,
+        Err(_) => return Err(crate::Error::RetryTimeout),
+    }
+}

--- a/topk-rs/src/error.rs
+++ b/topk-rs/src/error.rs
@@ -6,6 +6,9 @@ pub enum Error {
     #[error("lsn timeout")]
     QueryLsnTimeout,
 
+    #[error("retry timeout")]
+    RetryTimeout,
+
     #[error("collection already exists")]
     CollectionAlreadyExists,
 
@@ -48,11 +51,34 @@ pub enum Error {
     #[error("tonic transport error")]
     TransportError(#[from] tonic::transport::Error),
 
-    #[error("channel not initialized")]
-    TransportChannelNotInitialized,
-
     #[error("malformed response: {0}")]
     MalformedResponse(String),
+}
+
+impl Error {
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            // Retryable
+            Error::QueryLsnTimeout => true,
+            Error::SlowDown(_) => true,
+            // Not retryable
+            Error::RetryTimeout => false,
+            Error::CollectionAlreadyExists => false,
+            Error::CollectionNotFound => false,
+            Error::NotFound => false,
+            Error::SchemaValidationError(_) => false,
+            Error::DocumentValidationError(_) => false,
+            Error::CollectionValidationError(_) => false,
+            Error::InvalidArgument(_) => false,
+            Error::InvalidProto => false,
+            Error::PermissionDenied => false,
+            Error::QuotaExceeded(_) => false,
+            Error::RequestTooLarge(_) => false,
+            Error::TransportError(_) => false,
+            Error::MalformedResponse(_) => false,
+            Error::Unexpected(_) => false,
+        }
+    }
 }
 
 impl From<Status> for Error {
@@ -68,7 +94,10 @@ impl From<Status> for Error {
                 tonic::Code::ResourceExhausted => Error::QuotaExceeded(e.message().into()),
                 tonic::Code::InvalidArgument => match ValidationErrorBag::try_from(e.clone()) {
                     Ok(errors) => Error::DocumentValidationError(errors),
-                    Err(_) => Error::InvalidArgument(e.message().into()),
+                    Err(_) => match ValidationErrorBag::try_from(e.clone()) {
+                        Ok(errors) => Error::SchemaValidationError(errors),
+                        Err(_) => Error::InvalidArgument(e.message().into()),
+                    },
                 },
                 tonic::Code::OutOfRange => Error::RequestTooLarge(e.message().into()),
                 tonic::Code::PermissionDenied => Error::PermissionDenied,

--- a/topk-rs/src/lib.rs
+++ b/topk-rs/src/lib.rs
@@ -9,3 +9,5 @@ pub use client::Client;
 pub use client::ClientConfig;
 pub use client::CollectionClient;
 pub use client::CollectionsClient;
+
+pub use client::retry;


### PR DESCRIPTION
Introducing retries baked into `topk-rs` directly (topk-py & topk-js inherit). See the code for default values.

By default we retry in two scenarios:
* server needs client to slow down, `SlowDown` error is returned
* retries are also used for `query(..., lsn=N)` code path

