### PR TITLE
[js] fix release pipeline

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -98,7 +98,7 @@ test-js:
 
     RUN --mount=type=cache,target=/usr/local/cargo/registry \
         --mount=type=cache,target=/usr/local/cargo/git \
-        yarn build
+        yarn build && yarn typecheck
 
     ARG region=dev
     DO +SETUP_ENV --region=$region

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -79,7 +79,7 @@
   },
   "scripts": {
     "artifacts": "napi artifacts",
-    "build": "napi build --no-const-enum --platform --release && tsc --noEmit",
+    "build": "napi build --no-const-enum --platform --release",
     "dev": "napi build --no-const-enum --platform && tsc --noEmit",
     "build:debug": "napi build --no-const-enum --platform",
     "prepublishOnly": "napi prepublish -t npm --no-gh-release",


### PR DESCRIPTION
The release pipeline passes extra args to `yarn build` which [breaks](https://github.com/topk-io/topk/actions/runs/16002941310/job/45142371021#step:10:176) after I put `&& tsc --noEmit` in the `build` cmd. 