### PR TITLE
[py/js] update structs tests

### DIFF
--- a/topk-js/tests/test_collection_struct.spec.ts
+++ b/topk-js/tests/test_collection_struct.spec.ts
@@ -87,9 +87,10 @@ describe("Struct", () => {
 
     expect(results).toHaveLength(1);
     expect(results[0]._id).toBe("new");
-    expect(results[0].meta.author).toBe("bob");
-    expect(results[0].meta.tag).toBe("fresh");
-    expect(results[0].meta.year).toBeUndefined();
+    expect(results[0]["meta.author"]).toBe("bob");
+    expect(results[0]["meta.tag"]).toBe("fresh");
+    expect(results[0]["meta.year"]).toBeUndefined();
+    expect(results[0].meta).toBeUndefined();
   });
 
   test("struct semantic index on subfield", async () => {

--- a/topk-py/tests/test_collection_struct.py
+++ b/topk-py/tests/test_collection_struct.py
@@ -89,9 +89,10 @@ def test_struct_query_with_naked_dict(ctx: ProjectContext):
 
     assert len(results) == 1
     assert results[0]["_id"] == "new"
-    assert results[0]["meta"]["author"] == "bob"
-    assert results[0]["meta"]["tag"] == "fresh"
-    assert "year" not in results[0]["meta"]
+    assert results[0]["meta.author"] == "bob"
+    assert results[0]["meta.tag"] == "fresh"
+    assert "meta.year" not in results[0]
+    assert "meta" not in results[0]
 
 
 def test_struct_semantic_index_on_subfield(ctx: ProjectContext):


### PR DESCRIPTION
Updating py/js tests after the https://github.com/topk-io/topk/pull/470 changes.