### PR TITLE
[test] add `topk-test-sandbox`

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -171,10 +171,11 @@ test-runner-builder:
     RUN apt-get update && apt-get install -y protobuf-compiler
     RUN cargo install cargo-nextest --locked
 
-    WORKDIR /workspace
+    WORKDIR /sdk
     DO rust+INIT --keep_fingerprints=true
-    COPY --keep-ts --dir . .
+    COPY --keep-ts . .
 
+    WORKDIR /sdk/topk-rs
     ENV RUSTFLAGS="-C target-cpu=generic"
     ENV FORCE_COLOR=1
     DO rust+CARGO --args="nextest archive --release --archive-file test-runner.tar.zst"

--- a/Earthfile
+++ b/Earthfile
@@ -14,6 +14,7 @@ test-rs:
     # install dependencies
     RUN apt-get update && apt-get install -y protobuf-compiler
     RUN cargo install cargo-nextest --locked
+    COPY +test-sandbox/topk-test-sandbox /usr/local/bin/topk-test-sandbox
 
     DO rust+INIT --keep_fingerprints=true
     WORKDIR /sdk
@@ -33,7 +34,7 @@ test-rs:
     # test
     ENV FORCE_COLOR=1
     RUN --no-cache --secret TOPK_API_KEY \
-        TOPK_API_KEY=$TOPK_API_KEY cargo nextest run --archive-file e2e.tar.zst --no-fail-fast -j 16
+        TOPK_API_KEY=$TOPK_API_KEY topk-test-sandbox cargo nextest run --archive-file e2e.tar.zst --no-fail-fast -j 16
 
 
 test-py:
@@ -41,9 +42,8 @@ test-py:
 
     # install dependencies
     RUN apt-get update && apt-get install -y protobuf-compiler python3-venv
-
-    # setup maturin
     RUN cargo install maturin@1.9.0 --locked
+    COPY +test-sandbox/topk-test-sandbox /usr/local/bin/topk-test-sandbox
 
     # setup python
     RUN python3 -m venv /venv \
@@ -79,7 +79,7 @@ test-py:
     ARG args=""
     RUN --no-cache --secret TOPK_API_KEY \
         . /venv/bin/activate \
-        && TOPK_API_KEY=$TOPK_API_KEY pytest -n auto --tb=long --durations=50 --color=yes -vv $args
+        && TOPK_API_KEY=$TOPK_API_KEY topk-test-sandbox pytest -n auto --tb=long --durations=50 --color=yes -vv $args
 
 test-js:
     FROM node:20-slim
@@ -90,6 +90,8 @@ test-js:
     # install Rust
     RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
     ENV PATH="/root/.cargo/bin:${PATH}"
+
+    COPY +test-sandbox/topk-test-sandbox /usr/local/bin/topk-test-sandbox
 
     # Ensure yarn bins are in the PATH
     ENV PATH="/sdk/topk-js/node_modules/.bin:${PATH}"
@@ -124,13 +126,14 @@ test-js:
     # test
     ARG args=""
     RUN --no-cache --secret TOPK_API_KEY \
-        TOPK_API_KEY=$TOPK_API_KEY yarn test --colors $args
+        TOPK_API_KEY=$TOPK_API_KEY topk-test-sandbox yarn test --colors $args
 
 test-cli:
     FROM rust:slim
 
     # install dependencies
     RUN apt-get update && apt-get install -y protobuf-compiler jq
+    COPY +test-sandbox/topk-test-sandbox /usr/local/bin/topk-test-sandbox
 
     DO rust+INIT --keep_fingerprints=true
     WORKDIR /sdk
@@ -158,33 +161,50 @@ test-cli:
     ENV FORCE_COLOR=1
     ENV CARGO_BIN_EXE_topk=/sdk/topk-cli/target/debug/topk
     RUN --no-cache --secret TOPK_API_KEY \
-        TOPK_API_KEY=$TOPK_API_KEY cargo test -p topk-cli --lib --no-fail-fast
+        TOPK_API_KEY=$TOPK_API_KEY topk-test-sandbox cargo test -p topk-cli --lib --no-fail-fast
 
 #
 
-test-runner:
+test-runner-builder:
     FROM rust:slim
 
