### PR TITLE
[topk-rs] change request timeout to `180s`, increase max response size

### DIFF
--- a/topk-js/Cargo.toml
+++ b/topk-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-js"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "TopK JavaScript SDK with TypeScript support"
 license-file = "LICENSE"

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-py/Cargo.toml
+++ b/topk-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-py"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "TopK Python SDK"
 license-file = "LICENSE"

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-rs"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "TopK Rust SDK"
 license = "MIT"

--- a/topk-rs/src/client/retry.rs
+++ b/topk-rs/src/client/retry.rs
@@ -1,11 +1,19 @@
 use rand::prelude::*;
 use std::{future::Future, time::Duration};
 
+// On the backend, default timeout:
+// - for `Query` or `Get` is 60 seconds
+// - for `Upsert` is 15 seconds
+// - for Control Plane operations is 15 seconds
+//
+// Total timeout is set to 180s to account for additional latency.
+pub const DEFAULT_TIMEOUT: u64 = 180_000; // 3 minutes
+
+// Default retry config
 pub const DEFAULT_MAX_RETRIES: usize = 3; // 3 retries
-pub const DEFAULT_TIMEOUT: u64 = 30_000; // 30 seconds
 pub const DEFAULT_INIT_BACKOFF: u64 = 100; // 100 milliseconds
 pub const DEFAULT_MAX_BACKOFF: u64 = 10_000; // 10 seconds
-pub const DEFAULT_BASE: u32 = 2; // 2x backoff
+pub const DEFAULT_BASE: u32 = 2; // `Base` is the multiplier for the backoff
 
 #[derive(Clone, Debug)]
 pub struct RetryConfig {


### PR DESCRIPTION
Setting both of these to unreasonably high numbers so we can fully and easily control these parameters on gateway/grpc service side.