### PR TITLE
[docstring] update match fn docstrings

### DIFF
--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -410,38 +410,49 @@ Currently available public regions:
 URL: https://docs.topk.io/changelog
 
 {/* ## May 2026
-- structs */}
+  - structs */}
+
+#### May 2026
+
+- **Features**: Added native support for [`structs`](https://docs.topk.io/sdk/topk-py/schema#struct) with full indexing and filtering capabilities. Search and filter nested structured data without flattening your schema.
+- **Research**: Released [`Iso-ModernColBERT`](https://huggingface.co/topk-io/Iso-ModernColBERT), a late interaction model optimized for efficient inference and scalable retrieval. Built to deliver strong retrieval performance in production environments with strict latency and throughput requirements.
 
 #### April 2026
+
 - **Datasets API**: Shipped datasets API for unstructured document [ingestion](/datasets/ingest), [search](/datasets/search), and grounded [question answering](/datasets/ask). Give your agents context from complex PDFs, Markdown, HTML, and more.
-- **[CLI](/cli)**: Manage datasets, ingest documents, and query them from your terminal.
-- **[MCP](/mcp-server)**: Connect private data inside datasets to your agents.
+- [**CLI**](/cli): Manage datasets, ingest documents, and query them from your terminal.
+- [**MCP**](/mcp-server): Connect private data inside datasets to your agents.
 
 #### March 2026
+
 - **Features**: Added support for tuning [`BM25`](https://docs.topk.io/sdk/topk-py/query#bm25_score). Configure your own `b` and `k1` parameters to adjust ranking behavior and refine result relevance.
 - **Blog**: Published a post about [`SMVE`](https://www.topk.io/blog/20260311-smve-multi-vector-retrieval) — an algorithm for scaling multi-vector retrieval, focusing on improved efficiency and performance for large-scale workloads.
 
 #### February 2026
+
 - **Features**: Enabled native support for state-of-the-art retrieval models via multi-vector retrieval. ~5.5x faster than PLAID, ~7.5 faster than MUVERA with 1-bit, 2-bit and scalar quantization to optimize storage efficiency.
 - **Features**: Added native support for [`f8`](https://docs.topk.io/sdk/topk-py/schema#f8_vector) and [`f16`](https://docs.topk.io/sdk/topk-py/schema#f16_vector) vector types to optimize embedding storage size and improve efficiency when storing large document collections.
 
 #### January 2026
+
 - **Features**: Added support for multi-vector [`indexing`](https://docs.topk.io/sdk/topk-py/schema#multi_vector_index) and [`querying`](https://docs.topk.io/sdk/topk-py/query#multi_vector_distance), enabling more advanced multi-embedding retrieval use cases.
 - **Features**: Introduced the [`list<str>.starts_with`](https://docs.topk.io/sdk/topk-py/query#starts_with) operator in our query language, enabling efficient prefix filtering on array string fields.
 
-
 #### November 2025
+
 - **Features**: Added support for [`regular-expression`](/collections/query#regexp_match) filtering in our query language, enabling more flexible querying logic.
 - **Benchmarks**: Published the new [`TopK Benchmarks`](https://www.topk.io/blog/20251201-topk-bench) results, showcasing performance and scalability across production-like workloads for multiple providers.
 - **Billing**: Shipped billing, unlocking end-to-end usage tracking and payment workflows.
 - **Performance**: Shipped distributed compaction to optimize cost and improve indexing throughput per collection.
 
 #### October 2025
+
 - **Features**: Added [`update()`](https://docs.topk.io/sdk/topk-py/index#update)API to simplify partial record updates.
 - **Features**: Shipped support for [`delete-by-filter`](/collections/write#delete-documents-by-filter-expression) operations for more flexible bulk deletions.
 - **Docs & SDKs**: Added support for Cohere’s embed-v4 model in [`semantic_index()`](https://docs.topk.io/sdk/topk-py/schema#semantic-index) and exposed organization limits in ddb-management-plane for improved visibility and management.
 
 #### September 2025
+
 - **Docs & SDKs**: Published SDK reference for [**Python**](https://docs.topk.io/sdk/topk-py) and [**JavaScript**](https://docs.topk.io/sdk/topk-js) clients, and added detailed docstrings for a smoother developer experience in both SDKs
 - **Python SDK**: Released [`AsyncClient`](https://docs.topk.io/sdk/topk-py/index#asyncclient) for easier async workflows.
 - **String Operators**: Added [`lt`](/collections/query#lt), [`lte`](/collections/query#lte), [`gt`](https://docs.topk.io/sdk/topk-py/query#gt), [`gte`](https://docs.topk.io/sdk/topk-py/query#gte), [`min`](/collections/query#min), and [`max`](https://docs.topk.io/sdk/topk-py/query#max).
@@ -454,17 +465,20 @@ URL: https://docs.topk.io/changelog
 - **Performance**: Improved performance for queries with default & strong [consistency level](https://docs.topk.io/sdk/topk-py/index#consistencylevel).
 
 #### August 2025
+
 - **Lists Data Type**: Native support for [list](https://docs.topk.io/sdk/topk-py/data#list) fields.
 - **Performance**: Added [`skip_refine`](https://docs.topk.io/sdk/topk-py/query#vector-distance) query option to improve speed when reranking isn’t needed.
 - **Monitoring**: Usage Metrics now available directly in the [console](https://console.topk.io/).
 
 #### July 2025
+
 - **Math Operators**: Added [`ln`](https://docs.topk.io/sdk/topk-py/query#ln), [`exp`](https://docs.topk.io/sdk/topk-py/query#exp), [`sqrt`](https://docs.topk.io/sdk/topk-py/query#sqrt), [`square`](https://docs.topk.io/sdk/topk-py/query#square), [`min`](https://docs.topk.io/sdk/topk-py/query#min-2), [`max`](https://docs.topk.io/sdk/topk-py/query#max-2), and [`abs`](https://docs.topk.io/sdk/topk-py/query#abs).
 - **Advanced Querying**: Introduced [`choose`](https://docs.topk.io/sdk/topk-py/query#choose), [`match_all`](https://docs.topk.io/sdk/topk-py/query#match-all), [`match_any`](https://docs.topk.io/sdk/topk-py/query#match-any), [`coalesce`](https://docs.topk.io/sdk/topk-py/query#coalesce), and [`boost`](https://docs.topk.io/sdk/topk-py/query#boost) (with null coalescing).
 - **Binary Data**: Added [`bytes()`](https://docs.topk.io/sdk/topk-py/data#bytes) constructor to the Python SDK.
 - **Performance**: Optimized workload distribution for large-sacle deployments.
 
 #### June 2025
+
 - **Sparse Vectors**: Added support for [f32](https://docs.topk.io/sdk/topk-py/schema#f32-sparse-vector) and [u8](https://docs.topk.io/sdk/topk-py/schema#u8-sparse-vector) sparse vector fields.
 - **Benchmarks**: Published [billion-scale benchmarks](https://www.topk.io/benchmarks) for dense & sparse vector search with filtering.
 
@@ -7685,13 +7699,15 @@ Create a literal expression.
 match(token: str, field: str | None = None, weight: float = 1.0, all: bool = False) -> TextExpr
 ```
 
-Perform a keyword search for documents that contain specific keywords or phrases.
+Perform a BM25 keyword search using TopK's built-in tokenizer.
 
-    This function should be used in the filter stage of a query. You can configure
-    the match() function to:
-    - Match on multiple terms
-    - Match only on specific fields
-    - Use weights to prioritize certain terms
+    The ``token`` argument is a raw query string — TopK tokenizes it automatically,
+    removes stop words, and scores documents using BM25. Pass the full query string
+    directly; tokenization and stop-word removal happen server-side.
+
+    - ``field``: restrict matching to a specific keyword-indexed field (default: all).
+    - ``weight``: scale the BM25 contribution of this expression (default: 1.0).
+    - ``all``: if True, require all tokens to match (AND); default is any-token (OR).
 
 **Parameters**
 
@@ -10705,7 +10721,15 @@ Creates a literal value expression.
 function match(token: string, options?: MatchOptions): TextExpression;
 ```
 
-Creates a text match expression.
+Perform a BM25 keyword search using TopK's built-in tokenizer.
+
+The `token` argument is a raw query string — TopK tokenizes it automatically,
+removes stop words, and scores documents using BM25. Pass the full query string
+directly; tokenization and stop-word removal happen server-side.
+
+- `options.field`: restrict matching to a specific keyword-indexed field (default: all).
+- `options.weight`: scale the BM25 contribution of this expression (default: 1.0).
+- `options.all`: if true, require all tokens to match (AND); default is any-token (OR).
 
 **Parameters**
 

--- a/docs/sdk/topk-js/Namespace.query.mdx
+++ b/docs/sdk/topk-js/Namespace.query.mdx
@@ -140,7 +140,15 @@ Creates a literal value expression.
 function match(token: string, options?: MatchOptions): TextExpression;
 ```
 
-Creates a text match expression.
+Perform a BM25 keyword search using TopK's built-in tokenizer.
+
+The `token` argument is a raw query string — TopK tokenizes it automatically,
+removes stop words, and scores documents using BM25. Pass the full query string
+directly; tokenization and stop-word removal happen server-side.
+
+- `options.field`: restrict matching to a specific keyword-indexed field (default: all).
+- `options.weight`: scale the BM25 contribution of this expression (default: 1.0).
+- `options.all`: if true, require all tokens to match (AND); default is any-token (OR).
 
 **Parameters**
 

--- a/docs/sdk/topk-py/query.mdx
+++ b/docs/sdk/topk-py/query.mdx
@@ -984,13 +984,15 @@ Create a literal expression.
 match(token: str, field: str | None = None, weight: float = 1.0, all: bool = False) -> TextExpr
 ```
 
-Perform a keyword search for documents that contain specific keywords or phrases.
+Perform a BM25 keyword search using TopK's built-in tokenizer.
 
-    This function should be used in the filter stage of a query. You can configure
-    the match() function to:
-    - Match on multiple terms
-    - Match only on specific fields
-    - Use weights to prioritize certain terms
+    The ``token`` argument is a raw query string — TopK tokenizes it automatically,
+    removes stop words, and scores documents using BM25. Pass the full query string
+    directly; tokenization and stop-word removal happen server-side.
+
+    - ``field``: restrict matching to a specific keyword-indexed field (default: all).
+    - ``weight``: scale the BM25 contribution of this expression (default: 1.0).
+    - ``all``: if True, require all tokens to match (AND); default is any-token (OR).
 
 **Parameters**
 

--- a/topk-js/index.d.ts
+++ b/topk-js/index.d.ts
@@ -839,7 +839,17 @@ export declare namespace query {
   export function filter(expr: LogicalExpression | TextExpression): Query
   /** Creates a literal value expression. */
   export function literal(value: number | string | string[] | number[] | boolean | data.List): LogicalExpression
-  /** Creates a text match expression. */
+  /**
+   * Perform a BM25 keyword search using TopK's built-in tokenizer.
+   *
+   * The `token` argument is a raw query string — TopK tokenizes it automatically,
+   * removes stop words, and scores documents using BM25. Pass the full query string
+   * directly; tokenization and stop-word removal happen server-side.
+   *
+   * - `options.field`: restrict matching to a specific keyword-indexed field (default: all).
+   * - `options.weight`: scale the BM25 contribution of this expression (default: 1.0).
+   * - `options.all`: if true, require all tokens to match (AND); default is any-token (OR).
+   */
   export function match(token: string, options?: MatchOptions | undefined | null): TextExpression
   /**
    * Options for text matching.

--- a/topk-js/src/query/query.rs
+++ b/topk-js/src/query/query.rs
@@ -129,7 +129,15 @@ pub struct MatchOptions {
     pub all: Option<bool>,
 }
 
-/// Creates a text match expression.
+/// Perform a BM25 keyword search using TopK's built-in tokenizer.
+///
+/// The `token` argument is a raw query string — TopK tokenizes it automatically,
+/// removes stop words, and scores documents using BM25. Pass the full query string
+/// directly; tokenization and stop-word removal happen server-side.
+///
+/// - `options.field`: restrict matching to a specific keyword-indexed field (default: all).
+/// - `options.weight`: scale the BM25 contribution of this expression (default: 1.0).
+/// - `options.all`: if true, require all tokens to match (AND); default is any-token (OR).
 #[napi(js_name = "match", namespace = "query")]
 pub fn match_(token: String, options: Option<MatchOptions>) -> TextExpression {
     let options = options.unwrap_or_default();

--- a/topk-py/topk_sdk/query/__init__.pyi
+++ b/topk-py/topk_sdk/query/__init__.pyi
@@ -449,13 +449,15 @@ def match(
     all: builtins.bool = False,
 ) -> TextExpr:
     """
-    Perform a keyword search for documents that contain specific keywords or phrases.
+    Perform a BM25 keyword search using TopK's built-in tokenizer.
 
-    This function should be used in the filter stage of a query. You can configure
-    the match() function to:
-    - Match on multiple terms
-    - Match only on specific fields
-    - Use weights to prioritize certain terms
+    The ``token`` argument is a raw query string — TopK tokenizes it automatically,
+    removes stop words, and scores documents using BM25. Pass the full query string
+    directly; tokenization and stop-word removal happen server-side.
+
+    - ``field``: restrict matching to a specific keyword-indexed field (default: all).
+    - ``weight``: scale the BM25 contribution of this expression (default: 1.0).
+    - ``all``: if True, require all tokens to match (AND); default is any-token (OR).
     """
 
 ...


### PR DESCRIPTION
Update `match` function docstring to make clear that user does not need to tokenize the query manually