-    # install dependencies
     RUN apt-get update && apt-get install -y protobuf-compiler
     RUN cargo install cargo-nextest --locked
 
+    WORKDIR /workspace
     DO rust+INIT --keep_fingerprints=true
-    WORKDIR /sdk
-
-    COPY --keep-ts . .
-
-    WORKDIR /sdk/topk-rs
+    COPY --keep-ts --dir . .
 
     ENV RUSTFLAGS="-C target-cpu=generic"
     ENV FORCE_COLOR=1
     DO rust+CARGO --args="nextest archive --release --archive-file test-runner.tar.zst"
 
-    ENTRYPOINT ["cargo", "nextest", "run", "--archive-file", "test-runner.tar.zst", "--no-fail-fast", "-j", "16"]
+    SAVE ARTIFACT test-runner.tar.zst
+    SAVE ARTIFACT /usr/local/cargo/bin/cargo-nextest
 
-    ARG registry
-    ARG tag=latest
-    SAVE IMAGE --push $registry/topk-test-runner:$tag
+test-runner:
+    FROM ghcr.io/topk-io/rust-release:latest
+
+    COPY +test-runner-builder/cargo-nextest /usr/local/bin/cargo-nextest
+    COPY +test-sandbox/topk-test-sandbox /usr/local/bin/topk-test-sandbox
+    COPY +test-runner-builder/test-runner.tar.zst /workspace/test-runner.tar.zst
+
+    WORKDIR /workspace
+    ENTRYPOINT ["topk-test-sandbox", "cargo-nextest", "nextest", "run", "--archive-file", "test-runner.tar.zst", "--no-fail-fast", "-j", "16"]
+
+    ARG --required registry
+    ARG --required tag
+    SAVE IMAGE --push $registry:$tag
+
+test-sandbox:
+    FROM oven/bun:latest
+
+    COPY --dir utils/ /workspace
+
+    WORKDIR /workspace
+    RUN bun install --frozen-lockfile
+    RUN bun build --compile --outfile topk-test-sandbox test-sandbox.ts
+    SAVE ARTIFACT topk-test-sandbox
 
 #
 

--- a/topk-js/tests/setup.ts
+++ b/topk-js/tests/setup.ts
@@ -55,8 +55,7 @@ export class ProjectContext {
   }
 
   async cleanup() {
-    await this.deleteDatasets();
-    await this.deleteCollections();
+    await Promise.all([this.deleteDatasets(), this.deleteCollections()]);
   }
 }
 

--- a/topk-py/tests/__init__.py
+++ b/topk-py/tests/__init__.py
@@ -1,42 +1,82 @@
+import asyncio
 import os
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import Any, Coroutine
 from uuid import uuid4
 
 from topk_sdk import AsyncClient, Client
+from topk_sdk.error import CollectionNotFoundError, DatasetNotFoundError
 
 
 @dataclass
 class ProjectContext:
     client: Client
     scope_prefix: str
+    used: set[str]
 
     def scope(self, name: str):
-        return f"{self.scope_prefix}-{name}"
+        wrapped = f"{self.scope_prefix}-{name}"
+        self.used.add(wrapped)
+        return wrapped
 
     def cleanup(self):
-        for d in self.client.datasets().list():
-            if d.name.startswith(self.scope_prefix):
-                self.client.datasets().delete(d.name)
-        for c in self.client.collections().list():
-            if c.name.startswith(self.scope_prefix):
-                self.client.collections().delete(c.name)
+        def delete_dataset(name: str):
+            try:
+                self.client.datasets().delete(name)
+            except DatasetNotFoundError:
+                pass
+            except Exception as e:
+                print(f"Teardown error deleting dataset {name}: {e}")
+
+        def delete_collection(name: str):
+            try:
+                self.client.collections().delete(name)
+            except CollectionNotFoundError:
+                pass
+            except Exception as e:
+                print(f"Teardown error deleting collection {name}: {e}")
+
+        with ThreadPoolExecutor() as executor:
+            executor.map(delete_dataset, self.used)
+            executor.map(delete_collection, self.used)
 
 
 @dataclass
 class AsyncProjectContext:
     client: AsyncClient
     scope_prefix: str
+    used: set[str]
 
     def scope(self, name: str):
