### PR TITLE
[ci] fix nextest src path

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -188,10 +188,12 @@ test-runner:
 
     COPY +test-runner-builder/cargo-nextest /usr/local/bin/cargo-nextest
     COPY +test-sandbox/topk-test-sandbox /usr/local/bin/topk-test-sandbox
-    COPY +test-runner-builder/test-runner.tar.zst /workspace/test-runner.tar.zst
+    COPY +test-runner-builder/test-runner.tar.zst /test-runner.tar.zst
 
-    WORKDIR /workspace
-    ENTRYPOINT ["topk-test-sandbox", "cargo-nextest", "nextest", "run", "--archive-file", "test-runner.tar.zst", "--no-fail-fast", "-j", "16"]
+    COPY --dir . /sdk
+
+    WORKDIR /sdk/topk-rs
+    ENTRYPOINT ["topk-test-sandbox", "cargo-nextest", "nextest", "run", "--archive-file", "/test-runner.tar.zst", "--no-fail-fast", "-j", "16"]
 
     ARG --required registry
     ARG --required tag


### PR DESCRIPTION
The source must be copied over for nextest archive to work properly:

```
│ e2e-29646425-r67pl   Extracting 34 binaries, 1 build script output directory, and 1 linked path to /tmp/nextest-archive-kvz3JL                                                                                     │
│ e2e-29646425-r67pl    Extracted 72 files to /tmp/nextest-archive-kvz3JL in 1.10s                                                                                                                                   │
│ e2e-29646425-r67pl error: workspace root manifest at /sdk/topk-rs/Cargo.toml does not exist                                                                                                                        │
│ e2e-29646425-r67pl (hint: ensure that project source is available for reused build, using --workspace-remap if necessary)                                                                                          │
```