### PR TITLE
[ci] run _publish_ workflow on `tag` event

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,11 @@
 name: Build & publish all SDKs
 
 on:
+  push:
+    # TODO(jergus): we need to check that the GH tag matches
+    # the version(s) in the Cargo.toml to avoid running unhealthy builds
+    tags:
+      - "*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Right now we run [publish](https://github.com/topk-io/topk/actions/workflows/publish.yml) workflow manually when releasing a new version. The flow is roughly as this:

1. land all the changes you want in the next release on `main`
2. land a "bump version" PR that updates all `Cargo.toml`s and `package.json`s
3. create a new github tag (via github UI)
4. run the workflow automatically

This PR automates step (4). We could also automate (3) and potentially (2) too. 