### PR TITLE
boost operator

### DIFF
--- a/topk-rs/src/proto/data/v1/query_ext/expr_ext/logical.rs
+++ b/topk-rs/src/proto/data/v1/query_ext/expr_ext/logical.rs
@@ -160,6 +160,12 @@ impl LogicalExpr {
     pub fn choose(self, x: impl Into<LogicalExpr>, y: impl Into<LogicalExpr>) -> Self {
         Self::ternary(ternary_op::Op::Where, self, x, y)
     }
+
+    /// Multiplies the scoring expression by the provided `boost` value if the `condition` is true.
+    /// Otherwise, the scoring expression is unchanged (multiplied by 1).
+    pub fn boost(self, condition: impl Into<LogicalExpr>, boost: impl Into<Value>) -> Self {
+        self.mul(condition.into().choose(boost.into(), 1))
+    }
 }
 
 impl From<Value> for LogicalExpr {


### PR DESCRIPTION
Add `boost` operator that performs multiplicative boost by `value` based on `condition`. This is effectively the same as `score * cond.choose(value, 1)` expressed in a less verbose way.