### PR TITLE
[topk-py] refactor sparse data constructors

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -29,9 +29,9 @@ test-rs:
 
     # test
     ENV FORCE_COLOR=1
-    ARG args="--no-fail-fast -j 16"
+    ARG args=""
     RUN --no-cache --secret TOPK_API_KEY \
-        TOPK_API_KEY=$TOPK_API_KEY cargo nextest run --archive-file e2e.tar.zst $args
+        TOPK_API_KEY=$TOPK_API_KEY cargo nextest run --archive-file e2e.tar.zst --no-fail-fast -j 16 $args
 
 
 test-py:
@@ -70,9 +70,10 @@ test-py:
     DO +SETUP_ENV --region=$region
 
     # test
+    ARG args=""
     RUN --no-cache --secret TOPK_API_KEY \
         . /venv/bin/activate \
-        && TOPK_API_KEY=$TOPK_API_KEY pytest -n auto --tb=long --durations=50 --color=yes
+        && TOPK_API_KEY=$TOPK_API_KEY pytest -n auto --tb=long --durations=50 --color=yes $args
 
 test-js:
     FROM node:20-slim
@@ -103,8 +104,9 @@ test-js:
     ARG region=dev
     DO +SETUP_ENV --region=$region
     # test
+    ARG args=""
     RUN --no-cache --secret TOPK_API_KEY \
-        TOPK_API_KEY=$TOPK_API_KEY yarn test --colors
+        TOPK_API_KEY=$TOPK_API_KEY yarn test --colors $args
 
 #
 

--- a/topk-js/Cargo.toml
+++ b/topk-js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-js"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "TopK JavaScript SDK with TypeScript support"
 license-file = "LICENSE"