-        return f"{self.scope_prefix}-{name}"
+        wrapped = f"{self.scope_prefix}-{name}"
+        self.used.add(wrapped)
+        return wrapped
 
     async def cleanup(self):
-        for d in await self.client.datasets().list():
-            if d.name.startswith(self.scope_prefix):
-                await self.client.datasets().delete(d.name)
-        for c in await self.client.collections().list():
-            if c.name.startswith(self.scope_prefix):
-                await self.client.collections().delete(c.name)
+        futs: list[Coroutine[Any, Any, None]] = []
+
+        async def delete_dataset(name: str):
+            try:
+                await self.client.datasets().delete(name)
+            except DatasetNotFoundError:
+                pass
+            except Exception as e:
+                print(f"Teardown error deleting dataset {name}: {e}")
+
+        async def delete_collection(name: str):
+            try:
+                await self.client.collections().delete(name)
+            except CollectionNotFoundError:
+                pass
+            except Exception as e:
+                print(f"Teardown error deleting collection {name}: {e}")
+
+        for name in self.used:
+            futs.append(delete_dataset(name))
+            futs.append(delete_collection(name))
+
+        await asyncio.gather(*futs)
 
 
 def new_project_context():
@@ -55,6 +95,7 @@ def new_project_context():
     return ProjectContext(
         scope_prefix=f"topk-py-{uuid4()}",
         client=client,
+        used=set(),
     )
 
 
@@ -74,4 +115,5 @@ def new_async_project_context():
     return AsyncProjectContext(
         scope_prefix=f"topk-py-{uuid4()}",
         client=client,
+        used=set(),
     )

--- a/topk-rs/tests/utils/test_context/project.rs
+++ b/topk-rs/tests/utils/test_context/project.rs
@@ -1,58 +1,30 @@
+use std::{cell::RefCell, collections::HashSet};
+
+use futures::future::FutureExt;
+use futures::stream::{FuturesUnordered, StreamExt};
 use test_context::AsyncTestContext;
-use topk_rs::{Client, ClientConfig, Error};
 use uuid::Uuid;
