### PR TITLE
[rs] add text-too-long error variant

### DIFF
--- a/topk-rs/src/error.rs
+++ b/topk-rs/src/error.rs
@@ -312,6 +312,13 @@ pub enum DocumentValidationError {
     DocumentNotFound {
         doc_id: String,
     },
+
+    TextTooLong {
+        doc_id: String,
+        field: String,
+        max_length: usize,
+        got_length: usize,
+    },
 }
 
 #[derive(PartialEq, Debug, serde::Serialize, serde::Deserialize, Clone)]


### PR DESCRIPTION
Used for `semantic_index()` input validation.