### PR TITLE
[topk-py] fix bool type casting vol 2

### DIFF
--- a/topk-js/Cargo.toml
+++ b/topk-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-js"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "TopK JavaScript SDK with TypeScript support"
 license-file = "LICENSE"

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-protos/Cargo.toml
+++ b/topk-protos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-protos"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "TopK Protocol Buffers"
 license = "MIT"

--- a/topk-py/.gitignore
+++ b/topk-py/.gitignore
@@ -2,3 +2,4 @@ wheels
 __pycache__
 uv.lock
 target
+*.so

--- a/topk-py/Cargo.toml
+++ b/topk-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-py"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "TopK Python SDK"
 license-file = "LICENSE"

--- a/topk-py/src/client/mod.rs
+++ b/topk-py/src/client/mod.rs
@@ -75,7 +75,7 @@ pub struct RetryConfig {
 
 impl<'py> FromPyObject<'py> for RetryConfig {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
-        match obj.downcast::<PyDict>() {
+        match obj.downcast_exact::<PyDict>() {
             Ok(dict) => {
                 let max_retries = dict
                     .get_item("max_retries")?
@@ -131,7 +131,7 @@ pub struct BackoffConfig {
 
 impl<'py> FromPyObject<'py> for BackoffConfig {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
-        match obj.downcast::<PyDict>() {
+        match obj.downcast_exact::<PyDict>() {
             Ok(dict) => {
                 let base = dict
                     .get_item("base")?

--- a/topk-py/src/data/value.rs
+++ b/topk-py/src/data/value.rs
@@ -22,6 +22,7 @@ pub struct RawValue(pub Value);
 
 impl<'py> FromPyObject<'py> for RawValue {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        // NOTE: it's safe to use `downcast` for `Value` since it's a custom type
         if let Ok(v) = obj.downcast::<Value>() {
             Ok(RawValue(v.get().clone()))
         } else if let Ok(s) = obj.downcast_exact::<PyString>() {
@@ -44,7 +45,7 @@ impl<'py> FromPyObject<'py> for RawValue {
                     obj.get_type().name()
                 )))
             }
-        } else if let Ok(_) = obj.downcast::<PyNone>() {
+        } else if let Ok(_) = obj.downcast_exact::<PyNone>() {
             Ok(RawValue(Value::Null()))
         } else {
             Err(PyTypeError::new_err(format!(

--- a/topk-py/src/expr/flexible.rs
+++ b/topk-py/src/expr/flexible.rs
@@ -43,16 +43,17 @@ impl Into<LogicalExpr> for FlexibleExpr {
 
 impl<'py> FromPyObject<'py> for FlexibleExpr {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
-        if let Ok(s) = obj.downcast::<PyString>() {
+        if let Ok(s) = obj.downcast_exact::<PyString>() {
             Ok(FlexibleExpr::String(s.extract()?))
-        } else if let Ok(i) = obj.downcast::<PyInt>() {
+        } else if let Ok(i) = obj.downcast_exact::<PyInt>() {
             Ok(FlexibleExpr::Int(i.extract()?))
-        } else if let Ok(f) = obj.downcast::<PyFloat>() {
+        } else if let Ok(f) = obj.downcast_exact::<PyFloat>() {
             Ok(FlexibleExpr::Float(f.extract()?))
-        } else if let Ok(b) = obj.downcast::<PyBool>() {
+        } else if let Ok(b) = obj.downcast_exact::<PyBool>() {
             Ok(FlexibleExpr::Bool(b.extract()?))
-        } else if let Ok(_) = obj.downcast::<PyNone>() {
+        } else if let Ok(_) = obj.downcast_exact::<PyNone>() {
             Ok(FlexibleExpr::Null(Null))
+        // NOTE: it's safe to use `downcast` for `LogicalExpr` since it's a custom type
         } else if let Ok(e) = obj.downcast::<LogicalExpr>() {
             Ok(FlexibleExpr::Expr(e.get().clone()))
         } else {

--- a/topk-py/src/query/query.rs
+++ b/topk-py/src/query/query.rs
@@ -14,7 +14,7 @@ pub enum ConsistencyLevel {
 
 impl<'py> FromPyObject<'py> for ConsistencyLevel {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
-        match obj.downcast::<PyString>() {
+        match obj.downcast_exact::<PyString>() {
             Ok(val) => match val.extract::<&str>()? {
                 "indexed" => Ok(ConsistencyLevel::Indexed),
                 "strong" => Ok(ConsistencyLevel::Strong),

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-rs"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 description = "TopK Rust SDK"
 license = "MIT"


### PR DESCRIPTION
similar issue to #125, just on `FlexibleExpr`. I went ahead and replaced all usages of `.downcast` to `.downcast_exact`.