### PR TITLE
[rs] structs test coverage

### DIFF
--- a/topk-rs/src/proto/data/v1/data_ext/value.rs
+++ b/topk-rs/src/proto/data/v1/data_ext/value.rs
@@ -587,6 +587,12 @@ impl From<HashMap<String, Value>> for Value {
     }
 }
 
+impl<const N: usize, K: Into<String>, V: Into<Value>> From<[(K, V); N]> for Value {
+    fn from(arr: [(K, V); N]) -> Self {
+        Value::r#struct(arr.into_iter().map(|(k, v)| (k.into(), v.into())))
+    }
+}
+
 impl<T: Into<Value>> From<Option<T>> for Value {
     fn from(value: Option<T>) -> Self {
         match value {

--- a/topk-rs/tests/test_collection_struct.rs
+++ b/topk-rs/tests/test_collection_struct.rs
@@ -515,3 +515,67 @@ async fn test_struct_get_returns_flat_leaf(ctx: &mut ProjectTestContext) {
     assert!(one.get("meta").is_none());
     assert!(one.get("meta.year").is_none());
 }
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_underscore_sub_field(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(false, [("_bar", FieldSpec::text(false, None))]),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    // Upsert document
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta" => Value::r#struct([("_bar", "v".into())]),
+        )])
+        .await
+        .expect("could not upsert");
+
+    // Request the whole struct
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(
+            ["one"],
+            Some(vec!["meta".to_string()]),
+            Some(lsn.clone()),
+            None,
+        )
+        .await
+        .expect("could not get document");
+    let meta = docs
+        .get("one")
+        .and_then(|d| d.get("meta"))
+        .and_then(|v| v.as_struct())
+        .expect("missing meta struct");
+    assert_eq!(meta.get("_bar").and_then(|v| v.as_string()), Some("v"));
+
+    // Request the dotted leaf
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(
+            ["one"],
+            Some(vec!["meta._bar".to_string()]),
+            Some(lsn),
+            None,
+        )
+        .await
+        .expect("could not get document");
+    let one = docs.get("one").expect("missing doc");
+    assert_eq!(one.get("meta._bar").and_then(|v| v.as_string()), Some("v"));
+    assert!(one.get("meta").is_none());
+}

--- a/topk-rs/tests/test_collection_struct.rs
+++ b/topk-rs/tests/test_collection_struct.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
 use test_context::test_context;
 use topk_rs::doc;
+use topk_rs::error::{DocumentValidationError, ValidationErrorBag};
 use topk_rs::proto::v1::control::FieldSpec;
 use topk_rs::proto::v1::data::Value;
 use topk_rs::query::{field, fns, select};
+use topk_rs::Error;
 
 mod utils;
 use utils::ProjectTestContext;
