### PR TITLE
Verify pre-commit hooks pass in PR

### DIFF
--- a/.github/workflows/workflow_pr.yml
+++ b/.github/workflows/workflow_pr.yml
@@ -84,6 +84,7 @@ jobs:
 
       - name: Run pre-commit
         run: uvx pre-commit run --all-files --show-diff-on-failure --color always
+
   ready:
     name: Ready
     needs: [all_sdks_same_version, pre_commit]
@@ -91,4 +92,3 @@ jobs:
     steps:
       - name: Ready
         run: echo "Ready"
-


### PR DESCRIPTION
I decided it's best to only depend on the pre-commit pip package rather than:
- https://pre-commit.ci/ - this is a service recommended by the developer, I find it maybe a bit unnecessary, it's free for open source repos but otherwise costs 20$/month for startups
- https://github.com/pre-commit/action is in "maintenance mode" in favor of the service
