### PR TITLE
[ci] publish test runner image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,3 +22,13 @@ jobs:
       id-token: write
     with:
       publish: true
+
+  test-runner:
+    uses: ./.github/workflows/publish_test_runner.yml
+    secrets: inherit
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    with:
+      push: true

--- a/.github/workflows/publish_test_runner.yml
+++ b/.github/workflows/publish_test_runner.yml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Earthly build
-        run: earthly --ci ${{ inputs.push && '--push' || '' }} +test-runner --registry ghcr.io --tag ${{ needs.version.outputs.version }}-${{ matrix.arch }}
+        run: earthly --ci ${{ (inputs.push || true) && '--push' || '' }} +test-runner --registry ghcr.io --tag ${{ needs.version.outputs.version }}-${{ matrix.arch }}
 
   publish:
     name: "test-runner (publish)"

--- a/.github/workflows/publish_test_runner.yml
+++ b/.github/workflows/publish_test_runner.yml
@@ -1,0 +1,94 @@
+name: Build test runner
+
+on:
+  push:
+    # ff
+  workflow_call:
+    inputs:
+      push:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set version
+        id: version
+        run: |
+          tag=$(sed -nE 's/^version = "([^"]+)"/\1/p' topk-rs/Cargo.toml)
+          echo "version=$tag" >> $GITHUB_OUTPUT
+
+  build:
+    name: "test-runner (${{ matrix.arch }})"
+    runs-on: "public-${{ matrix.arch }}"
+    needs: [version]
+    strategy:
+      fail-fast: true
+      matrix:
+        arch: [amd64, arm64]
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    env:
+      FORCE_COLOR: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: earthly/actions-setup@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "0.8.5"
+          use-cache: false
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Earthly build
+        run: earthly --ci ${{ inputs.push && '--push' || '' }} +test-runner --registry ghcr.io --tag ${{ needs.version.outputs.version }}-${{ matrix.arch }}
+
+  publish:
+    name: "test-runner (publish)"
+    runs-on: ubuntu-latest
+    if: ${{ inputs.push || true }}
+    needs:
+      - build
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    steps:
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish manifest
+        run: |
+          tag="ghcr.io/topk-io/topk-test-runner:${{ inputs.tag || 'abc'}}"
+
+          if ! docker manifest create $tag ${tag}-amd64 ${tag}-arm64; then
+            echo "Failed to create manifest for $tag"
+            exit 1
+          fi
+
+          if ! docker manifest push $tag; then
+            echo "Failed to push manifest for $tag"
+            exit 1
+          fi

--- a/.github/workflows/publish_test_runner.yml
+++ b/.github/workflows/publish_test_runner.yml
@@ -66,6 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ inputs.push || true }}
     needs:
+      - version
       - build
     permissions:
       id-token: write
@@ -81,7 +82,7 @@ jobs:
 
       - name: Publish manifest
         run: |
-          tag="ghcr.io/topk-io/topk-test-runner:${{ inputs.tag || 'abc'}}"
+          tag="ghcr.io/topk-io/topk-test-runner:${{ needs.version.outputs.version }}"
 
           if ! docker manifest create $tag ${tag}-amd64 ${tag}-arm64; then
             echo "Failed to create manifest for $tag"

--- a/.github/workflows/publish_test_runner.yml
+++ b/.github/workflows/publish_test_runner.yml
@@ -1,8 +1,6 @@
 name: Build test runner
 
 on:
-  push:
-    # ff
   workflow_call:
     inputs:
       push:
@@ -59,12 +57,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Earthly build
-        run: earthly --ci ${{ (inputs.push || true) && '--push' || '' }} +test-runner --registry ghcr.io/topk-io --tag ${{ needs.version.outputs.version }}-${{ matrix.arch }}
+        run: earthly --ci ${{ inputs.push && '--push' || '' }} +test-runner --registry ghcr.io/topk-io --tag ${{ needs.version.outputs.version }}-${{ matrix.arch }}
 
   publish:
     name: "test-runner (publish)"
     runs-on: ubuntu-latest
-    if: ${{ inputs.push || true }}
+    if: ${{ inputs.push }}
     needs:
       - version
       - build

--- a/.github/workflows/publish_test_runner.yml
+++ b/.github/workflows/publish_test_runner.yml
@@ -1,6 +1,13 @@
 name: Build test runner
 
 on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Whether to push the test runner to ghcr.io"
+        type: boolean
+        default: false
+
   workflow_call:
     inputs:
       push:

--- a/.github/workflows/publish_test_runner.yml
+++ b/.github/workflows/publish_test_runner.yml
@@ -59,7 +59,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Earthly build
-        run: earthly --ci ${{ (inputs.push || true) && '--push' || '' }} +test-runner --registry ghcr.io --tag ${{ needs.version.outputs.version }}-${{ matrix.arch }}
+        run: earthly --ci ${{ (inputs.push || true) && '--push' || '' }} +test-runner --registry ghcr.io/topk-io --tag ${{ needs.version.outputs.version }}-${{ matrix.arch }}
 
   publish:
     name: "test-runner (publish)"


### PR DESCRIPTION
For each release, we publish `topk-test-runner` image that wraps `cargo nextest run -p topk-rs` in a container for easier execution locally/in-cluster/etc.