### PR TITLE
[proto] re-map decode error

### DIFF
--- a/topk-rs/build.rs
+++ b/topk-rs/build.rs
@@ -35,6 +35,7 @@ fn build_topk_v1_protos() {
     }
 
     builder
+        .codec_path("crate::proto::codec::ProstCodec")
         .compile_protos(
             &[
                 "../protos/topk/control/v1/collection_service.proto",

--- a/topk-rs/src/proto/codec.rs
+++ b/topk-rs/src/proto/codec.rs
@@ -1,0 +1,56 @@
+use prost::Message;
+use tonic::codec::{Codec, DecodeBuf, Decoder};
+use tonic::{Code, Status};
+
+#[derive(Clone, Default)]
+pub(crate) struct ProstDecoder<T> {
+    inner: tonic_prost::ProstDecoder<T>,
+}
+
+impl<T> Decoder for ProstDecoder<T>
+where
+    T: Default + prost::Message,
+{
+    type Item = T;
+    type Error = Status;
+
+    fn decode(&mut self, buf: &mut DecodeBuf<'_>) -> Result<Option<Self::Item>, Self::Error> {
+        // By default, `prost` will return an INTERNAL_ERROR if the payload cannot be decoded.
+        // This happens, for example, if the proto recursion limit is exceeded (eg. expr to deep).
+        // Instead of returning an INTERNAL_ERROR, we want to remap this to INVALID_ARGUMENT instead.
+        self.inner
+            .decode(buf)
+            .map_err(|status| Status::new(Code::InvalidArgument, status.message()))
+    }
+
+    fn buffer_settings(&self) -> tonic::codec::BufferSettings {
+        self.inner.buffer_settings()
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct ProstCodec<Req, Resp> {
+    #[allow(dead_code)]
+    inner: tonic_prost::ProstCodec<Req, Resp>,
+}
+
+impl<Req, Resp> Codec for ProstCodec<Req, Resp>
+where
+    Req: Default + Message + Send + 'static,
+    Resp: Default + Message + Send + 'static,
+{
+    type Encode = Resp;
+    type Decode = Req;
+    type Encoder = tonic_prost::ProstEncoder<Resp>;
+    type Decoder = ProstDecoder<Req>;
+
+    fn encoder(&mut self) -> Self::Encoder {
+        tonic_prost::ProstEncoder::<Resp>::default()
+    }
+
+    fn decoder(&mut self) -> Self::Decoder {
+        ProstDecoder::<Req> {
+            inner: tonic_prost::ProstDecoder::default(),
+        }
+    }
+}

--- a/topk-rs/src/proto/mod.rs
+++ b/topk-rs/src/proto/mod.rs
@@ -1,3 +1,4 @@
+mod codec;
 mod control;
 mod data;
 mod macros;

--- a/topk-rs/tests/test_client.rs
+++ b/topk-rs/tests/test_client.rs
@@ -1,4 +1,9 @@
+use test_context::test_context;
+use topk_rs::query::{field, filter, r#match};
 use topk_rs::{Client, ClientConfig, Error};
+
+mod utils;
+use utils::ProjectTestContext;
 
 #[tokio::test]
 async fn test_invalid_api_key() {
@@ -19,4 +24,27 @@ async fn test_invalid_api_key() {
         .expect_err("should not be able to list collections");
 
     assert!(matches!(response, Error::PermissionDenied));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_protobuf_recursion_limit_returns_invalid_argument(ctx: &mut ProjectTestContext) {
+    // Build a deeply nested OR expression that exceeds protobuf recursion limit (100)
+    let mut deep_expr = r#match("test", Some("field"), None, false);
+    for i in 0..200 {
+        deep_expr = deep_expr.or(r#match(&format!("term{}", i), Some("field"), None, false));
+    }
+
+    let err = ctx
+        .client
+        .collection("test")
+        .query(filter(deep_expr).topk(field("id"), 10, true), None, None)
+        .await
+        .expect_err("Query should fail due to protobuf recursion limit");
+
+    assert!(
+        matches!(err, Error::InvalidArgument(_) if err.to_string().contains("failed to decode Protobuf message")),
+        "Expected InvalidArgument error with 'failed to decode Protobuf message', but got: {}",
+        err
+    );
 }


### PR DESCRIPTION
By default, `prost` will return an INTERNAL_ERROR if the payload cannot be decoded, we want to remap this to INVALID_ARGUMENT instead. 

We limit maximum depth of a `TextExpr` or `LogicalExpr` to 16 (cc @petertoth for docs), but that assume the proto can be decoded by `tonic`. `prost` comes with a baked-in max depth of `100`. There is `no-recursion-limit` feature flag but we don't want since it would be possible to overload the server, only to reject the request right after.

---

This happens, for example, if the proto recursion limit is exceeded (eg. expr to deep). Now, the following error is returned:

```
invalid argument: failed to decode Protobuf message: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: TextOrExpr.left: TextExpr.expr: FilterExpr.expr: FilterStage.expr: Stage.stage: Query.stages: QueryRequest.query: recursion limit reached
```

--- 


the `test_protobuf_recursion_limit_returns_invalid_argument` test will fail until upstream is deployed.