### PR TITLE
Support null coalescing

### DIFF
--- a/protos/topk/data/v1/expr/logical.proto
+++ b/protos/topk/data/v1/expr/logical.proto
@@ -40,6 +40,7 @@ message LogicalExpr {
       OP_CONTAINS = 14;
       OP_MATCH_ALL = 15;
       OP_MATCH_ANY = 16;
+      OP_COALESCE = 17;
     }
     Op op = 1;
     LogicalExpr left = 2;

--- a/topk-rs/src/proto/data/v1/query_ext/expr_ext/logical.rs
+++ b/topk-rs/src/proto/data/v1/query_ext/expr_ext/logical.rs
@@ -111,6 +111,11 @@ impl LogicalExpr {
         Self::binary(binary_op::Op::MatchAny, self, right)
     }
 
+    /// Coalesce nulls in the left expression with the provided value.
+    pub fn coalesce(self, right: impl Into<LogicalExpr>) -> Self {
+        Self::binary(binary_op::Op::Coalesce, self, right)
+    }
+
     pub fn add(self, right: impl Into<LogicalExpr>) -> Self {
         Self::binary(binary_op::Op::Add, self, right)
     }

--- a/topk-rs/tests/utils/dataset/books.rs
+++ b/topk-rs/tests/utils/dataset/books.rs
@@ -52,6 +52,9 @@ pub fn schema() -> HashMap<String, FieldSpec> {
 
 #[allow(dead_code)]
 pub fn docs() -> Vec<Document> {
+    // !!! IMPORTANT !!!
+    // Do not change the values of existing fields.
+    // If you need to test new behavior which is not already covered by existing fields, add a new field.
     vec![
         doc!(
             "_id" => "mockingbird",
@@ -64,6 +67,7 @@ pub fn docs() -> Vec<Document> {
             "binary_embedding" => Value::u8_vector(vec![0, 1]),
             "sparse_f32_embedding" => Value::f32_sparse_vector(vec![0, 1, 2], vec![1.0, 2.0, 3.0]),
             "sparse_u8_embedding" => Value::u8_sparse_vector(vec![0, 1, 2], vec![1, 2, 3]),
+            "nullable_importance" => 2.0_f32
         ),
         doc!(
             "_id" => "1984",
@@ -115,6 +119,7 @@ pub fn docs() -> Vec<Document> {
             "summary_embedding" => vec![6.0; 16],
             "sparse_f32_embedding" => Value::f32_sparse_vector(vec![6,7,8], vec![1.0, 2.0, 3.0]),
             "sparse_u8_embedding" => Value::u8_sparse_vector(vec![6,7,8], vec![1, 2, 3]),
+            "nullable_importance" => 5.0_f32
         ),
         doc!(
             "_id" => "hobbit",


### PR DESCRIPTION
Support `coalesce` operator with the following semantics:
```python
def coalesce(x: Array, y: Array):
    [x[i] if (x[i] is not None) else y[i] for i in range(len(x))]
```

### Testing
```bash
PASS [   0.815s] topk-rs::test_query_logical test_query_coalesce_non_nullable
PASS [   0.820s] topk-rs::test_query_logical test_query_coalesce_missing
PASS [   0.825s] topk-rs::test_query_logical test_query_coalesce_nullable
PASS [   0.773s] topk-rs::test_query_hybrid test_query_hybrid_coalesce_score
```