@@ -133,24 +135,22 @@ async fn test_struct_query(ctx: &mut ProjectTestContext) {
 
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id().unwrap(), "new");
-    let meta = results[0]
-        .fields
-        .get("meta")
-        .and_then(|v| v.as_struct())
-        .expect("meta should re-nest as struct");
-    assert_eq!(meta.get("author").and_then(|v| v.as_string()), Some("bob"));
-    assert_eq!(meta.get("tag").and_then(|v| v.as_string()), Some("fresh"));
-    // We did not request `meta.year`; it should not be returned.
-    assert!(
-        meta.get("year").is_none(),
-        "fetch should not over-return: {meta:?}"
+    let fields = &results[0].fields;
+    assert_eq!(
+        fields.get("meta.author").and_then(|v| v.as_string()),
+        Some("bob"),
     );
+    assert_eq!(
+        fields.get("meta.tag").and_then(|v| v.as_string()),
+        Some("fresh"),
+    );
+    assert!(fields.get("meta.year").is_none());
+    assert!(fields.get("meta").is_none());
 }
 
 #[test_context(ProjectTestContext)]
 #[tokio::test]
 async fn test_struct_semantic_index_on_sub_field(ctx: &mut ProjectTestContext) {
-    // Semantic index declared on a struct sub-field; query via dotted path.
     let collection = ctx
         .client
         .collections()
@@ -269,4 +269,249 @@ async fn test_struct_update(ctx: &mut ProjectTestContext) {
         meta.get("author").and_then(|v| v.as_string()),
         Some("alice")
     );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_literal_dotted_field_roundtrip(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default(), None)
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta.foo" => 3i64,
+        )])
+        .await
+        .expect("could not upsert");
+
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(["one"], None, Some(lsn.clone()), None)
+        .await
+        .expect("could not get document");
+    let one = docs.get("one").expect("missing doc");
+    assert_eq!(one.get("meta.foo").and_then(|v| v.as_i64()), Some(3));
+    assert!(one.get("meta").is_none());
+
+    let results = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            select([("meta.foo", field("meta.foo"))]).topk(field("meta.foo"), 10, true),
+            Some(lsn),
+            None,
+        )
+        .await
+        .expect("could not query");
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].fields.get("meta.foo").and_then(|v| v.as_i64()),
+        Some(3),
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_mixed_dotted_and_struct_rejected(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default(), None)
+        .await
+        .expect("could not create collection");
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta.foo" => 3i64,
+            "meta" => Value::r#struct([("bar", 4i64.into())]),
+        )])
+        .await
+        .expect_err("mixing literal dotted key with a struct sibling should fail");
+
+    assert!(
+        matches!(
+            err,
+            Error::DocumentValidationError(ref s) if s == &ValidationErrorBag::from(vec![
+                DocumentValidationError::InvalidFieldName {
+                    doc_id: "one".to_string(),
+                    field: "meta.foo".to_string(),
+                },
+            ])
+        ),
+        "got: {err:?}",
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_get_all_fields(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(
+                    false,
+                    [
+                        ("author", FieldSpec::text(false, None)),
+                        ("year", FieldSpec::integer(false)),
+                    ],
+                ),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta" => Value::r#struct([
+                ("author", "alice".into()),
+                ("year", 2024i64.into()),
+            ]),
+        )])
+        .await
+        .expect("could not upsert");
+
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(["one"], None, Some(lsn), None)
+        .await
+        .expect("could not get document");
+    let one = docs.get("one").expect("missing doc");
+
+    let meta = one.get("meta").and_then(|v| v.as_struct()).unwrap();
+    assert_eq!(
+        meta.get("author").and_then(|v| v.as_string()),
+        Some("alice"),
+    );
+    assert_eq!(meta.get("year").and_then(|v| v.as_i64()), Some(2024));
+    assert!(one.get("meta.author").is_none());
+    assert!(one.get("meta.year").is_none());
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_get_returns_whole_struct(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(
+                    false,
+                    [
+                        ("author", FieldSpec::text(false, None)),
+                        ("year", FieldSpec::integer(false)),
+                    ],
+                ),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta" => Value::r#struct([
+                ("author", "alice".into()),
+                ("year", 2024i64.into()),
+            ]),
+        )])
+        .await
+        .expect("could not upsert");
+
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(["one"], Some(vec!["meta".to_string()]), Some(lsn), None)
+        .await
+        .expect("could not get document");
+    let one = docs.get("one").expect("missing doc");
+
+    let meta = one.get("meta").and_then(|v| v.as_struct()).unwrap();
+    assert_eq!(
+        meta.get("author").and_then(|v| v.as_string()),
+        Some("alice"),
+    );
+    assert_eq!(meta.get("year").and_then(|v| v.as_i64()), Some(2024));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_struct_get_returns_flat_leaf(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(
+                    false,
+                    [
+                        ("author", FieldSpec::text(false, None)),
+                        ("year", FieldSpec::integer(false)),
+                    ],
+                ),
+            )]),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta" => Value::r#struct([
+                ("author", "alice".into()),
+                ("year", 2024i64.into()),
+            ]),
+        )])
+        .await
+        .expect("could not upsert");
+
+    let docs = ctx
+        .client
+        .collection(&collection.name)
+        .get(
+            ["one"],
+            Some(vec!["meta.author".to_string()]),
+            Some(lsn),
+            None,
+        )
+        .await
+        .expect("could not get document");
+    let one = docs.get("one").expect("missing doc");
+
+    assert_eq!(
+        one.get("meta.author").and_then(|v| v.as_string()),
+        Some("alice")
+    );
+    assert!(one.get("meta").is_none());
+    assert!(one.get("meta.year").is_none());
 }

--- a/topk-rs/tests/test_collection_struct.rs
+++ b/topk-rs/tests/test_collection_struct.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use test_context::test_context;
 use topk_rs::doc;
-use topk_rs::error::{DocumentValidationError, ValidationErrorBag};
+use topk_rs::error::{DocumentValidationError, SchemaValidationError, ValidationErrorBag};
 use topk_rs::proto::v1::control::FieldSpec;
 use topk_rs::proto::v1::data::Value;
 use topk_rs::query::{field, fns, select};
@@ -346,6 +346,69 @@ async fn test_upsert_mixed_dotted_and_struct_rejected(ctx: &mut ProjectTestConte
                 DocumentValidationError::InvalidFieldName {
                     doc_id: "one".to_string(),
                     field: "meta.foo".to_string(),
+                },
+            ])
+        ),
+        "got: {err:?}",
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_create_schema_struct_dotted_sub_field_rejected(ctx: &mut ProjectTestContext) {
+    let err = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("test"),
+            HashMap::from_iter([(
+                "meta".to_string(),
+                FieldSpec::r#struct(false, [("a.b", FieldSpec::text(false, None))]),
+            )]),
+            None,
+        )
+        .await
+        .expect_err("schema with dotted sub-field name should fail");
+
+    assert!(
+        matches!(
+            err,
+            Error::SchemaValidationError(ref bag) if bag.iter().any(|e| matches!(
+                e,
+                SchemaValidationError::FieldNameContainsDot { field } if field == "meta.a.b",
+            ))
+        ),
+        "got: {err:?}",
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_upsert_struct_dotted_sub_field_rejected(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("test"), HashMap::default(), None)
+        .await
+        .expect("could not create collection");
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![doc!(
+            "_id" => "one",
+            "meta" => Value::r#struct([("a.b", "v".into())]),
+        )])
+        .await
+        .expect_err("dotted sub-field name should fail");
+
+    assert!(
+        matches!(
+            err,
+            Error::DocumentValidationError(ref s) if s == &ValidationErrorBag::from(vec![
+                DocumentValidationError::InvalidFieldName {
+                    doc_id: "one".to_string(),
+                    field: "meta.a.b".to_string(),
                 },
             ])
         ),


### PR DESCRIPTION
Add more e2e tests for check dotted notation in field names (eg. `meta.foo` vs `meta: { foo: ... }`).