### PR TITLE
[topk-py] fix GIL error in delete by filter expr

### DIFF
--- a/topk-py/src/client/sync/collection.rs
+++ b/topk-py/src/client/sync/collection.rs
@@ -82,12 +82,15 @@ impl CollectionClient {
         lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
     ) -> PyResult<Vec<Document>> {
+        // Convert query to proto while GIL is held
+        let query: topk_rs::proto::v1::data::Query = query.into();
+
         let docs = self
             .runtime
             .block_on(
                 py,
                 self.client.collection(&self.collection).query(
-                    query.into(),
+                    query,
                     lsn,
                     consistency.map(|c| c.into()),
                 ),

--- a/topk-py/src/client/sync/collection.rs
+++ b/topk-py/src/client/sync/collection.rs
@@ -145,6 +145,9 @@ impl CollectionClient {
     }
 
     pub fn delete(&self, py: Python<'_>, spec: DeleteExprUnion) -> PyResult<String> {
+        // Convert spec to proto while GIL is held
+        let spec: topk_rs::proto::v1::data::DeleteDocumentsRequest = spec.into();
+
         Ok(self
             .runtime
             .block_on(py, self.client.collection(&self.collection).delete(spec))

--- a/topk-py/tests/test_collection_delete.py
+++ b/topk-py/tests/test_collection_delete.py
@@ -60,6 +60,33 @@ def test_delete_with_filter(ctx: ProjectContext):
     assert doc_ids(docs) == {"two"}
 
 
+def test_delete_with_compound_filter(ctx: ProjectContext):
+    collection = ctx.client.collections().create(ctx.scope("test"), schema={})
+
+    lsn = ctx.client.collection(collection.name).upsert(
+        [
+            {"_id": "one", "rank": 1, "tag": "a"},
+            {"_id": "two", "rank": 2, "tag": "b"},
+            {"_id": "three", "rank": 3, "tag": "a"},
+        ]
+    )
+    assert lsn == "1"
+
+    # wait for write to be flushed
+    ctx.client.collection(collection.name).count()
+
+    lsn = ctx.client.collection(collection.name).delete(
+        (field("rank") != 2) & (field("tag") == "a")
+    )
+    assert lsn == "2"
+
+    docs = ctx.client.collection(collection.name).query(
+        select("rank").topk(field("rank"), 100, True), lsn=lsn
+    )
+
+    assert doc_ids(docs) == {"two"}
+
+
 def test_delete_non_existent_document(ctx: ProjectContext):
     collection = ctx.client.collections().create(ctx.scope("test"), schema={})
 


### PR DESCRIPTION
Fixes
```pyo3_runtime.PanicException: Cannot clone pointer into Python heap without the thread being attached.```

Mirrors Async Client [`delete()`](https://github.com/topk-io/topk/blob/main/topk-py/src/client/async/collection.rs#L162-L163)