### PR TITLE
[schema] vector dimension limit

### DIFF
--- a/topk-rs/src/error.rs
+++ b/topk-rs/src/error.rs
@@ -3,6 +3,8 @@ use std::time::Duration;
 use tonic::Status;
 use tracing::error;
 
+pub const MAX_VECTOR_DIMENSION: u32 = 16_384; // Double the size of `8192` which is the largest widely used vector dimension.
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("lsn timeout")]
@@ -166,6 +168,9 @@ pub enum SchemaValidationError {
 
     #[error("vector field `{field}` cannot be have zero dimension")]
     VectorDimensionCannotBeZero { field: String },
+
+    #[error("vector field `{field}` cannot have dimension greater than {MAX_VECTOR_DIMENSION}")]
+    VectorDimensionTooLarge { field: String, dimension: u32 },
 
     #[error("Invalid semantic index for field `{field}. Error: {error}`")]
     InvalidSemanticIndex { field: String, error: String },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce a max vector dimension (16,384) with a new schema validation error and a test ensuring collection creation fails when exceeded.
> 
> - **Schema/Validation**:
>   - Add `MAX_VECTOR_DIMENSION = 16_384`.
>   - Introduce `SchemaValidationError::VectorDimensionTooLarge { field, dimension }` with message capped at `MAX_VECTOR_DIMENSION`.
> - **Tests**:
>   - Add `test_create_collection_with_invalid_vector_dimension` using `FieldSpec::f32_vector(..., 20_000, ...)` to expect `SchemaValidationError::VectorDimensionTooLarge`.
>   - Import `SchemaValidationError`, `FieldSpec`, and `VectorDistanceMetric` in `tests/test_collections.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f5d548dadd7acf9b3a953601d62e99cc8cd667c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->