### PR TITLE
[tests] publish test runner image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,12 @@ jobs:
       id-token: write
     with:
       publish: true
+
+  test-runner:
+    uses: ./.github/workflows/publish_test_runner.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: write
+    with:
+      publish: true

--- a/.github/workflows/publish_test_runner.yml
+++ b/.github/workflows/publish_test_runner.yml
@@ -1,0 +1,41 @@
+name: Build & publish TopK test runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        type: boolean
+        description: "Whether to publish the image"
+        default: false
+  workflow_call:
+    inputs:
+      publish:
+        type: boolean
+        description: "Whether to publish the image"
+        default: false
+
+jobs:
+  test-runner:
+    runs-on: amd64
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install earthly
+        run: sudo bash -c "curl -L https://github.com/earthly/earthly/releases/latest/download/earthly-linux-amd64 -o /usr/local/bin/earthly && chmod +x /usr/local/bin/earthly"
+
+      - name: Test runner
+        run: |
+          tag=$(sed -nE 's/^version = "([^"]+)"/\1/p' topk-rs/Cargo.toml)
+          # earthly ${{ inputs.publish && '--push' || '' }} +test-runner --tag $tag
+          earthly --push +test-runner --tag $tag


### PR DESCRIPTION
Publish `cargo-nextest`-based runner (from topk-rs tests) as image so we can run test in various envs in an encapsulated way.