### PR TITLE
[rs] add `Struct` value

### DIFF
--- a/protos/topk/control/v1/schema.proto
+++ b/protos/topk/control/v1/schema.proto
@@ -38,7 +38,7 @@ message FieldType {
     FieldTypeI8SparseVector i8_sparse_vector = 16;
     FieldTypeF8SparseVector f8_sparse_vector = 17;
     FieldTypeF16SparseVector f16_sparse_vector = 18;
-
+    FieldTypeStruct struct = 19;
   }
 }
 
@@ -101,6 +101,10 @@ message FieldTypeList {
     LIST_VALUE_TYPE_STRING = 3;
   }
   ListValueType value_type = 1;
+}
+
+message FieldTypeStruct {
+  map<string, FieldSpec> fields = 1;
 }
 
 // Keyword index specification

--- a/topk-rs/build.rs
+++ b/topk-rs/build.rs
@@ -92,6 +92,7 @@ fn build_topk_v1_protos() {
         "topk.control.v1.FieldTypeText",
         "topk.control.v1.FieldTypeBytes",
         "topk.control.v1.FieldTypeList",
+        "topk.control.v1.FieldTypeStruct",
         // indexes
         "topk.control.v1.FieldIndex",
         "topk.control.v1.FieldIndex.index",
@@ -121,6 +122,15 @@ fn build_topk_v1_protos() {
         "topk.control.v1.MultiVectorIndex.skip_smve",
         "#[serde(default)]",
     );
+
+    for ty in [
+        "topk.control.v1.FieldTypeStruct",
+        "topk.control.v1.FieldType",
+        "topk.control.v1.FieldType.data_type",
+        "topk.control.v1.FieldSpec",
+    ] {
+        builder = builder.type_attribute(ty, "#[derive(Eq)]");
+    }
 
     builder
         .codec_path("crate::proto::codec::ProstCodec")

--- a/topk-rs/src/error.rs
+++ b/topk-rs/src/error.rs
@@ -228,6 +228,12 @@ pub enum SchemaValidationError {
 
     #[error("Invalid semantic index for field `{field}. Error: {error}`")]
     InvalidSemanticIndex { field: String, error: String },
+
+    #[error("field `{field}` contains '.' which is reserved as a struct path separator")]
+    FieldNameContainsDot { field: String },
+
+    #[error("struct field `{field}` exceeds maximum nesting depth of {max_depth}")]
+    StructTooDeep { field: String, max_depth: usize },
 }
 
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, Clone)]
@@ -347,6 +353,15 @@ impl<T: Serialize + DeserializeOwned + Clone> ValidationErrorBag<T> {
 
     pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.0.iter()
+    }
+}
+
+impl<T: Serialize + DeserializeOwned + Clone> IntoIterator for ValidationErrorBag<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/topk-rs/src/proto/control/v1/data_type_ext.rs
+++ b/topk-rs/src/proto/control/v1/data_type_ext.rs
@@ -73,4 +73,10 @@ impl field_type::DataType {
     pub fn bytes() -> Self {
         field_type::DataType::Bytes(FieldTypeBytes {})
     }
+
+    pub fn r#struct(fields: impl IntoIterator<Item = (impl Into<String>, FieldSpec)>) -> Self {
+        field_type::DataType::Struct(FieldTypeStruct {
+            fields: fields.into_iter().map(|(k, v)| (k.into(), v)).collect(),
+        })
+    }
 }

--- a/topk-rs/src/proto/control/v1/field_spec_ext.rs
+++ b/topk-rs/src/proto/control/v1/field_spec_ext.rs
@@ -205,4 +205,17 @@ impl FieldSpec {
             index: None,
         }
     }
+
+    pub fn r#struct(
+        required: bool,
+        fields: impl IntoIterator<Item = (impl Into<String>, FieldSpec)>,
+    ) -> FieldSpec {
+        FieldSpec {
+            data_type: Some(FieldType {
+                data_type: Some(field_type::DataType::r#struct(fields)),
+            }),
+            required,
+            index: None,
+        }
+    }
 }

--- a/topk-rs/src/proto/control/v1/mod.rs
+++ b/topk-rs/src/proto/control/v1/mod.rs
@@ -42,6 +42,8 @@ impl field_type::DataType {
                 field_type_matrix::MatrixValueType::I8 => "matrix<i8>".to_string(),
                 field_type_matrix::MatrixValueType::Unspecified => "matrix<_>".to_string(),
             },
+            // Struct
+            field_type::DataType::Struct(..) => "struct".to_string(),
         }
     }
 }

