### PR TITLE
[topk-cli] flatten search result content in json output

### DIFF
--- a/topk-cli/Cargo.lock
+++ b/topk-cli/Cargo.lock
@@ -1929,6 +1929,8 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
+ "base64",
+ "bytes",
  "bytesize",
  "chrono",
  "clap",

--- a/topk-cli/Cargo.toml
+++ b/topk-cli/Cargo.toml
@@ -29,6 +29,8 @@ tracing = { version = "0.1" }
 regex = { version = "1" }
 futures = { version = "0.3" }
 serde = { version = "1", features = ["derive"] }
+base64 = "0.22"
+bytes = "1"
 bytesize = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 comfy-table = { version = "7" }

--- a/topk-cli/src/commands/ask.rs
+++ b/topk-cli/src/commands/ask.rs
@@ -170,7 +170,7 @@ pub async fn run(client: &Client, args: &AskArgs, output: &Output) -> Result<Ask
 
     let answer = answer.ok_or_else(|| Error::Internal("No answer found".to_string()))?;
 
-    AskResult::from_answer(answer, args.show_refs)
+    Ok(AskResult::from_answer(answer, args.show_refs)?)
 }
 
 #[cfg(test)]

--- a/topk-cli/src/commands/ask.rs
+++ b/topk-cli/src/commands/ask.rs
@@ -47,17 +47,17 @@ pub struct AskResult {
 }
 
 impl AskResult {
-    fn from_answer(a: Answer, show_refs: bool) -> Self {
-        Self {
+    fn from_answer(a: Answer, show_refs: bool) -> Result<Self, Error> {
+        Ok(Self {
             facts: a.facts,
             refs: a
                 .refs
                 .into_iter()
-                .map(|(k, v)| (k, SearchResult::from(v)))
-                .collect(),
+                .map(|(k, v)| SearchResult::try_from(v).map(|v| (k, v)))
+                .collect::<Result<HashMap<_, _>, _>>()?,
             confidence: a.confidence,
             show_refs,
-        }
+        })
     }
 
     pub fn render_refs(&self, paths: &HashMap<String, PathBuf>) -> Option<String> {
@@ -170,7 +170,7 @@ pub async fn run(client: &Client, args: &AskArgs, output: &Output) -> Result<Ask
 
     let answer = answer.ok_or_else(|| Error::Internal("No answer found".to_string()))?;
 
-    Ok(AskResult::from_answer(answer, args.show_refs))
+    AskResult::from_answer(answer, args.show_refs)
 }
 
 #[cfg(test)]

--- a/topk-cli/src/commands/ask.rs
+++ b/topk-cli/src/commands/ask.rs
@@ -47,17 +47,17 @@ pub struct AskResult {
 }
 
 impl AskResult {
-    fn from_answer(a: Answer, show_refs: bool) -> Result<Self, Error> {
-        Ok(Self {
+    fn from_answer(a: Answer, show_refs: bool) -> Self {
+        Self {
             facts: a.facts,
             refs: a
                 .refs
                 .into_iter()
-                .map(|(k, v)| SearchResult::try_from(v).map(|v| (k, v)))
-                .collect::<Result<HashMap<_, _>, _>>()?,
+                .map(|(k, v)| (k, v.into()))
+                .collect::<HashMap<_, _>>(),
             confidence: a.confidence,
             show_refs,
-        })
+        }
     }
 
     pub fn render_refs(&self, paths: &HashMap<String, PathBuf>) -> Option<String> {
@@ -170,7 +170,7 @@ pub async fn run(client: &Client, args: &AskArgs, output: &Output) -> Result<Ask
 
     let answer = answer.ok_or_else(|| Error::Internal("No answer found".to_string()))?;
 
-    Ok(AskResult::from_answer(answer, args.show_refs)?)
+    Ok(AskResult::from_answer(answer, args.show_refs))
 }
 
 #[cfg(test)]

--- a/topk-cli/src/commands/ask.rs
+++ b/topk-cli/src/commands/ask.rs
@@ -54,7 +54,7 @@ impl AskResult {
                 .refs
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
-                .collect::<HashMap<_, _>>(),
+                .collect(),
             confidence: a.confidence,
             show_refs,
         }

--- a/topk-cli/src/commands/search.rs
+++ b/topk-cli/src/commands/search.rs
@@ -440,7 +440,12 @@ mod tests {
             doc_name: "doc1.md".to_string(),
             dataset: "sec-10k".to_string(),
             content_id: "chunk-1".to_string(),
-            content: None,
+            content: Some(topk_rs::proto::v1::ctx::Content {
+                data: Some(topk_rs::proto::v1::ctx::content::Data::Chunk(topk_rs::proto::v1::ctx::Chunk {
+                    text: "hello".to_string(),
+                    doc_pages: vec![],
+                })),
+            }),
             metadata: [
                 ("ticker".to_string(), Value::string("AAPL")),
                 ("cik".to_string(), Value::i64(320193)),
@@ -459,7 +464,10 @@ mod tests {
                 "doc_name": "doc1.md",
                 "dataset": "sec-10k",
                 "content_id": "chunk-1",
-                "content": null,
+                "content": {
+                    "text": "hello",
+                    "doc_pages": []
+                },
                 "metadata": {
                     "ticker": "AAPL",
                     "cik": 320193

--- a/topk-cli/src/commands/search.rs
+++ b/topk-cli/src/commands/search.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use topk_rs::{Client, Error};
 
-use crate::util::{mime::MimeType, read_query_from_stdin, value::value_to_json, Base64Bytes};
+use crate::util::{mime::MimeType, read_query_from_stdin, value::value_to_json, Base64};
 
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
@@ -42,13 +42,11 @@ pub enum Content {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Image {
     pub mime_type: String,
-    pub data: Base64Bytes,
+    pub data: Base64,
 }
 
-impl TryFrom<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
-    type Error = Error;
-
-    fn try_from(result: topk_rs::proto::v1::ctx::SearchResult) -> Result<Self, Self::Error> {
+impl From<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
+    fn from(result: topk_rs::proto::v1::ctx::SearchResult) -> Self {
         let content = match result.content {
             None => None,
             Some(proto) => match proto.data {
@@ -57,7 +55,7 @@ impl TryFrom<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
             },
         };
 
-        Ok(Self {
+        Self {
             doc_id: result.doc_id,
             doc_type: result.doc_type,
             dataset: result.dataset,
@@ -69,7 +67,7 @@ impl TryFrom<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
                 .into_iter()
                 .map(|(k, v)| (k, value_to_json(v)))
                 .collect(),
-        })
+        }
     }
 }
 
@@ -82,13 +80,13 @@ impl From<topk_rs::proto::v1::ctx::content::Data> for Content {
             },
             topk_rs::proto::v1::ctx::content::Data::Image(image) => Self::Image(Image {
                 mime_type: image.mime_type,
-                data: Base64Bytes(image.data),
+                data: image.data.into(),
             }),
             topk_rs::proto::v1::ctx::content::Data::Page(page) => Self::Page {
                 page_number: page.page_number,
                 image: page.image.map(|image| Image {
                     mime_type: image.mime_type,
-                    data: Base64Bytes(image.data),
+                    data: image.data.into(),
                 }),
             },
         }
@@ -153,8 +151,8 @@ pub async fn run(client: &Client, args: &SearchArgs) -> Result<SearchResults, Er
             .try_collect::<Vec<_>>()
             .await?
             .into_iter()
-            .map(|r| r.try_into())
-            .collect::<Result<Vec<_>, _>>()?,
+            .map(|r| r.into())
+            .collect::<Vec<_>>(),
     })
 }
 
@@ -277,7 +275,7 @@ pub fn format_content_text(content: &Content) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Base64Bytes, Content, Image, SearchResult};
+    use super::{Base64, Content, Image, SearchResult};
     use assert_cmd::Command;
     use serde_json::json;
     use tempfile::tempdir;
@@ -517,7 +515,7 @@ mod tests {
             doc_name: "doc1.png".to_string(),
             content: Some(Content::Image(Image {
                 mime_type: "image/png".to_string(),
-                data: Base64Bytes(bytes::Bytes::from(vec![1, 2, 3])),
+                data: bytes::Bytes::from(vec![1, 2, 3]).into(),
             })),
             metadata: serde_json::Map::new(),
         };

--- a/topk-cli/src/commands/search.rs
+++ b/topk-cli/src/commands/search.rs
@@ -47,13 +47,7 @@ pub struct Image {
 
 impl From<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
     fn from(result: topk_rs::proto::v1::ctx::SearchResult) -> Self {
-        let content = match result.content {
-            None => None,
-            Some(proto) => match proto.data {
-                None => None,
-                Some(data) => Some(Content::from(data)),
-            },
-        };
+        let content = result.content.and_then(|proto| proto.data).map(Content::from);
 
         Self {
             doc_id: result.doc_id,
@@ -152,7 +146,7 @@ pub async fn run(client: &Client, args: &SearchArgs) -> Result<SearchResults, Er
             .await?
             .into_iter()
             .map(|r| r.into())
-            .collect::<Vec<_>>(),
+            .collect(),
     })
 }
 
@@ -171,13 +165,13 @@ pub fn save_search_results(
             Content::Chunk { text, .. } => ("txt".to_string(), text.as_bytes()),
             Content::Image(img) => (
                 MimeType::from(img.mime_type.as_str()).to_ext().to_string(),
-                img.data.0.as_ref(),
+                img.data.as_ref(),
             ),
             Content::Page { image, .. } => {
                 let img = image.as_ref().ok_or(Error::InvalidProto)?;
                 (
                     MimeType::from(img.mime_type.as_str()).to_ext().to_string(),
-                    img.data.0.as_ref(),
+                    img.data.as_ref(),
                 )
             }
         };
@@ -268,14 +262,14 @@ pub fn format_content_text(content: &Content) -> Option<String> {
         Content::Image(img) => Some(format!(
             "<image {} {}>",
             img.mime_type,
-            bytesize::ByteSize(img.data.0.len() as u64)
+            bytesize::ByteSize(img.data.as_ref().len() as u64)
         )),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Base64, Content, Image, SearchResult};
+    use super::{Content, Image, SearchResult};
     use assert_cmd::Command;
     use serde_json::json;
     use tempfile::tempdir;

--- a/topk-cli/src/commands/search.rs
+++ b/topk-cli/src/commands/search.rs
@@ -3,12 +3,9 @@ use futures::TryStreamExt;
 use std::collections::HashMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
-use topk_rs::{
-    proto::v1::ctx::{content, Content},
-    Client, Error,
-};
+use topk_rs::{Client, Error};
 
-use crate::util::{mime::MimeType, read_query_from_stdin, value::value_to_json};
+use crate::util::{mime::MimeType, read_query_from_stdin, value::value_to_json, Base64Bytes};
 
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
@@ -28,20 +25,72 @@ pub struct SearchResult {
     pub metadata: serde_json::Map<String, serde_json::Value>,
 }
 
-impl From<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
-    fn from(result: topk_rs::proto::v1::ctx::SearchResult) -> Self {
-        Self {
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum Content {
+    Chunk {
+        text: String,
+        doc_pages: Vec<u32>,
+    },
+    Image(Image),
+    Page {
+        page_number: u32,
+        image: Option<Image>,
+    },
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Image {
+    pub mime_type: String,
+    pub data: Base64Bytes,
+}
+
+impl TryFrom<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
+    type Error = Error;
+
+    fn try_from(result: topk_rs::proto::v1::ctx::SearchResult) -> Result<Self, Self::Error> {
+        let content = match result.content {
+            None => None,
+            Some(proto) => match proto.data {
+                None => None,
+                Some(data) => Some(Content::from(data)),
+            },
+        };
+
+        Ok(Self {
             doc_id: result.doc_id,
             doc_type: result.doc_type,
             dataset: result.dataset,
             content_id: result.content_id,
             doc_name: result.doc_name,
-            content: result.content,
+            content,
             metadata: result
                 .metadata
                 .into_iter()
                 .map(|(k, v)| (k, value_to_json(v)))
                 .collect(),
+        })
+    }
+}
+
+impl From<topk_rs::proto::v1::ctx::content::Data> for Content {
+    fn from(data: topk_rs::proto::v1::ctx::content::Data) -> Self {
+        match data {
+            topk_rs::proto::v1::ctx::content::Data::Chunk(chunk) => Self::Chunk {
+                text: chunk.text,
+                doc_pages: chunk.doc_pages,
+            },
+            topk_rs::proto::v1::ctx::content::Data::Image(image) => Self::Image(Image {
+                mime_type: image.mime_type,
+                data: Base64Bytes(image.data),
+            }),
+            topk_rs::proto::v1::ctx::content::Data::Page(page) => Self::Page {
+                page_number: page.page_number,
+                image: page.image.map(|image| Image {
+                    mime_type: image.mime_type,
+                    data: Base64Bytes(image.data),
+                }),
+            },
         }
     }
 }
@@ -104,8 +153,8 @@ pub async fn run(client: &Client, args: &SearchArgs) -> Result<SearchResults, Er
             .try_collect::<Vec<_>>()
             .await?
             .into_iter()
-            .map(|r| r.into())
-            .collect(),
+            .map(|r| r.try_into())
+            .collect::<Result<Vec<_>, _>>()?,
     })
 }
 
@@ -118,42 +167,24 @@ pub fn save_search_results(
 
     let mut paths = HashMap::new();
     for (ref_id, result) in refs {
-        let data = result
-            .content
-            .as_ref()
-            .ok_or(Error::InvalidProto)?
-            .data
-            .as_ref()
-            .ok_or(Error::InvalidProto)?;
+        let content = result.content.as_ref().ok_or(Error::InvalidProto)?;
 
-        let ext = match data {
-            content::Data::Chunk(_) => "txt".to_string(),
-            content::Data::Image(img) => {
-                MimeType::from(img.mime_type.as_str()).to_ext().to_string()
+        let (ext, bytes): (String, &[u8]) = match content {
+            Content::Chunk { text, .. } => ("txt".to_string(), text.as_bytes()),
+            Content::Image(img) => (
+                MimeType::from(img.mime_type.as_str()).to_ext().to_string(),
+                img.data.0.as_ref(),
+            ),
+            Content::Page { image, .. } => {
+                let img = image.as_ref().ok_or(Error::InvalidProto)?;
+                (
+                    MimeType::from(img.mime_type.as_str()).to_ext().to_string(),
+                    img.data.0.as_ref(),
+                )
             }
-            content::Data::Page(page) => MimeType::from(
-                page.image
-                    .as_ref()
-                    .ok_or(Error::InvalidProto)?
-                    .mime_type
-                    .as_str(),
-            )
-            .to_ext()
-            .to_string(),
         };
 
         let path = output_dir.join(format!("{ref_id}.{ext}"));
-
-        let bytes = match data {
-            content::Data::Chunk(chunk) => chunk.text.as_bytes(),
-            content::Data::Image(img) => img.data.as_ref(),
-            content::Data::Page(page) => page
-                .image
-                .as_ref()
-                .ok_or(Error::InvalidProto)?
-                .data
-                .as_ref(),
-        };
 
         std::fs::write(&path, bytes)?;
 
@@ -164,18 +195,16 @@ pub fn save_search_results(
 }
 
 pub fn render_search_result(ref_id: &str, result: &SearchResult, path: Option<&Path>) -> String {
-    let text = match result.content.as_ref().and_then(|c| c.data.as_ref()) {
-        Some(content::Data::Chunk(chunk)) => Some(chunk.text.to_string()),
+    let text = match &result.content {
+        Some(Content::Chunk { text, .. }) => Some(text.to_string()),
         _ => None,
     };
 
     let placeholder = if path.is_none()
         && text.is_none()
-        && !matches!(
-            result.content.as_ref().and_then(|c| c.data.as_ref()),
-            Some(content::Data::Chunk(_)) | None
-        ) {
-        format_content_text(result.content.as_ref())
+        && !matches!(&result.content, Some(Content::Chunk { .. }))
+    {
+        result.content.as_ref().and_then(format_content_text)
     } else {
         None
     };
@@ -227,29 +256,28 @@ fn display_path(path: &Path) -> String {
     path.display().to_string()
 }
 
-pub fn format_content_text(content: Option<&Content>) -> Option<String> {
-    match content.and_then(|c| c.data.as_ref()) {
-        Some(content::Data::Chunk(chunk)) => {
-            if chunk.doc_pages.is_empty() {
-                Some(chunk.text.clone())
+pub fn format_content_text(content: &Content) -> Option<String> {
+    match content {
+        Content::Chunk { text, doc_pages } => {
+            if doc_pages.is_empty() {
+                Some(text.clone())
             } else {
-                let pages: Vec<String> = chunk.doc_pages.iter().map(|p| p.to_string()).collect();
-                Some(format!("{} [p.{}]", chunk.text, pages.join(",")))
+                let pages: Vec<String> = doc_pages.iter().map(|p| p.to_string()).collect();
+                Some(format!("{} [p.{}]", text, pages.join(",")))
             }
         }
-        Some(content::Data::Page(page)) => Some(format!("<page {}>", page.page_number)),
-        Some(content::Data::Image(img)) => Some(format!(
+        Content::Page { page_number, .. } => Some(format!("<page {}>", page_number)),
+        Content::Image(img) => Some(format!(
             "<image {} {}>",
             img.mime_type,
-            bytesize::ByteSize(img.data.len() as u64)
+            bytesize::ByteSize(img.data.0.len() as u64)
         )),
-        None => None,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::SearchResult;
+    use super::{Base64Bytes, Content, Image, SearchResult};
     use assert_cmd::Command;
     use serde_json::json;
     use tempfile::tempdir;
@@ -421,7 +449,7 @@ mod tests {
             .collect(),
         };
 
-        let json_result = SearchResult::from(result);
+        let json_result = SearchResult::try_from(result).unwrap();
 
         assert_eq!(
             serde_json::to_value(json_result).unwrap(),
@@ -435,6 +463,68 @@ mod tests {
                 "metadata": {
                     "ticker": "AAPL",
                     "cik": 320193
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn search_result_json_flattens_chunk_content() {
+        let result = SearchResult {
+            doc_id: "doc1".to_string(),
+            doc_type: "application/pdf".to_string(),
+            dataset: "sec-10k".to_string(),
+            content_id: "chunk-1".to_string(),
+            doc_name: "doc1.pdf".to_string(),
+            content: Some(Content::Chunk {
+                text: "hello".to_string(),
+                doc_pages: vec![170],
+            }),
+            metadata: serde_json::Map::new(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(result).unwrap(),
+            json!({
+                "doc_id": "doc1",
+                "doc_type": "application/pdf",
+                "dataset": "sec-10k",
+                "content_id": "chunk-1",
+                "doc_name": "doc1.pdf",
+                "content": {
+                    "text": "hello",
+                    "doc_pages": [170]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn search_result_json_encodes_image_bytes_as_base64() {
+        let result = SearchResult {
+            doc_id: "doc1".to_string(),
+            doc_type: "image/png".to_string(),
+            dataset: "images".to_string(),
+            content_id: "img-1".to_string(),
+            doc_name: "doc1.png".to_string(),
+            content: Some(Content::Image(Image {
+                mime_type: "image/png".to_string(),
+                data: Base64Bytes(bytes::Bytes::from(vec![1, 2, 3])),
+            })),
+            metadata: serde_json::Map::new(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(result).unwrap(),
+            json!({
+                "doc_id": "doc1",
+                "doc_type": "image/png",
+                "dataset": "images",
+                "content_id": "img-1",
+                "doc_name": "doc1.png",
+                "content": {
+                    "mime_type": "image/png",
+                    "data": "AQID"
                 }
             })
         );

--- a/topk-cli/src/util/bytes.rs
+++ b/topk-cli/src/util/bytes.rs
@@ -2,9 +2,15 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use bytes::Bytes;
 
 #[derive(Debug, Clone)]
-pub struct Base64Bytes(pub Bytes);
+pub struct Base64(pub Bytes);
 
-impl serde::Serialize for Base64Bytes {
+impl From<Bytes> for Base64 {
+    fn from(b: Bytes) -> Self {
+        Self(b)
+    }
+}
+
+impl serde::Serialize for Base64 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -13,7 +19,7 @@ impl serde::Serialize for Base64Bytes {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for Base64Bytes {
+impl<'de> serde::Deserialize<'de> for Base64 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -22,7 +28,7 @@ impl<'de> serde::Deserialize<'de> for Base64Bytes {
         STANDARD
             .decode(s)
             .map(Bytes::from)
-            .map(Base64Bytes)
+            .map(Base64::from)
             .map_err(serde::de::Error::custom)
     }
 }

--- a/topk-cli/src/util/bytes.rs
+++ b/topk-cli/src/util/bytes.rs
@@ -1,0 +1,28 @@
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use bytes::Bytes;
+
+#[derive(Debug, Clone)]
+pub struct Base64Bytes(pub Bytes);
+
+impl serde::Serialize for Base64Bytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&STANDARD.encode(self.0.as_ref()))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Base64Bytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        STANDARD
+            .decode(s)
+            .map(Bytes::from)
+            .map(Base64Bytes)
+            .map_err(serde::de::Error::custom)
+    }
+}

--- a/topk-cli/src/util/bytes.rs
+++ b/topk-cli/src/util/bytes.rs
@@ -2,11 +2,17 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use bytes::Bytes;
 
 #[derive(Debug, Clone)]
-pub struct Base64(pub Bytes);
+pub struct Base64(Bytes);
 
 impl From<Bytes> for Base64 {
     fn from(b: Bytes) -> Self {
         Self(b)
+    }
+}
+
+impl AsRef<[u8]> for Base64 {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 

--- a/topk-cli/src/util/mod.rs
+++ b/topk-cli/src/util/mod.rs
@@ -8,7 +8,7 @@ pub mod mime;
 pub mod progress;
 pub mod value;
 
-pub use bytes::Base64Bytes;
+pub use bytes::Base64;
 pub use mime::MimeType;
 use topk_rs::Error;
 

--- a/topk-cli/src/util/mod.rs
+++ b/topk-cli/src/util/mod.rs
@@ -2,11 +2,13 @@ use std::io::{self, IsTerminal, Read};
 
 use chrono::{DateTime, Local, Utc};
 
+pub mod bytes;
 pub mod files;
 pub mod mime;
 pub mod progress;
 pub mod value;
 
+pub use bytes::Base64Bytes;
 pub use mime::MimeType;
 use topk_rs::Error;
 

--- a/topk-js/src/data/ask.rs
+++ b/topk-js/src/data/ask.rs
@@ -132,36 +132,33 @@ impl TryFrom<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
     fn try_from(v: topk_rs::proto::v1::ctx::SearchResult) -> Result<Self> {
         let content = match v.content {
             None => None,
-            Some(content) => Some(
-                match content
-                    .data
-                    .ok_or_else(|| napi::Error::from_reason(topk_rs::Error::InvalidProto.to_string()))?
-                {
-                    Data::Chunk(chunk) => Content {
-                        r#type: "chunk".to_string(),
-                        data: Either3::A(Chunk {
-                            text: chunk.text,
-                            doc_pages: chunk.doc_pages,
-                        }),
-                    },
-                    Data::Page(page) => Content {
-                        r#type: "page".to_string(),
-                        data: Either3::B(Page {
-                            page_number: page.page_number,
-                            image: page.image.map(|img| Image {
-                                data: img.data.to_vec(),
-                                mime_type: img.mime_type,
-                            }),
-                        }),
-                    },
-                    Data::Image(img) => Content {
-                        r#type: "image".to_string(),
-                        data: Either3::C(Image {
+            Some(content) => match content.data {
+                None => None,
+                Some(Data::Chunk(chunk)) => Some(Content {
+                    r#type: "chunk".to_string(),
+                    data: Either3::A(Chunk {
+                        text: chunk.text,
+                        doc_pages: chunk.doc_pages,
+                    }),
+                }),
+                Some(Data::Page(page)) => Some(Content {
+                    r#type: "page".to_string(),
+                    data: Either3::B(Page {
+                        page_number: page.page_number,
+                        image: page.image.map(|img| Image {
                             data: img.data.to_vec(),
                             mime_type: img.mime_type,
                         }),
-                    },
-                })
+                    }),
+                }),
+                Some(Data::Image(img)) => Some(Content {
+                    r#type: "image".to_string(),
+                    data: Either3::C(Image {
+                        data: img.data.to_vec(),
+                        mime_type: img.mime_type,
+                    }),
+                }),
+            },
         };
 
         Ok(SearchResult {

--- a/topk-py/src/data/ask.rs
+++ b/topk-py/src/data/ask.rs
@@ -216,6 +216,28 @@ impl Content {
     }
 }
 
+impl From<Data> for Content {
+    fn from(data: Data) -> Self {
+        match data {
+            Data::Chunk(chunk) => Content::Chunk(Chunk {
+                text: chunk.text,
+                doc_pages: chunk.doc_pages,
+            }),
+            Data::Page(page) => Content::Page(Page {
+                page_number: page.page_number,
+                image: page.image.map(|img| Image {
+                    data: img.data.to_vec(),
+                    mime_type: img.mime_type,
+                }),
+            }),
+            Data::Image(img) => Content::Image(Image {
+                data: img.data.to_vec(),
+                mime_type: img.mime_type,
+            }),
+        }
+    }
+}
+
 #[pyclass]
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchResult {
@@ -246,27 +268,7 @@ impl TryFrom<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
     type Error = RustError;
 
     fn try_from(v: topk_rs::proto::v1::ctx::SearchResult) -> Result<Self, Self::Error> {
-        let content = match v.content {
-            None => None,
-            Some(content) => match content.data {
-                None => None,
-                Some(Data::Chunk(chunk)) => Some(Content::Chunk(Chunk {
-                    text: chunk.text,
-                    doc_pages: chunk.doc_pages,
-                })),
-                Some(Data::Page(page)) => Some(Content::Page(Page {
-                    page_number: page.page_number,
-                    image: page.image.map(|img| Image {
-                        data: img.data.to_vec(),
-                        mime_type: img.mime_type,
-                    }),
-                })),
-                Some(Data::Image(img)) => Some(Content::Image(Image {
-                    data: img.data.to_vec(),
-                    mime_type: img.mime_type,
-                })),
-            },
-        };
+        let content = v.content.and_then(|proto| proto.data).map(Content::from);
 
         Ok(SearchResult {
             doc_id: v.doc_id,

--- a/topk-py/src/data/ask.rs
+++ b/topk-py/src/data/ask.rs
@@ -248,25 +248,24 @@ impl TryFrom<topk_rs::proto::v1::ctx::SearchResult> for SearchResult {
     fn try_from(v: topk_rs::proto::v1::ctx::SearchResult) -> Result<Self, Self::Error> {
         let content = match v.content {
             None => None,
-            Some(content) => {
-                Some(match content.data.ok_or(topk_rs::Error::InvalidProto)? {
-                    Data::Chunk(chunk) => Content::Chunk(Chunk {
-                        text: chunk.text,
-                        doc_pages: chunk.doc_pages,
-                    }),
-                    Data::Page(page) => Content::Page(Page {
-                        page_number: page.page_number,
-                        image: page.image.map(|img| Image {
-                            data: img.data.to_vec(),
-                            mime_type: img.mime_type,
-                        }),
-                    }),
-                    Data::Image(img) => Content::Image(Image {
+            Some(content) => match content.data {
+                None => None,
+                Some(Data::Chunk(chunk)) => Some(Content::Chunk(Chunk {
+                    text: chunk.text,
+                    doc_pages: chunk.doc_pages,
+                })),
+                Some(Data::Page(page)) => Some(Content::Page(Page {
+                    page_number: page.page_number,
+                    image: page.image.map(|img| Image {
                         data: img.data.to_vec(),
                         mime_type: img.mime_type,
                     }),
-                })
-            }
+                })),
+                Some(Data::Image(img)) => Some(Content::Image(Image {
+                    data: img.data.to_vec(),
+                    mime_type: img.mime_type,
+                })),
+            },
         };
 
         Ok(SearchResult {


### PR DESCRIPTION
Flatten the `SearchResult.content` in CLI JSON output and directly encode bytes into base64 strings:

New:

```json
"5": {
      "doc_id": "f830c658d1f46821",
      "doc_type": "application/pdf",
      "dataset": "vidore-v3",
      "content": {
          "text": "# U.S. Securities ...",
          "doc_pages": [
              170
          ]
      }
 },
"3": {
    "doc_id": "f830c658d1f46821",
    "doc_type": "application/pdf",
    "dataset": "vidore-v3",
    "content": {
        "mime_type": "image/jpeg",
        "data": "/9j/4AAQSkZJRgABAgAAAQABAAD/wAARCASwA58DAREAAhEBAxEB/....
     }
 }
```

Old:

```json
"5": {
    "doc_id": "f830c658d1f46821",
    "doc_type": "application/pdf",
    "dataset": "vidore-v3",
    "content": {
        "data": {
            "Chunk": {
                "text": "# U.S. Securities ....",
                "doc_pages": [
                    170
                ]
            }
        }
    },
},
"3": {
    "doc_id": "f830c658d1f46821",
    "doc_type": "application/pdf",
    "dataset": "vidore-v3",
    "content": {
        "data": {
            "Image": {
                "mime_type": "image/jpeg",
                "data": [1, 2, 3, ....]
             },
         },
     }
```