### PR TITLE
Add skip_refine arg to vector_distance

### DIFF
--- a/protos/topk/data/v1/expr/function.proto
+++ b/protos/topk/data/v1/expr/function.proto
@@ -12,6 +12,10 @@ message FunctionExpr {
     SparseVector sparse_query = 3 [deprecated = true];
     // Query value to compute distance against.
     Value query = 4;
+    // Skip vector score refinement if set to `true`.
+    // This will improve performance for large top_k values at the cost of lower quality.
+    // Intended to be used in conjunction with a custom reranker on top of the returned candidates.
+    bool skip_refine = 5;
   }
 
   message Bm25Score {}

--- a/topk-js/src/expr/function.rs
+++ b/topk-js/src/expr/function.rs
@@ -9,8 +9,15 @@ pub struct FunctionExpression(pub(crate) FunctionExpressionUnion);
 #[derive(Debug, Clone)]
 pub enum FunctionExpressionUnion {
     KeywordScore,
-    VectorScore { field: String, query: Value },
-    SemanticSimilarity { field: String, query: String },
+    VectorScore {
+        field: String,
+        query: Value,
+        skip_refine: bool,
+    },
+    SemanticSimilarity {
+        field: String,
+        query: String,
+    },
 }
 
 impl From<FunctionExpression> for topk_rs::proto::v1::data::FunctionExpr {
@@ -19,9 +26,11 @@ impl From<FunctionExpression> for topk_rs::proto::v1::data::FunctionExpr {
             FunctionExpressionUnion::KeywordScore => {
                 topk_rs::proto::v1::data::FunctionExpr::bm25_score()
             }
-            FunctionExpressionUnion::VectorScore { field, query } => {
-                topk_rs::proto::v1::data::FunctionExpr::vector_distance(field, query)
-            }
+            FunctionExpressionUnion::VectorScore {
+                field,
+                query,
+                skip_refine,
+            } => topk_rs::proto::v1::data::FunctionExpr::vector_distance(field, query, skip_refine),
             FunctionExpressionUnion::SemanticSimilarity { field, query } => {
                 topk_rs::proto::v1::data::FunctionExpr::semantic_similarity(field, query)
             }

--- a/topk-py/src/expr/function.rs
+++ b/topk-py/src/expr/function.rs
@@ -5,17 +5,26 @@ use pyo3::prelude::*;
 #[derive(Debug, Clone)]
 pub enum FunctionExpr {
     KeywordScore {},
-    VectorScore { field: String, query: Value },
-    SemanticSimilarity { field: String, query: String },
+    VectorScore {
+        field: String,
+        query: Value,
+        skip_refine: bool,
+    },
+    SemanticSimilarity {
+        field: String,
+        query: String,
+    },
 }
 
 impl From<FunctionExpr> for topk_rs::proto::v1::data::FunctionExpr {
     fn from(expr: FunctionExpr) -> Self {
         match expr {
             FunctionExpr::KeywordScore {} => topk_rs::proto::v1::data::FunctionExpr::bm25_score(),
-            FunctionExpr::VectorScore { field, query } => {
-                topk_rs::proto::v1::data::FunctionExpr::vector_distance(field, query)
-            }
+            FunctionExpr::VectorScore {
+                field,
+                query,
+                skip_refine,
+            } => topk_rs::proto::v1::data::FunctionExpr::vector_distance(field, query, skip_refine),
             FunctionExpr::SemanticSimilarity { field, query } => {
                 topk_rs::proto::v1::data::FunctionExpr::semantic_similarity(field, query)
             }

--- a/topk-py/src/query/mod.rs
+++ b/topk-py/src/query/mod.rs
@@ -127,15 +127,18 @@ pub fn bm25_score() -> FunctionExpr {
 }
 
 #[pyfunction]
-pub fn vector_distance(field: String, query: Value) -> PyResult<FunctionExpr> {
+#[pyo3(signature = (field, query, skip_refine=false))]
+pub fn vector_distance(field: String, query: Value, skip_refine: bool) -> PyResult<FunctionExpr> {
     match query {
         Value::List(list) => Ok(FunctionExpr::VectorScore {
             field,
             query: Value::List(list),
+            skip_refine,
         }),
         Value::SparseVector(vector) => Ok(FunctionExpr::VectorScore {
             field,
             query: Value::SparseVector(vector),
+            skip_refine,
         }),
         _ => Err(PyValueError::new_err(
             "Vector query must be a vector or sparse vector",

--- a/topk-rs/src/lib.rs
+++ b/topk-rs/src/lib.rs
@@ -51,7 +51,7 @@ pub mod query {
         use crate::proto::v1::data::{FunctionExpr, Value};
 
         pub fn vector_distance(field: impl Into<String>, query: impl Into<Value>) -> FunctionExpr {
-            FunctionExpr::vector_distance(field, query)
+            FunctionExpr::vector_distance(field, query, false)
         }
 
         pub fn semantic_similarity(

--- a/topk-rs/src/proto/data/v1/query_ext/expr_ext/function.rs
+++ b/topk-rs/src/proto/data/v1/query_ext/expr_ext/function.rs
@@ -4,12 +4,17 @@ use crate::proto::{
 };
 
 impl FunctionExpr {
-    pub fn vector_distance(field: impl Into<String>, query: impl Into<Value>) -> Self {
+    pub fn vector_distance(
+        field: impl Into<String>,
+        query: impl Into<Value>,
+        skip_refine: bool,
+    ) -> Self {
         FunctionExpr {
             func: Some(function_expr::Func::VectorDistance(
                 function_expr::VectorDistance {
                     field: field.into(),
                     query: Some(query.into()),
+                    skip_refine,
                     #[allow(deprecated)]
                     dense_query: None,
                     #[allow(deprecated)]
@@ -34,5 +39,12 @@ impl FunctionExpr {
                 },
             )),
         }
+    }
+
+    pub fn skip_refine(mut self, skip_refine: bool) -> Self {
+        if let Some(function_expr::Func::VectorDistance(vector_distance)) = &mut self.func {
+            vector_distance.skip_refine = skip_refine;
+        }
+        self
     }
 }


### PR DESCRIPTION
Add `skip_refine` argument to `vector_distance` function that allows users to explicitly opt out of internal vector distance refinement. This is particularly useful with learned rerankers that accept a large number of candidates (=> high `top_k`) where the internal reranking provides little benefit but causes higher tail latencies.