### PR TITLE
pre-commit ignore docs mdx files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+exclude: ^docs/.*\.mdx$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0


### PR DESCRIPTION
* ignore running pre-commit hooks on docs mdx files
* these files are either generated(SDKs references) or mintlify applies its own formatting when editing via the mintlify UI