### PR TITLE
[build] add explicit build triggers

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -74,7 +74,7 @@ test-py:
     ARG args=""
     RUN --no-cache --secret TOPK_API_KEY \
         . /venv/bin/activate \
-        && TOPK_API_KEY=$TOPK_API_KEY pytest -n auto --tb=long --durations=50 --color=yes $args
+        && TOPK_API_KEY=$TOPK_API_KEY pytest -n auto --tb=long --durations=50 --color=yes -vv $args
 
 test-js:
     FROM node:20-slim

--- a/topk-py/tests/test_async_collection.py
+++ b/topk-py/tests/test_async_collection.py
@@ -33,6 +33,7 @@ async def test_async_get(async_ctx: AsyncProjectContext):
             "sparse_u8_embedding": {9: 1, 10: 2, 11: 3},
             "tags": ["lord of the rings", "fellowship", "magic", "wizard", "elves"],
             "codes": ["ISBN 978-0-547-92821-0", "ISBN 0-547-92821-2", "OCLC 434394005", "LCCN 2004558654", "Barcode 0618346252"],
+            "user_ratings": ["epic", "legendary", "good"],
         }
     }
 

--- a/topk-rs/build.rs
+++ b/topk-rs/build.rs
@@ -1,12 +1,30 @@
 fn main() {
+    // Rerun if build.rs changes
+    println!("cargo::rerun-if-changed=build.rs");
     build_topk_v1_protos();
 }
 
 fn build_topk_v1_protos() {
     let mut builder = tonic_prost_build::configure();
 
+    let proto_paths = [
+        "../protos/topk/control/v1/collection_service.proto",
+        "../protos/topk/control/v1/collection.proto",
+        "../protos/topk/control/v1/schema.proto",
+        "../protos/topk/data/v1/write_service.proto",
+        "../protos/topk/data/v1/document.proto",
+        "../protos/topk/data/v1/query_service.proto",
+        "../protos/topk/data/v1/query.proto",
+        "../protos/topk/data/v1/value.proto",
+    ];
+
+    // Rerun if any proto file changes
+    for path in proto_paths {
+        println!("cargo::rerun-if-changed={}", path);
+    }
+
     // #[derive(serde::Serialize, serde::Deserialize)]
-    for message in vec![
+    for message in [
         // field spec
         "topk.control.v1.FieldSpec",
         // field type
@@ -37,18 +55,6 @@ fn build_topk_v1_protos() {
     builder
         .codec_path("crate::proto::codec::ProstCodec")
         .bytes(".topk.data.v1.Value")
-        .compile_protos(
-            &[
-                "../protos/topk/control/v1/collection_service.proto",
-                "../protos/topk/control/v1/collection.proto",
-                "../protos/topk/control/v1/schema.proto",
-                "../protos/topk/data/v1/write_service.proto",
-                "../protos/topk/data/v1/document.proto",
-                "../protos/topk/data/v1/query_service.proto",
-                "../protos/topk/data/v1/query.proto",
-                "../protos/topk/data/v1/value.proto",
-            ],
-            &["../protos/"],
-        )
+        .compile_protos(&proto_paths, &["../protos/"])
         .expect("failed to build [topk.v1] protos");
 }


### PR DESCRIPTION
Add explicit build trigger to `topk-rs/build.rs` to make sure crate is rebuilt when any of the proto files change.