--- a/topk-js/package.json
+++ b/topk-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "topk-js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "napi": {
     "binaryName": "topk-js",
     "triples": {

--- a/topk-py/Cargo.toml
+++ b/topk-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-py"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "TopK Python SDK"
 license-file = "LICENSE"

--- a/topk-py/src/data/mod.rs
+++ b/topk-py/src/data/mod.rs
@@ -1,4 +1,6 @@
-use crate::data::vector::{F32SparseVector, F32Vector, U8SparseVector, U8Vector};
+use crate::data::vector::{
+    F32SparseVector, F32Vector, SparseVector, U8SparseVector, U8Vector, Vector,
+};
 use pyo3::prelude::*;
 
 pub mod collection;
@@ -28,31 +30,31 @@ pub fn pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 #[pyfunction]
-#[pyo3(signature = (values))]
-pub fn f32_vector(values: F32Vector) -> PyResult<value::Value> {
-    Ok(value::Value::Vector(values.into()))
-}
-
-#[pyfunction]
-#[pyo3(signature = (values))]
-pub fn u8_vector(values: U8Vector) -> PyResult<value::Value> {
-    Ok(value::Value::Vector(values.into()))
-}
-
-#[pyfunction]
-#[pyo3(signature = (values))]
-pub fn binary_vector(values: U8Vector) -> PyResult<value::Value> {
-    Ok(value::Value::Vector(values.into()))
+#[pyo3(signature = (vector))]
+pub fn f32_vector(vector: F32Vector) -> Vector {
+    vector.into()
 }
 
 #[pyfunction]
 #[pyo3(signature = (vector))]
-pub fn f32_sparse_vector(vector: F32SparseVector) -> PyResult<value::Value> {
-    Ok(value::Value::SparseVector(vector.into()))
+pub fn u8_vector(vector: U8Vector) -> Vector {
+    vector.into()
 }
 
 #[pyfunction]
 #[pyo3(signature = (vector))]
-pub fn u8_sparse_vector(vector: U8SparseVector) -> PyResult<value::Value> {
-    Ok(value::Value::SparseVector(vector.into()))
+pub fn binary_vector(vector: U8Vector) -> Vector {
+    vector.into()
+}
+
+#[pyfunction]
+#[pyo3(signature = (vector))]
+pub fn f32_sparse_vector(vector: F32SparseVector) -> SparseVector {
+    vector.into()
+}
+
+#[pyfunction]
+#[pyo3(signature = (vector))]
+pub fn u8_sparse_vector(vector: U8SparseVector) -> SparseVector {
+    vector.into()
 }

--- a/topk-py/src/data/mod.rs
+++ b/topk-py/src/data/mod.rs
@@ -1,4 +1,5 @@
-use pyo3::{prelude::*, types::PyDict};
+use crate::data::vector::{F32SparseVector, F32Vector, U8SparseVector, U8Vector};
+use pyo3::prelude::*;
 
 pub mod collection;
 pub mod document;
@@ -28,36 +29,30 @@ pub fn pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[pyfunction]
 #[pyo3(signature = (values))]
-pub fn f32_vector(values: Vec<f32>) -> PyResult<value::Value> {
-    Ok(value::Value::Vector(vector::Vector::F32(values)))
+pub fn f32_vector(values: F32Vector) -> PyResult<value::Value> {
+    Ok(value::Value::Vector(values.into()))
 }
 
 #[pyfunction]
 #[pyo3(signature = (values))]
-pub fn u8_vector(values: Vec<u8>) -> PyResult<value::Value> {
-    Ok(value::Value::Vector(vector::Vector::U8(values)))
+pub fn u8_vector(values: U8Vector) -> PyResult<value::Value> {
+    Ok(value::Value::Vector(values.into()))
 }
 
 #[pyfunction]
 #[pyo3(signature = (values))]
-pub fn binary_vector(values: Vec<u8>) -> PyResult<value::Value> {
-    Ok(value::Value::Vector(vector::Vector::U8(values)))
+pub fn binary_vector(values: U8Vector) -> PyResult<value::Value> {
+    Ok(value::Value::Vector(values.into()))
 }
 
 #[pyfunction]
 #[pyo3(signature = (vector))]
-pub fn f32_sparse_vector(vector: &Bound<'_, PyDict>) -> PyResult<value::Value> {
-    Ok(value::Value::SparseVector(vector::SparseVector::F32 {
-        indices: vector.keys().extract::<Vec<u32>>()?,
-        values: vector.values().extract::<Vec<f32>>()?,
-    }))
+pub fn f32_sparse_vector(vector: F32SparseVector) -> PyResult<value::Value> {
+    Ok(value::Value::SparseVector(vector.into()))
 }
 
 #[pyfunction]
 #[pyo3(signature = (vector))]
-pub fn u8_sparse_vector(vector: &Bound<'_, PyDict>) -> PyResult<value::Value> {
-    Ok(value::Value::SparseVector(vector::SparseVector::U8 {
-        indices: vector.keys().extract::<Vec<u32>>()?,
-        values: vector.values().extract::<Vec<u8>>()?,
-    }))
+pub fn u8_sparse_vector(vector: U8SparseVector) -> PyResult<value::Value> {
+    Ok(value::Value::SparseVector(vector.into()))
 }

--- a/topk-py/src/data/value.rs
+++ b/topk-py/src/data/value.rs
@@ -20,6 +20,22 @@ pub enum Value {
     Bytes(Vec<u8>),
 }
 
+#[pymethods]
+impl Value {
+    fn __str__(&self) -> String {
+        match self {
+            Value::Null() => "Null".to_string(),
+            Value::String(s) => s.to_string(),
+            Value::Int(i) => i.to_string(),
+            Value::Float(f) => f.to_string(),
+            Value::Bool(b) => b.to_string(),
+            Value::Vector(v) => format!("Vector({:?})", v),
+            Value::SparseVector(v) => format!("SparseVector({:?})", v),
+            Value::Bytes(b) => format!("Bytes({:?})", b),
+        }
+    }
+}
+
 pub struct RawValue(pub Value);
 
 impl<'py> FromPyObject<'py> for RawValue {

--- a/topk-py/src/data/value.rs
+++ b/topk-py/src/data/value.rs
@@ -5,7 +5,9 @@ use pyo3::{
     IntoPyObjectExt,
 };
 
-use super::vector::{SparseVector, Vector};
+use crate::data::vector::F32Vector;
+
+use super::vector::{F32SparseVector, SparseVector, Vector};
 
 #[pyclass]
 #[derive(Debug, PartialEq, Clone)]
@@ -40,9 +42,13 @@ pub struct RawValue(pub Value);
 
 impl<'py> FromPyObject<'py> for RawValue {
     fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
-        // NOTE: it's safe to use `downcast` for `Value` since it's a custom type
+        // NOTE: it's safe to use `downcast` for custom types
         if let Ok(v) = obj.downcast::<Value>() {
             Ok(RawValue(v.get().clone()))
+        } else if let Ok(v) = obj.downcast::<Vector>() {
+            Ok(RawValue(Value::Vector(v.get().clone())))
+        } else if let Ok(v) = obj.downcast::<SparseVector>() {
+            Ok(RawValue(Value::SparseVector(v.get().clone())))
         } else if let Ok(s) = obj.downcast_exact::<PyString>() {
             Ok(RawValue(Value::String(s.extract()?)))
         } else if let Ok(i) = obj.downcast_exact::<PyInt>() {
@@ -53,41 +59,13 @@ impl<'py> FromPyObject<'py> for RawValue {
             Ok(RawValue(Value::Float(f.extract()?)))
         } else if let Ok(b) = obj.downcast_exact::<PyBool>() {
             Ok(RawValue(Value::Bool(b.extract()?)))
-        } else if let Ok(d) = obj.downcast_exact::<PyDict>() {
-            if let Ok(indices) = d.keys().extract::<Vec<u32>>() {
-                let values = d.values();
-                if let Ok(values) = values.extract::<Vec<f32>>() {
-                    Ok(RawValue(Value::SparseVector(SparseVector::F32 {
-                        indices,
-                        values,
-                    })))
-                } else if let Ok(values) = values.extract::<Vec<u8>>() {
-                    Ok(RawValue(Value::SparseVector(SparseVector::U8 {
-                        indices,
-                        values,
-                    })))
-                } else {
-                    Err(PyTypeError::new_err(format!(
-                        "Can't convert from {:?} to Value",
-                        obj.get_type().name()
-                    )))
-                }
-            } else {
-                Err(PyTypeError::new_err(format!(
-                    "Can't convert from {:?} to Value",
-                    obj.get_type().name()
-                )))
-            }
-        } else if let Ok(v) = obj.downcast_exact::<PyList>() {
-            // Try converting to vector from starting with most restrictive type first.
-            if let Ok(values) = v.extract::<Vec<f32>>() {
-                Ok(RawValue(Value::Vector(Vector::F32(values))))
-            } else {
-                Err(PyTypeError::new_err(format!(
-                    "Can't convert from {:?} to Value",
-                    obj.get_type().name()
-                )))
-            }
+        } else if let Ok(v) = F32SparseVector::extract_bound(obj) {
+            Ok(RawValue(Value::SparseVector(SparseVector::F32 {
+                indices: v.indices,
+                values: v.values,
+            })))
+        } else if let Ok(v) = F32Vector::extract_bound(obj) {
+            Ok(RawValue(Value::Vector(Vector::F32(v.values))))
         } else if let Ok(_) = obj.downcast_exact::<PyNone>() {
             Ok(RawValue(Value::Null()))
         } else {

--- a/topk-py/src/data/vector/dense.rs
+++ b/topk-py/src/data/vector/dense.rs
@@ -1,10 +1,56 @@
-use pyo3::prelude::*;
+use pyo3::{exceptions::PyTypeError, prelude::*};
 
 #[pyclass]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Vector {
     F32(Vec<f32>),
     U8(Vec<u8>),
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct F32Vector {
+    values: Vec<f32>,
+}
+
+impl From<F32Vector> for Vector {
+    fn from(vector: F32Vector) -> Self {
+        Vector::F32(vector.values)
+    }
+}
+
+impl<'py> FromPyObject<'py> for F32Vector {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(values) = Vec::<f32>::extract_bound(obj) {
+            return Ok(F32Vector { values });
+        }
+
+        Err(PyTypeError::new_err(
+            "Invalid vector value, must be `list[float]`",
+        ))
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct U8Vector {
+    values: Vec<u8>,
+}
+
+impl From<U8Vector> for Vector {
+    fn from(vector: U8Vector) -> Self {
+        Vector::U8(vector.values)
+    }
+}
+
+impl<'py> FromPyObject<'py> for U8Vector {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        if let Ok(values) = Vec::<u8>::extract_bound(obj) {
+            return Ok(U8Vector { values });
+        }
+
+        Err(PyTypeError::new_err(
+            "Invalid vector value, must be `list[int]`",
+        ))
+    }
 }
 
 impl From<Vector> for topk_rs::proto::v1::data::Vector {

--- a/topk-py/src/data/vector/dense.rs
+++ b/topk-py/src/data/vector/dense.rs
@@ -7,9 +7,19 @@ pub enum Vector {
     U8(Vec<u8>),
 }
 
+#[pymethods]
+impl Vector {
+    fn __str__(&self) -> String {
+        match self {
+            Vector::F32(values) => format!("Vector(F32({:?}))", values),
+            Vector::U8(values) => format!("Vector(U8({:?}))", values),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct F32Vector {
-    values: Vec<f32>,
+    pub(crate) values: Vec<f32>,
 }
 
 impl From<F32Vector> for Vector {
@@ -32,7 +42,7 @@ impl<'py> FromPyObject<'py> for F32Vector {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct U8Vector {
-    values: Vec<u8>,
+    pub(crate) values: Vec<u8>,
 }
 
 impl From<U8Vector> for Vector {

--- a/topk-py/src/data/vector/mod.rs
+++ b/topk-py/src/data/vector/mod.rs
@@ -2,4 +2,6 @@ mod dense;
 mod sparse;
 
 pub use dense::Vector;
+pub(crate) use dense::{F32Vector, U8Vector};
 pub use sparse::SparseVector;
+pub(crate) use sparse::{F32SparseVector, U8SparseVector};

--- a/topk-py/src/data/vector/sparse.rs
+++ b/topk-py/src/data/vector/sparse.rs
@@ -13,8 +13,22 @@ pub enum SparseVector {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct F32SparseVector {
-    indices: Vec<u32>,
-    values: Vec<f32>,
+    pub(crate) indices: Vec<u32>,
+    pub(crate) values: Vec<f32>,
+}
+
+#[pymethods]
+impl SparseVector {
+    fn __str__(&self) -> String {
+        match self {
+            SparseVector::F32 { indices, values } => {
+                format!("SparseVector(F32({:?}, {:?}))", indices, values)
+            }
+            SparseVector::U8 { indices, values } => {
+                format!("SparseVector(U8({:?}, {:?}))", indices, values)
+            }
+        }
+    }
 }
 
 impl From<F32SparseVector> for SparseVector {
@@ -28,8 +42,8 @@ impl From<F32SparseVector> for SparseVector {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct U8SparseVector {
-    indices: Vec<u32>,
-    values: Vec<u8>,
+    pub(crate) indices: Vec<u32>,
+    pub(crate) values: Vec<u8>,
 }
 
 impl From<U8SparseVector> for SparseVector {

--- a/topk-py/src/data/vector/sparse.rs
+++ b/topk-py/src/data/vector/sparse.rs
@@ -1,10 +1,98 @@
-use pyo3::prelude::*;
+use pyo3::{
+    exceptions::PyTypeError,
+    prelude::*,
+    types::{PyDict, PyTuple},
+};
 
 #[pyclass]
 #[derive(Debug, PartialEq, Clone)]
 pub enum SparseVector {
     F32 { indices: Vec<u32>, values: Vec<f32> },
     U8 { indices: Vec<u32>, values: Vec<u8> },
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct F32SparseVector {
+    indices: Vec<u32>,
+    values: Vec<f32>,
+}
+
+impl From<F32SparseVector> for SparseVector {
+    fn from(sparse: F32SparseVector) -> Self {
+        SparseVector::F32 {
+            indices: sparse.indices,
+            values: sparse.values,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct U8SparseVector {
+    indices: Vec<u32>,
+    values: Vec<u8>,
+}
+
+impl From<U8SparseVector> for SparseVector {
+    fn from(sparse: U8SparseVector) -> Self {
+        SparseVector::U8 {
+            indices: sparse.indices,
+            values: sparse.values,
+        }
+    }
+}
+
+impl<'py> FromPyObject<'py> for F32SparseVector {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let dict = obj.downcast_exact::<PyDict>().map_err(|_| {
+            PyTypeError::new_err("Invalid sparse vector, must be `dict[int, float]`")
+        })?;
+        let mut indices = Vec::new();
+        let mut values = Vec::new();
+
+        for item in dict.items() {
+            let (key, value) = item
+                .downcast_exact::<PyTuple>()
+                .map_err(|_| {
+                    PyTypeError::new_err("Invalid sparse vector, must be `dict[int, float]`")
+                })?
+                .extract::<(u32, f32)>()
+                .map_err(|_| {
+                    PyTypeError::new_err("Invalid sparse vector, must be `dict[int, float]`")
+                })?;
+
+            indices.push(key);
+            values.push(value);
+        }
+
+        Ok(F32SparseVector { indices, values })
+    }
+}
+
+impl<'py> FromPyObject<'py> for U8SparseVector {
+    fn extract_bound(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let dict = obj
+            .downcast_exact::<PyDict>()
+            .map_err(|_| PyTypeError::new_err("Invalid sparse vector, must be `dict[int, int]`"))?;
+        let mut indices = Vec::new();
+        let mut values = Vec::new();
+
+        for item in dict.items() {
+            let (key, value) = item
+                .downcast_exact::<PyTuple>()
+                .map_err(|_| {
+                    PyTypeError::new_err("Invalid sparse vector, must be `dict[int, int]`")
+                })?
+                .extract::<(u32, u8)>()
+                .map_err(|_| {
+                    PyTypeError::new_err("Invalid sparse vector, must be `dict[int, int]`")
+                })?;
+
+            indices.push(key);
+            values.push(value);
+        }
+
+        Ok(U8SparseVector { indices, values })
+    }
 }
 
 impl From<SparseVector> for topk_rs::proto::v1::data::SparseVector {

--- a/topk-py/src/query/mod.rs
+++ b/topk-py/src/query/mod.rs
@@ -1,5 +1,4 @@
 use crate::data::scalar::Scalar;
-use crate::data::value::Value;
 use crate::data::vector::{SparseVector, Vector};
 use crate::expr::filter::FilterExprUnion;
 use crate::expr::flexible::Vectorish;
@@ -103,17 +102,13 @@ pub fn vector_distance(field: String, query: Vectorish) -> FunctionExpr {
         field,
         query: match query {
             Vectorish::DenseF32(values) => QueryVector::Dense(Vector::F32(values)),
+            Vectorish::DenseU8(values) => QueryVector::Dense(Vector::U8(values)),
             Vectorish::SparseF32(indices, values) => {
                 QueryVector::Sparse(SparseVector::F32 { indices, values })
             }
             Vectorish::SparseU8(indices, values) => {
                 QueryVector::Sparse(SparseVector::U8 { indices, values })
             }
-            Vectorish::Value(value) => match value {
-                Value::Vector(vector) => QueryVector::Dense(vector),
-                Value::SparseVector(sparse_vector) => QueryVector::Sparse(sparse_vector),
-                _ => unreachable!("Invalid vector type: {:?}", value),
-            },
         },
     }
 }

--- a/topk-py/tests/test_data_vector_dense.py
+++ b/topk-py/tests/test_data_vector_dense.py
@@ -1,0 +1,101 @@
+import pytest
+from topk_sdk.data import binary_vector, f32_vector, u8_vector
+
+TYPE_ERROR = "Invalid vector value"
+
+
+class TestF32Vector:
+    def test_valid(self):
+        f32_vector([1, 2, 3])
+
+    def test_empty_case(self):
+        f32_vector([])
+
+    def test_to_string(self):
+        assert str(f32_vector([1, 2, 3])) == "Vector(F32([1.0, 2.0, 3.0]))"
+
+    def test_invalid_arguments(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector(0)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector(None)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector(False)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector(float("nan"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector(float("inf"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector(float("-inf"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector({1: 256})  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_vector({1: -1})  # type: ignore
+
+
+class TestU8Vector:
+    def test_valid(self):
+        u8_vector([1, 2, 3])
+
+    def test_empty_case(self):
+        u8_vector([])
+
+    def test_to_string(self):
+        assert str(u8_vector([1, 2, 3])) == "Vector(U8([1, 2, 3]))"
+
+    def test_invalid_number_range(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector([256])  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector([-1])  # type: ignore
+
+    def test_invalid_arguments(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector(0)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector(None)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector(False)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector(float("nan"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector(float("inf"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector({1: 256})  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_vector({1: -1})  # type: ignore
+
+
+class TestBinaryVector:
+    def test_valid(self):
+        binary_vector([1, 2, 3])
+
+    def test_empty_case(self):
+        binary_vector([])
+
+    def test_to_string(self):
+        assert str(binary_vector([1, 2, 3])) == "Vector(U8([1, 2, 3]))"
+
+    def test_invalid_number_range(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector([256])  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector([-1])  # type: ignore
+
+    def test_invalid_arguments(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector(0)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector(None)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector(False)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector(float("nan"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector(float("inf"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector(float("-inf"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector({1: 256})  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            binary_vector({1: -1})  # type: ignore

--- a/topk-py/tests/test_data_vector_sparse.py
+++ b/topk-py/tests/test_data_vector_sparse.py
@@ -13,10 +13,7 @@ class TestF32SparseVector:
         f32_sparse_vector({})
 
     def test_to_string(self):
-        assert (
-            str(f32_sparse_vector({1: 1.1}))
-            == "SparseVector(F32 { indices: [1], values: [1.1] })"
-        )
+        assert str(f32_sparse_vector({1: 1.1})) == "SparseVector(F32([1], [1.1]))"
 
     def test_invalid_key(self):
         with pytest.raises(TypeError, match=TYPE_ERROR):
@@ -52,10 +49,7 @@ class TestU8SparseVector:
         u8_sparse_vector({})
 
     def test_to_string(self):
-        assert (
-            str(u8_sparse_vector({1: 1}))
-            == "SparseVector(U8 { indices: [1], values: [1] })"
-        )
+        assert str(u8_sparse_vector({1: 1})) == "SparseVector(U8([1], [1]))"
 
     def test_invalid_key(self):
         with pytest.raises(TypeError, match=TYPE_ERROR):

--- a/topk-py/tests/test_data_vector_sparse.py
+++ b/topk-py/tests/test_data_vector_sparse.py
@@ -1,0 +1,88 @@
+import pytest
+from topk_sdk.data import f32_sparse_vector, u8_sparse_vector
+
+TYPE_ERROR = "Invalid sparse vector"
+
+
+class TestF32SparseVector:
+    def test_valid(self):
+        f32_sparse_vector({1: 1.1})
+        f32_sparse_vector({1: 1})
+
+    def test_empty_case(self):
+        f32_sparse_vector({})
+
+    def test_to_string(self):
+        assert (
+            str(f32_sparse_vector({1: 1.1}))
+            == "SparseVector(F32 { indices: [1], values: [1.1] })"
+        )
+
+    def test_invalid_key(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector({"foo": 1})  # type: ignore
+
+    def test_invalid_value(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector({1: "foo"})  # type: ignore
+
+    def test_invalid_arguments(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector(0)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector([])  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector(None)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector(False)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector(float("nan"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector(float("inf"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            f32_sparse_vector(float("-inf"))  # type: ignore
+
+
+class TestU8SparseVector:
+    def test_valid(self):
+        u8_sparse_vector({1: 1})
+        u8_sparse_vector({1: 1, 2: 2})
+
+    def test_empty_case(self):
+        u8_sparse_vector({})
+
+    def test_to_string(self):
+        assert (
+            str(u8_sparse_vector({1: 1}))
+            == "SparseVector(U8 { indices: [1], values: [1] })"
+        )
+
+    def test_invalid_key(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector({"foo": 1})  # type: ignore
+
+    def test_invalid_value(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector({1: "foo"})  # type: ignore
+
+    def test_invalid_number_range(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector({1: 256})  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector({1: -1})  # type: ignore
+
+    def test_invalid_arguments(self):
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector(0)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector([])  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector(None)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector(False)  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector(float("nan"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector(float("inf"))  # type: ignore
+        with pytest.raises(TypeError, match=TYPE_ERROR):
+            u8_sparse_vector(float("-inf"))  # type: ignore

--- a/topk-py/tests/test_query_sparse_vector.py
+++ b/topk-py/tests/test_query_sparse_vector.py
@@ -30,7 +30,9 @@ def test_query_sparse_vector_distance_u8_vector(ctx: ProjectContext):
 
     result = ctx.client.collection(collection.name).query(
         select(
-            score=fn.vector_distance("sparse_u8_embedding", {0: 1, 1: 2, 2: 3})
+            score=fn.vector_distance(
+                "sparse_u8_embedding", data.u8_sparse_vector({0: 1, 1: 2, 2: 3})
+            )
         ).topk(field("score"), 3, False)
     )
 
@@ -44,7 +46,7 @@ def test_query_sparse_vector_distance_nullable(ctx: ProjectContext):
         select(
             "title",
             sparse_u8_distance=fn.vector_distance(
-                "sparse_u8_embedding", {0: 1, 1: 2, 2: 3}
+                "sparse_u8_embedding", data.u8_sparse_vector({0: 1, 1: 2, 2: 3})
             ),
         ).topk(field("sparse_u8_distance"), 3, False)
     )
@@ -71,7 +73,7 @@ def test_query_sparse_vector_distance_nullable(ctx: ProjectContext):
         select(
             "title",
             sparse_u8_distance=fn.vector_distance(
-                "sparse_u8_embedding", {0: 1, 1: 2, 2: 3}
+                "sparse_u8_embedding", data.u8_sparse_vector({0: 1, 1: 2, 2: 3})
             ),
         ).topk(field("sparse_u8_distance"), 3, False),
         lsn=lsn,

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topk-rs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "TopK Rust SDK"
 license = "MIT"


### PR DESCRIPTION
Following the pattern from topk-js, `data.u8_vector()` and similar fns get better tests and cleaner impl.