+
+use topk_rs::{Client, ClientConfig, Error};
 
 pub struct ProjectTestContext {
     pub client: Client,
     pub scope: String,
+    pub used: RefCell<HashSet<String>>,
 }
 
 impl ProjectTestContext {
     pub fn wrap(&self, name: &str) -> String {
-        format!("{}-{}", self.scope, name)
-    }
-
-    async fn cleanup_collections(&self) {
-        let client = self.client.collections();
-        let collections = client
-            .list()
-            .await
-            .expect("Failed to list collections on teardown");
-        for collection in collections {
-            if collection.name.starts_with(&self.scope) {
-                println!("Deleting collection: {}", collection.name);
-                let res = client.delete(&collection.name).await;
-
-                if let Err(e) = res {
-                    println!("Failed to delete collection {}: {}", collection.name, e);
-                }
-            }
-        }
-    }
-
-    async fn cleanup_datasets(&self) -> Result<(), Error> {
-        let client = self.client.datasets();
-        let datasets = client.list().await?;
-        for dataset in &datasets {
-            if dataset.name.starts_with(&self.scope) {
-                println!("Deleting dataset: {}", dataset.name);
-                let res = client.delete(&dataset.name).await;
-
-                if let Err(e) = res {
-                    println!("Failed to delete dataset {}: {}", dataset.name, e);
-                }
-            }
-        }
-        Ok(())
+        let wrapped = format!("{}-{}", self.scope, name);
+        self.used.borrow_mut().insert(wrapped.clone());
+        wrapped
     }
 }
 
 impl AsyncTestContext for ProjectTestContext {
     async fn setup() -> Self {
-        let scope = format!("topk-rs-{}", Uuid::new_v4());
-
-        let host = std::env::var("TOPK_HOST").unwrap_or("topk.io".to_string());
-        let region = std::env::var("TOPK_REGION").unwrap_or("elastica".to_string());
+        let host = std::env::var("TOPK_HOST").expect("TOPK_HOST not set");
+        let region = std::env::var("TOPK_REGION").expect("TOPK_REGION not set");
         let api_key = std::env::var("TOPK_API_KEY").expect("TOPK_API_KEY not set");
         let https = std::env::var("TOPK_HTTPS").unwrap_or("true".to_string()) == "true";
 
@@ -62,13 +34,30 @@ impl AsyncTestContext for ProjectTestContext {
                 .with_https(https),
         );
 
-        Self { client, scope }
+        Self {
+            client,
+            scope: format!("topk-rs-{}", Uuid::new_v4()),
+            used: RefCell::new(HashSet::new()),
+        }
     }
 
     async fn teardown(self) {
-        if let Err(e) = self.cleanup_datasets().await {
-            println!("Failed to cleanup datasets: {}", e);
+        let datasets = self.client.datasets();
+        let collections = self.client.collections();
+        let names = self.used.borrow().clone();
+
+        let mut futs = FuturesUnordered::new();
+        for name in names {
+            futs.push(datasets.delete(name.clone()).boxed());
+            futs.push(collections.delete(name).boxed());
         }
-        self.cleanup_collections().await;
+
+        while let Some(result) = futs.next().await {
+            match result {
+                Ok(_) => {}
+                Err(Error::DatasetNotFound) | Err(Error::CollectionNotFound) => {}
+                Err(e) => println!("Teardown error: {e:?}"),
+            }
+        }
     }
 }

--- a/utils/bun.lock
+++ b/utils/bun.lock
@@ -1,13 +1,133 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "dependencies": {
+        "@types/bun": "^1.3.13",
+        "@types/ms": "^2.1.0",
         "commander": "^14.0.2",
+        "ms": "^2.1.3",
+        "p-limit": "^7.3.0",
+        "p-retry": "^8.0.0",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
+        "topk-js": "^0.9.3",
+        "zod": "^4.4.3",
       },
     },
   },
   "packages": {
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "fast-copy": ["fast-copy@4.0.3", "", {}, "sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw=="],
+
+    "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "is-network-error": ["is-network-error@1.3.2", "", {}, "sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
+
+    "p-retry": ["p-retry@8.0.0", "", { "dependencies": { "is-network-error": "^1.3.0" } }, "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A=="],
+
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "thread-stream": ["thread-stream@4.1.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-Bw6h2iBDt16v6iHLChBIoVYU8CBo9GPsW8TG7h1hRVhqKhIkH6N8qkxNSmiOZTKsCLPbtWG4ViWLkU6KeKXpig=="],
+
+    "topk-js": ["topk-js@0.9.3", "", { "optionalDependencies": { "topk-js-android-arm-eabi": "0.9.3", "topk-js-android-arm64": "0.9.3", "topk-js-darwin-arm64": "0.9.3", "topk-js-darwin-universal": "0.9.3", "topk-js-darwin-x64": "0.9.3", "topk-js-linux-arm-gnueabihf": "0.9.3", "topk-js-linux-arm-musleabihf": "0.9.3", "topk-js-linux-arm64-gnu": "0.9.3", "topk-js-linux-arm64-musl": "0.9.3", "topk-js-linux-riscv64-gnu": "0.9.3", "topk-js-linux-x64-gnu": "0.9.3", "topk-js-linux-x64-musl": "0.9.3", "topk-js-win32-arm64-msvc": "0.9.3", "topk-js-win32-ia32-msvc": "0.9.3", "topk-js-win32-x64-msvc": "0.9.3" } }, "sha512-fUZbdKj1uNQ4QUYfLramAvOmZ8+U+B/wxNbBUMhhhN0B6yku8PnaLfl0kSLxRn0Y8K9rkuuprB8durwPYNsB1g=="],
+
+    "topk-js-android-arm-eabi": ["topk-js-android-arm-eabi@0.9.3", "", { "os": "android", "cpu": "arm" }, "sha512-iNggmWFZVVzNVp/yrh9QAjDfMT1gLx1Wh5zjTGNv1u0PKW0Ha6/iuwVc6x+nxAVQggYZ3mncRfhHCk1Ff/aV2w=="],
+
+    "topk-js-android-arm64": ["topk-js-android-arm64@0.9.3", "", { "os": "android", "cpu": "arm64" }, "sha512-pa/vVGnsDr2zylARHcvPoiOlnGDJn0vy8JfKd9tUytEZgg6jHTB+83kVcReKlau3QVh56e3esXZlYg1MNJAlHg=="],
+
+    "topk-js-darwin-arm64": ["topk-js-darwin-arm64@0.9.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+J6/tMIi8z6+fY6WgM96LsAVuNMpUWJUej2+mgC2oybB7sA4SeLwCXWYV4DSzl8b31ppqXMZqXyY8ehSRF3XhQ=="],
+
+    "topk-js-darwin-universal": ["topk-js-darwin-universal@0.9.3", "", { "os": "darwin" }, "sha512-UbbgDzpNuVl7YLj4UQNLSu3xX28tohU4PPJDysIdxCojzj1l8deZp/w5Zd9UrafQ+YGVFno4V3u19JYxoz1/qA=="],
+
+    "topk-js-darwin-x64": ["topk-js-darwin-x64@0.9.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fJsFmoc9OJFjNjhrlvft69XRXNfsD5xVI7eCbwRuMZn39lht823x1N6ZsJxqUGpQb3zDDfMYaYLpOedryExZKQ=="],
+
+    "topk-js-linux-arm-gnueabihf": ["topk-js-linux-arm-gnueabihf@0.9.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Z2SFNIFVxhUX52PkcJrlyuFPYHCCvFuGO024y9Jth2RpiBF5W7otOs0CexxaCtRA+ODQjcpR45Lk4zXMtlmIEA=="],
+
+    "topk-js-linux-arm-musleabihf": ["topk-js-linux-arm-musleabihf@0.9.3", "", { "os": "linux", "cpu": "arm" }, "sha512-SzmkHGsaCD8Y4a9zRbdCZKlyOESz3N27K4DWTUbqSCCmWfdKmWNh1fSvWDoHvJqSAGozkUL/e+4FS0pGvc28JA=="],
+
+    "topk-js-linux-arm64-gnu": ["topk-js-linux-arm64-gnu@0.9.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-+gqjIkPowgvhPjvANFlhWUCp4iMkyc3BVZ/TI0w12Rp74K0Rf6gWpnucCn19Xv7fdOGADtNu4M8HxAvfPlUgcw=="],
+
+    "topk-js-linux-arm64-musl": ["topk-js-linux-arm64-musl@0.9.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Kn4Y3n7BG7EuDtK85MD3vQ+vM07+/yo5eFW9sXkuvmYiMLkil+bAX8wqmZGSNsKHre9KagmZCKQqc/wqwoqKg=="],
+
+    "topk-js-linux-riscv64-gnu": ["topk-js-linux-riscv64-gnu@0.9.3", "", { "os": "linux", "cpu": "none" }, "sha512-pWVkW7qu6aHeH1L29HDfAKshSqPKM/tXT5boqmiAKJZTopR1P5SAnuB4HWqERc94aEaYSS8YvO8udK+09DZNjw=="],
+
+    "topk-js-linux-x64-gnu": ["topk-js-linux-x64-gnu@0.9.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Z/vGbvdMov6XuWFMdMJlYB03ElrLov2nPA5pCDchtXW/EFVKOg9zDMQzVK67XcC94VcV5jcJpWKXuEo8JVySXg=="],
+
+    "topk-js-linux-x64-musl": ["topk-js-linux-x64-musl@0.9.3", "", { "os": "linux", "cpu": "x64" }, "sha512-NdGJvyxWzLMSrtpwWvbaFbpYGXEUNIYhr2RYr5VOgO1+YjHuSyxfgxnU2J3iFk98KVVXefhIwu1alAAr8OjNMQ=="],
+
+    "topk-js-win32-arm64-msvc": ["topk-js-win32-arm64-msvc@0.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-n2R2aUrxwQ/9k3kJ5kXsM6kWv/0rdir+cQ514txZnrp1LgXHMzu0WhbXO7d36Jj2iBEhH6e//iX52iYoeRoUGA=="],
+
+    "topk-js-win32-ia32-msvc": ["topk-js-win32-ia32-msvc@0.9.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-eMF8C038ZDld9v+umtyrumuxUeRURYtuYhGqq4dqxnmMsyHry4fD0DvTfMHqwiKnwA6KP6X264yW2KquwGQu+w=="],
+
+    "topk-js-win32-x64-msvc": ["topk-js-win32-x64-msvc@0.9.3", "", { "os": "win32", "cpu": "x64" }, "sha512-ZmKjVAM0K6mqatLnDsahEvCQu+qr5QgSfQOo5lv1oePdQ32IDldrQXyCw8SRranj3zhKA/aNQaiZtvqmCFjLxg=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
   }
 }

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
-    "commander": "^14.0.2"
+    "@types/bun": "^1.3.13",
+    "@types/ms": "^2.1.0",
+    "commander": "^14.0.2",
+    "ms": "^2.1.3",
+    "p-limit": "^7.3.0",
+    "p-retry": "^8.0.0",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
+    "topk-js": "^0.9.3",
+    "zod": "^4.4.3"
   }
 }