--- a/topk-rs/tests/test_collection_struct.rs
+++ b/topk-rs/tests/test_collection_struct.rs
@@ -1,0 +1,272 @@
+use std::collections::HashMap;
+use test_context::test_context;
+use topk_rs::doc;
+use topk_rs::proto::v1::control::FieldSpec;
+use topk_rs::proto::v1::data::Value;
+use topk_rs::query::{field, fns, select};
+
+mod utils;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_round_trip(ctx: &mut ProjectTestContext) {
+    // 2-level nested struct: outer.inner.{leaf, sibling}
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "outer".to_string(),
+                FieldSpec::r#struct(
+                    false,
+                    [(
+                        "inner",
+                        FieldSpec::r#struct(
+                            false,
+                            [
+                                ("leaf", FieldSpec::text(false, None)),
+                                ("sibling", FieldSpec::text(false, None)),
+                            ],
+                        ),
+                    )],
+                ),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "outer" => Value::r#struct([(
+                "inner",
+                Value::r#struct([("leaf", "v".into()), ("sibling", "s".into())]),
+            )]),
+        )])
+        .await
+        .expect("could not upsert");
+
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(["one"], None, Some(lsn), None)
+        .await
+        .expect("could not get document");
+
+    let one = docs.get("one").expect("missing doc");
+    let inner = one
+        .get("outer")
+        .and_then(|v| v.as_struct())
+        .and_then(|s| s.get("inner"))
+        .and_then(|v| v.as_struct())
+        .expect("inner should be nested struct");
+    assert_eq!(inner.get("leaf").and_then(|v| v.as_string()), Some("v"));
+    assert_eq!(inner.get("sibling").and_then(|v| v.as_string()), Some("s"));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_query(ctx: &mut ProjectTestContext) {
+    // select(dotted) + filter(dotted) + fetch(dotted) in one query.
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(
+                    false,
+                    [
+                        ("author", FieldSpec::text(false, None)),
+                        ("year", FieldSpec::integer(false)),
+                        ("tag", FieldSpec::text(false, None)),
+                    ],
+                ),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    ctx.client
+        .collection(&collection.name)
+        .upsert(vec![
+            doc!(
+                "_id" => "old",
+                "meta" => Value::r#struct([
+                    ("author", "alice".into()),
+                    ("year", 1999i64.into()),
+                    ("tag", "classic".into()),
+                ]),
+            ),
+            doc!(
+                "_id" => "new",
+                "meta" => Value::r#struct([
+                    ("author", "bob".into()),
+                    ("year", 2024i64.into()),
+                    ("tag", "fresh".into()),
+                ]),
+            ),
+        ])
+        .await
+        .expect("could not upsert");
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            select([("meta.author", field("meta.author"))])
+                .filter(field("meta.year").gt(2020i64))
+                .topk(field("meta.year"), 10, true)
+                .fetch(["meta.tag"]),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id().unwrap(), "new");
+    let meta = results[0]
+        .fields
+        .get("meta")
+        .and_then(|v| v.as_struct())
+        .expect("meta should re-nest as struct");
+    assert_eq!(meta.get("author").and_then(|v| v.as_string()), Some("bob"));
+    assert_eq!(meta.get("tag").and_then(|v| v.as_string()), Some("fresh"));
+    // We did not request `meta.year`; it should not be returned.
+    assert!(
+        meta.get("year").is_none(),
+        "fetch should not over-return: {meta:?}"
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_semantic_index_on_sub_field(ctx: &mut ProjectTestContext) {
+    // Semantic index declared on a struct sub-field; query via dotted path.
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(false, [("description", FieldSpec::semantic(false))]),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![
+            doc!(
+                "_id" => "rust",
+                "meta" => Value::r#struct([("description", "a systems programming language".into())]),
+            ),
+            doc!(
+                "_id" => "python",
+                "meta" => Value::r#struct([("description", "a snake".into())]),
+            ),
+        ])
+        .await
+        .expect("could not upsert");
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            select([(
+                "sim",
+                fns::semantic_similarity("meta.description", "programming"),
+            )])
+            .topk(field("sim"), 2, true),
+            Some(lsn),
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(results.len(), 2);
+    for doc in &results {
+        assert!(
+            doc.fields.get("sim").is_some(),
+            "missing sim score: {doc:?}"
+        );
+    }
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_update(ctx: &mut ProjectTestContext) {
+    // Partial sub-field update must preserve siblings (deep merge).
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(
+                    false,
+                    [
+                        ("author", FieldSpec::text(false, None)),
+                        ("title", FieldSpec::text(false, None)),
+                    ],
+                ),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    ctx.client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta" => Value::r#struct([("author", "alice".into()), ("title", "v1".into())]),
+        )])
+        .await
+        .expect("could not upsert");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .update(
+            vec![doc!(
+                "_id" => "one",
+                "meta" => Value::r#struct([("title", "v2".into())]),
+            )],
+            true,
+        )
+        .await
+        .expect("could not update");
+
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(["one"], None, Some(lsn), None)
+        .await
+        .expect("could not get document");
+
+    let meta = docs
+        .get("one")
+        .and_then(|d| d.get("meta"))
+        .and_then(|v| v.as_struct())
+        .expect("expected nested struct");
+    assert_eq!(meta.get("title").and_then(|v| v.as_string()), Some("v2"));
+    // Sibling sub-field set at upsert and not mentioned in update — must survive.
+    assert_eq!(
+        meta.get("author").and_then(|v| v.as_string()),
+        Some("alice")
+    );
+}


### PR DESCRIPTION
Adding support for _structs_. Now possible to express `{ _id: "...", meta: { name: "Jergus" } }`, `select("meta.name")`/`fetch("meta.name")`/`filter(field("meta.name").eq(...))` works naturally. It's _not_ possible to select an entire struct (eg. `select("meta.*")` - can be added in the future).