### PR TITLE
[topk-py] and/or rs methods missing underscore

### DIFF
--- a/docs/documents/query.mdx
+++ b/docs/documents/query.mdx
@@ -358,7 +358,7 @@ from topk_sdk.query import select, field
 select(
   weight_in_grams=field("weight").mul(1000),
   is_adult=field("age").gt(18),
-  published_in_nineteenth_century=field("published_year") >= 1800 && field("published_year") < 1900,
+  published_in_nineteenth_century=field("published_year") >= 1800 & field("published_year") < 1900,
 )
 ```
 
@@ -492,7 +492,7 @@ You can give weight to specific terms by using the `weight` parameter:
 ```python Python
 from topk_sdk.query import match
 
-.filter(match("catcher", weight=2.0).or(match("rye", weight=1.0)))
+.filter(match("catcher", weight=2.0) | match("rye", weight=1.0))
 ```
 
 
@@ -508,7 +508,7 @@ import { match } from "topk-js/query";
 
 You can combine metadata filtering and keyword search in a single query by stacking multiple filter stages.
 
-In the example below, we're searching for documents that contain the keyword `"catcher"` and were published in `1997`, or documents that were published between `1920` and `1980`.
+In the example below, we're searching for documents that contain the keyword `"catcher"` and were published in `1997`, or between `1920` and `1980`.
 
 <CodeGroup>
 
@@ -517,7 +517,7 @@ In the example below, we're searching for documents that contain the keyword `"c
     match("catcher")
 )
 .filter(
-    field("published_year") == 1997 || (field("published_year") >= 1920 && field("published_year") <= 1980)
+    field("published_year") == 1997 | ((field("published_year") >= 1920 & field("published_year") <= 1980))
 )
 ```
 
@@ -552,7 +552,7 @@ The `and` operator can be used to combine multiple logical expressions.
 
 ```python Python
 .filter(
-    field("published_year") == 1997 && field("title") == "The Catcher in the Rye"
+    field("published_year") == 1997 & field("title") == "The Catcher in the Rye"
 )
 
 # or
@@ -579,13 +579,13 @@ The `or` operator can be used to combine multiple logical expressions.
 
 ```python Python
 .filter(
-    field("published_year") == 1997 || field("title") == "The Catcher in the Rye"
+    field("published_year") == 1997 | field("title") == "The Catcher in the Rye"
 )
 
 # or
 
 .filter(
-    field("published_year").eq(1997).or(field("title").eq("The Catcher in the Rye"))
+    field("published_year").eq(1997).or_(field("title").eq("The Catcher in the Rye"))
 )
 ```
 

--- a/topk-py/src/expr/logical.rs
+++ b/topk-py/src/expr/logical.rs
@@ -524,7 +524,7 @@ impl LogicalExpr {
         })
     }
 
-    fn and(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
+    fn and_(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
         let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
@@ -535,14 +535,14 @@ impl LogicalExpr {
     }
 
     fn __and__(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
-        self.and(py, other)
+        self.and_(py, other)
     }
 
     fn __rand__(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
-        self.and(py, other)
+        self.and_(py, other)
     }
 
-    fn or(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
+    fn or_(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
         let expr: LogicalExpr = other.into();
 
         Ok(Self::Binary {
@@ -553,11 +553,11 @@ impl LogicalExpr {
     }
 
     fn __or__(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
-        self.or(py, other)
+        self.or_(py, other)
     }
 
     fn __ror__(&self, py: Python<'_>, other: Boolish) -> PyResult<Self> {
-        self.or(py, other)
+        self.or_(py, other)
     }
 
     fn starts_with(&self, py: Python<'_>, other: Stringy) -> PyResult<Self> {

--- a/topk-py/tests/test_query_expr.py
+++ b/topk-py/tests/test_query_expr.py
@@ -21,6 +21,14 @@ def test_query_expr_with_flexible_expr():
     assert (field("a") | False)._expr_eq(field("a") | literal(False))
     assert (False | field("a"))._expr_eq(field("a") | literal(False))
 
+    assert (field("a") & True)._expr_eq(field("a").and_(True))
+    assert (True & field("a"))._expr_eq(field("a").and_(True))
+
+    assert (field("a") | False)._expr_eq(field("a").or_(False))
+    assert (False | field("a"))._expr_eq(field("a").or_(False))
+
+    assert (field("a") & field("b"))._expr_eq(field("a").and_(field("b")))
+    assert (field("a") | field("b"))._expr_eq(field("a").or_(field("b")))
 
 def test_comparison_operators():
     assert (field("a") == 1)._expr_eq(field("a") == literal(1))


### PR DESCRIPTION
- the pyi stub already uses `and_`, `or_`.
- `and`, `or` are reserved keywords
- and, or operators cannot be overloaded
- `&`, `|` are bitwise and, or