--- a/utils/test-sandbox.ts
+++ b/utils/test-sandbox.ts
@@ -1,0 +1,249 @@
+import { Command } from "commander";
+import { Client, Collection, Dataset } from "topk-js";
+import Bun from "bun";
+import { z } from "zod";
+import pino from "pino";
+import pretty from "pino-pretty";
+import pLimit, { LimitFunction } from "p-limit";
+import pRetry, { Options as RetryOptions } from "p-retry";
+import ms, { StringValue } from "ms";
+
+type Env = ReturnType<typeof loadEnv>;
+type State = { datasets: Dataset[]; collections: Collection[] };
+type Opts = {
+  concurrency: number;
+  prefix?: string;
+  age?: number;
+  dryRun: boolean;
+};
+
+const log = pino({ level: process.env.LOG_LEVEL ?? "info" }, pretty());
+const program = new Command();
+
+program
+  .name("test-sandbox")
+  .description("Run a command with sandbox discovery before and after")
+  .argument("[cmd...]", "command to run")
+  .option(
+    "--concurrency <n>",
+    "number of concurrent operations",
+    (value) => Number.parseInt(value),
+    16
+  )
+  .option(
+    "--prefix <s>",
+    "filters to datasets/collections whose name starts with this prefix"
+  )
+  .option(
+    "--age <duration>",
+    "minimum age of datasets/collections to remove (e.g. 2d, 30m. default: 24h)",
+    parseAge,
+    24 * 60 * 60 * 1000 // 24 hours
+  )
+  .option("--dry-run", "do not perform the reset operation", false)
+  .passThroughOptions()
+  .allowUnknownOption()
+  .action(async (cmd: string[], opts: Opts) => {
+    if (cmd.length === 0) {
+      program.help();
+    }
+
+    const env = loadEnv();
+    const limit = pLimit(opts.concurrency);
+
+    const client = createClient(env);
+
+    // "Before" hook
+    const beforeState = await discoverState(client, opts);
+    if (!opts.dryRun) {
+      await resetState(client, beforeState, limit);
+    } else {
+      log.warn(`Skipping reset.`);
+    }
+
+    // Run the command
+    const exitCode = await exec(cmd, opts.dryRun);
+
+    // "After" hook
+    const afterState = await discoverState(client, opts);
+    if (!opts.dryRun) {
+      await resetState(client, afterState, limit);
+    } else {
+      log.warn(`Skipping reset.`);
+    }
+
+    process.exit(exitCode);
+  })
+  .parseAsync();
+
+async function discoverState(client: Client, opts: Opts): Promise<State> {
+  log.info(`Discovering state for ${JSON.stringify(opts)}`);
+
+  const [allDatasets, allCollections] = await Promise.all([
+    withRetry(() => client.datasets().list()),
+    withRetry(() => client.collections().list()),
+  ]);
+  log.info(
+    `Found ${allDatasets.length} datasets and ${allCollections.length} collections`
+  );
+
+  const datasets = allDatasets.filter((d) => {
+    if (opts.prefix && !d.name.startsWith(opts.prefix)) return false;
+    if (opts.age && !olderThan(d.createdAt, opts.age)) return false;
+    return true;
+  });
+  const collections = allCollections.filter((c) => {
+    if (opts.prefix && !c.name.startsWith(opts.prefix)) return false;
+    if (opts.age && !olderThan(c.createdAt, opts.age)) return false;
+    return true;
+  });
+  log.info(
+    `Filtered to ${datasets.length} datasets, ${collections.length} collections`
+  );
+
+  return { datasets, collections };
+}
+
+async function resetState(client: Client, state: State, limit: LimitFunction) {
+  const futs: Promise<void>[] = [];
+
+  for (const dataset of state.datasets) {
+    futs.push(
+      limit(async () => {
+        try {
+          await client.datasets().delete(dataset.name);
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("dataset not found")
+          ) {
+            return;
+          }
+
+          log.error(`Error deleting dataset ${dataset.name}:`, error);
+        }
+      })
+    );
+  }
+
+  for (const collection of state.collections) {
+    futs.push(
+      limit(async () => {
+        try {
+          await client.collections().delete(collection.name);
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            error.message.includes("collection not found")
+          ) {
+            return;
+          }
+
+          log.error(`Error deleting collection ${collection.name}:`, error);
+        }
+      })
+    );
+  }
+
+  await Promise.all(futs);
+}
+
+// Client
+
+function createClient(env: Env) {
+  log.info(
+    `Initializing client TOPK_REGION=${env.TOPK_REGION} TOPK_HOST=${env.TOPK_HOST} TOPK_HTTPS=${env.TOPK_HTTPS} TOPK_API_KEY=***`
+  );
+  return new Client({
+    apiKey: env.TOPK_API_KEY,
+    region: env.TOPK_REGION,
+    host: env.TOPK_HOST,
+    https: env.TOPK_HTTPS,
+  });
+}
+
+function loadEnv() {
+  const schema = z.object({
+    TOPK_API_KEY: z.string(),
+    TOPK_REGION: z.string(),
+    TOPK_HOST: z.string(),
+    TOPK_HTTPS: z.stringbool().default(true),
+  });
+
+  const result = schema.safeParse(process.env);
+  if (!result.success) {
+    log.error(`Invalid environment:\n${z.prettifyError(result.error)}`);
+    process.exit(1);
+  }
+  return result.data;
+}
+
+// Command
+
+async function exec(cmd: string[], dryRun: boolean): Promise<number> {
+  if (dryRun) {
+    log.info(`Dry run: ${cmd.join(" ")}`);
+    return 0;
+  }
+
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    // @ts-ignore
+    proc = Bun.spawn({
+      cmd,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+  } catch (error) {
+    log.error(error instanceof Error ? error.message : String(error));
+    return 127;
+  }
+
+  const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"];
+  const forward = (sig: NodeJS.Signals) => () => {
+    try {
+      proc.kill(sig);
+    } catch {}
+  };
+  const handlers = signals.map((sig) => {
+    const h = forward(sig);
+    process.on(sig, h);
+    return [sig, h] as const;
+  });
+
+  try {
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      log.error(`Command "${cmd.join(" ")}" exited with code ${exitCode}`);
+    }
+    return exitCode;
+  } finally {
+    for (const [sig, h] of handlers) process.off(sig, h);
+  }
+}
+
+// Utils
+
+function withRetry<T>(fn: () => Promise<T>, opts?: RetryOptions): Promise<T> {
+  return pRetry(fn, {
+    retries: 5,
+    minTimeout: 200,
+    factor: 2,
+    ...opts,
+  });
+}
+
+function parseAge(value: string): number {
+  const result = ms(value as StringValue);
+  if (typeof result !== "number" || Number.isNaN(result)) {
+    log.error(`Invalid --age value: ${value} (expected e.g. 2d, 30m, 1h)`);
+    process.exit(1);
+  }
+  return result;
+}
+
+function olderThan(ts: string, age: number): boolean {
+  const createdMs = Date.parse(ts);
+  return Date.now() - createdMs >= age;
+}


### PR DESCRIPTION
Adding new `topk-test-sandbox` binary that can wrap any test command (invoked like `topk-test-sandbox cargo nextest run ...`) and manage state (collections & datasets) before/after a test command runs.

This allows use to remove `client.collection()/dataset().list()` call after every test. We simply attempt to delete the resource, yielding back to `topk-test-sandbox` for further cleanup. 

Note: since `ctx.wrap()` is used in tests without knowing if its a dataset/collection, we attempt to delete both. This is safe since all resource names have uuid in them.

---

Example:


```
              +test-js | [20:11:31.059] INFO (14): Discovering state for {"concurrency":16,"age":86400000,"dryRun":false}
              +test-js | [20:11:31.160] INFO (14): Found 8 datasets and 5 collections
              +test-js | [20:11:31.160] INFO (14): Filtered to 0 datasets, 0 collections
```