### PR TITLE
[sql] custom syntax for `INDEX`es

### DIFF
--- a/topk-sql/README.md
+++ b/topk-sql/README.md
@@ -8,10 +8,10 @@ SQL parser and query builder for TopK. Used by the PostgreSQL wire protocol adap
 
 ## Connecting
 
-Use the TopK API key as the password. The database name is the project ID.
+Use the TopK API key as the password. 
 
 ```
-psql "host=<host> port=5432 user=any password=<api-key> dbname=<project-id>"
+psql "host=<host> password=<api-key> port=5432 user=topk dbname=topk"
 ```
 
 ---
@@ -56,23 +56,20 @@ per project. Partition can be specified with `$` or the `PARTITION` keyword:
 | `collection PARTITION name` | `books PARTITION 2024` |
 
 Partition syntax applies to `SELECT`, `INSERT`, `UPDATE`, and `DELETE` only. DDL
-(`CREATE TABLE`, `DROP TABLE`, `CREATE INDEX`) names collections without partitions;
+(`CREATE TABLE`, `DROP TABLE`) names collections without partitions;
 partitions are created implicitly on first write.
 
 ---
 
 ### CREATE TABLE
 
-Schema is defined once at collection creation. `CREATE TABLE` and `CREATE INDEX`
-statements must be submitted together in a single SQL string; standalone `CREATE INDEX`
-is not supported.
+Schema is defined once at collection creation. Indexes are declared inline on each column.
 
 ```sql
 CREATE TABLE [IF NOT EXISTS] <table> (
-    <column> <type> [NOT NULL],
+    <column> <type> [NOT NULL] [INDEX <method>(<options>)],
     ...
 );
-CREATE INDEX ON <table> USING <method> (<column>) [WITH (<options>)];
 ```
 
 `IF NOT EXISTS` suppresses the error if the collection already exists.
@@ -129,25 +126,20 @@ CREATE INDEX ON <table> USING <method> (<column>) [WITH (<options>)];
 
 ```sql
 CREATE TABLE books (
-    title          TEXT NOT NULL,
+    title          TEXT NOT NULL               INDEX keyword_index(),
     author         TEXT NOT NULL,
     published_year INTEGER NOT NULL,
     rating         FLOAT,
     genre          TEXT,
     in_print       BOOLEAN,
-    bio            TEXT,
-    embedding      f32_vector(4),
-    sparse_emb     f32_sparse_vector,
-    multi_emb      f32_matrix(4),
+    bio            TEXT                        INDEX semantic_index(),
+    embedding      f32_vector(4)               INDEX vector_index(metric = 'cosine'),
+    sparse_emb     f32_sparse_vector           INDEX vector_index(metric = 'dot_product'),
+    multi_emb      f32_matrix(4)               INDEX multi_vector_index(metric = 'maxsim'),
     tags           TEXT[],
     checksum       BYTEA,
     metadata       JSONB
 );
-CREATE INDEX ON books USING keyword_index      (title);
-CREATE INDEX ON books USING semantic_index     (bio);
-CREATE INDEX ON books USING vector_index       (embedding)  WITH (metric = 'cosine');
-CREATE INDEX ON books USING vector_index       (sparse_emb) WITH (metric = 'dot_product');
-CREATE INDEX ON books USING multi_vector_index (multi_emb)  WITH (metric = 'maxsim');
 ```
 
 ---

--- a/topk-sql/README.md
+++ b/topk-sql/README.md
@@ -8,7 +8,7 @@ SQL parser and query builder for TopK. Used by the PostgreSQL wire protocol adap
 
 ## Connecting
 
-Use the TopK API key as the password. 
+Use the TopK API key as the password.
 
 ```
 psql "host=<host> password=<api-key> port=5432 user=topk dbname=topk"

--- a/topk-sql/src/dialect.rs
+++ b/topk-sql/src/dialect.rs
@@ -1,0 +1,138 @@
+use sqlparser::ast::{ColumnOption, Expr as SqlExpr, Statement as SqlStatement};
+use sqlparser::dialect::{Dialect, PostgreSqlDialect, Precedence};
+use sqlparser::keywords::Keyword;
+use sqlparser::parser::{Parser, ParserError};
+
+#[derive(Debug)]
+pub struct TopKDialect {
+    postgres: PostgreSqlDialect,
+}
+
+impl Default for TopKDialect {
+    fn default() -> Self {
+        Self {
+            postgres: PostgreSqlDialect {},
+        }
+    }
+}
+
+impl Dialect for TopKDialect {
+    fn identifier_quote_style(&self, identifier: &str) -> Option<char> {
+        self.postgres.identifier_quote_style(identifier)
+    }
+
+    fn is_delimited_identifier_start(&self, ch: char) -> bool {
+        self.postgres.is_delimited_identifier_start(ch)
+    }
+
+    fn is_identifier_start(&self, ch: char) -> bool {
+        self.postgres.is_identifier_start(ch)
+    }
+
+    fn is_identifier_part(&self, ch: char) -> bool {
+        self.postgres.is_identifier_part(ch)
+    }
+
+    fn supports_unicode_string_literal(&self) -> bool {
+        self.postgres.supports_unicode_string_literal()
+    }
+
+    fn is_custom_operator_part(&self, ch: char) -> bool {
+        self.postgres.is_custom_operator_part(ch)
+    }
+
+    fn get_next_precedence(&self, parser: &Parser) -> Option<Result<u8, ParserError>> {
+        self.postgres.get_next_precedence(parser)
+    }
+
+    fn supports_filter_during_aggregation(&self) -> bool {
+        self.postgres.supports_filter_during_aggregation()
+    }
+
+    fn supports_group_by_expr(&self) -> bool {
+        self.postgres.supports_group_by_expr()
+    }
+
+    fn prec_value(&self, prec: Precedence) -> u8 {
+        self.postgres.prec_value(prec)
+    }
+
+    fn allow_extract_custom(&self) -> bool {
+        self.postgres.allow_extract_custom()
+    }
+
+    fn allow_extract_single_quotes(&self) -> bool {
+        self.postgres.allow_extract_single_quotes()
+    }
+
+    fn supports_create_index_with_clause(&self) -> bool {
+        false
+    }
+
+    fn supports_explain_with_utility_options(&self) -> bool {
+        self.postgres.supports_explain_with_utility_options()
+    }
+
+    fn supports_listen(&self) -> bool {
+        false
+    }
+
+    fn supports_notify(&self) -> bool {
+        false
+    }
+
+    fn parse_statement(&self, parser: &mut Parser) -> Option<Result<SqlStatement, ParserError>> {
+        if parser.parse_keyword(Keyword::UPDATE) {
+            return Some(parse_update_statement(parser));
+        }
+
+        self.postgres.parse_statement(parser)
+    }
+
+    fn parse_column_option(
+        &self,
+        parser: &mut Parser,
+    ) -> Result<Option<Result<Option<ColumnOption>, ParserError>>, ParserError> {
+        if !parser.parse_keyword(Keyword::INDEX) {
+            return Ok(None);
+        }
+        let expr = parser.parse_expr()?;
+        match expr {
+            SqlExpr::Function(_) => Ok(Some(Ok(Some(ColumnOption::Check(expr))))),
+            _ => Ok(Some(Err(ParserError::ParserError(
+                "INDEX must be followed by a function call, e.g. INDEX vector_index(metric = 'cosine')"
+                    .to_string(),
+            )))),
+        }
+    }
+}
+
+// sqlparser's parse_update gates UPDATE … FROM behind a dialect_of! TypeId check that
+// only matches built-in dialects. Pulled out here so parse_statement can intercept UPDATE
+// before the main dispatch and handle FROM correctly.
+fn parse_update_statement(parser: &mut Parser) -> Result<SqlStatement, ParserError> {
+    let table = parser.parse_table_and_joins()?;
+    let assignments = parser
+        .expect_keyword(Keyword::SET)
+        .and_then(|_| parser.parse_comma_separated(Parser::parse_assignment))?;
+    let from = parser
+        .parse_keyword(Keyword::FROM)
+        .then(|| parser.parse_table_and_joins())
+        .transpose()?;
+    let selection = parser
+        .parse_keyword(Keyword::WHERE)
+        .then(|| parser.parse_expr())
+        .transpose()?;
+    let returning = parser
+        .parse_keyword(Keyword::RETURNING)
+        .then(|| parser.parse_comma_separated(Parser::parse_select_item))
+        .transpose()?;
+
+    Ok(SqlStatement::Update {
+        table,
+        assignments,
+        from,
+        selection,
+        returning,
+    })
+}

--- a/topk-sql/src/lib.rs
+++ b/topk-sql/src/lib.rs
@@ -3,8 +3,10 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 use sqlparser::ast::{self, visit_expressions};
-use sqlparser::dialect::PostgreSqlDialect;
 use sqlparser::parser::ParserError;
+
+mod dialect;
+use dialect::TopKDialect;
 
 mod ext;
 pub use ext::{
@@ -15,10 +17,10 @@ mod expr;
 pub use expr::{Expr, SqlFn};
 
 mod stmt;
-pub use stmt::{RowFilter, Statement, Variable, aggregate_stmts};
+pub use stmt::{RowFilter, Statement, Variable};
 
 mod table;
-pub use table::{Index, Table};
+pub use table::Table;
 
 pub mod util;
 
@@ -59,7 +61,7 @@ pub fn parse_sql(sql: &str) -> Result<Vec<ast::Statement>, Error> {
     let sql = rewrite_partition_syntax(sql);
 
     // Parse
-    let dialect = PostgreSqlDialect {};
+    let dialect = TopKDialect::default();
     let stmts = sqlparser::parser::Parser::parse_sql(&dialect, &sql)?;
 
     // Validate
@@ -98,6 +100,22 @@ pub fn parse_sql(sql: &str) -> Result<Vec<ast::Statement>, Error> {
     }
 
     Ok(stmts)
+}
+
+/// Convert a parsed SQL batch into typed statements.
+///
+/// Returns pairs of `(Statement, Option<ast::Statement>)` where the raw SQL is
+/// preserved only for `Query` statements (needed by callers for projection inference).
+pub fn convert_sql(
+    batch: Vec<ast::Statement>,
+) -> Result<Vec<(Statement, Option<ast::Statement>)>, Error> {
+    batch
+        .into_iter()
+        .map(|sql| {
+            let raw = matches!(sql, ast::Statement::Query(_)).then(|| sql.clone());
+            Statement::try_from(sql).map(|stmt| (stmt, raw))
+        })
+        .collect()
 }
 
 // Rewrite "SELECT * FROM books PARTITION p1" → "SELECT * FROM books$p1"

--- a/topk-sql/src/stmt/create_table.rs
+++ b/topk-sql/src/stmt/create_table.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use sqlparser::ast::{
-    ArrayElemTypeDef, BinaryOperator, ColumnDef, ColumnOption, CreateIndex as SqlCreateIndex,
-    CreateTable as SqlCreateTable, DataType, Expr as SqlExpr,
+    ArrayElemTypeDef, BinaryOperator, ColumnDef, ColumnOption, CreateTable as SqlCreateTable,
+    DataType, Expr as SqlExpr, Function, FunctionArg, FunctionArgExpr, FunctionArguments,
 };
 use topk_rs::proto::v1::control::{
     FieldIndex, FieldSpec, FieldType, KeywordIndexType, MultiVectorDistanceMetric,
@@ -11,7 +11,7 @@ use topk_rs::proto::v1::control::{
 };
 
 use crate::{
-    Error, FromSql, Index, SqlExprExt, Statement, Table, parse_args, parse_kwargs, sql_invalid,
+    Error, FromSql, SqlExprExt, Statement, Table, parse_args, parse_kwargs, sql_invalid,
     sql_unsupported,
 };
 
@@ -44,124 +44,20 @@ impl TryFrom<SqlCreateTable> for Statement {
     }
 }
 
-impl FromSql<SqlCreateIndex> for Index {
-    fn from_sql(idx: SqlCreateIndex) -> Result<Self, Error> {
-        sql_unsupported!(idx.unique, "CREATE UNIQUE INDEX");
-        sql_unsupported!(idx.concurrently, "CREATE INDEX CONCURRENTLY");
-        sql_unsupported!(idx.if_not_exists, "CREATE INDEX IF NOT EXISTS");
-        sql_unsupported!(!idx.include.is_empty(), "INDEX … INCLUDE");
-        sql_unsupported!(idx.predicate.is_some(), "partial index (WHERE clause)");
-        sql_invalid!(
-            idx.columns.len() != 1,
-            "CREATE INDEX must reference exactly one column"
-        );
-
-        // Parse table name.
-        let table = Table::new(idx.table_name)?;
-        sql_invalid!(
-            !matches!(table, Table::Collection(_)),
-            "CREATE INDEX requires a collection name"
-        );
-
-        // Parse index method.
-        let method = idx
-            .using
-            .as_ref()
-            .map(|using| using.value.to_ascii_lowercase());
-        let method = match method {
-            Some(method) => method,
-            None => sql_invalid!("CREATE INDEX requires USING <index method>"),
-        };
-
-        // Parse field name.
-        let field = match &idx.columns[0].expr {
-            SqlExpr::Identifier(ident) => ident.value.clone(),
-            e => sql_invalid!("expected column name in CREATE INDEX, got {e:?}"),
-        };
-
-        // Parse WITH options.
-        let opts = idx
-            .with
-            .into_iter()
-            .map(|expr| match expr {
-                SqlExpr::BinaryOp {
-                    left,
-                    op: BinaryOperator::Eq,
-                    right,
-                } => {
-                    let key = match left.as_ident() {
-                        Some(key) => key,
-                        None => sql_invalid!("expected identifier in WITH option"),
-                    };
-                    let value = match right.as_string() {
-                        Some(value) => value,
-                        None => sql_invalid!("expected string in WITH option"),
-                    };
-
-                    Ok((key, value))
-                }
-                e => sql_invalid!("expected key = value in WITH clause, got {e:?}"),
-            })
-            .collect::<Result<HashMap<String, String>, Error>>()?;
-
-        let index = match method.as_str() {
-            "keyword_index" => {
-                sql_unsupported!(!opts.is_empty(), "keyword_index does not take WITH options");
-                FieldIndex::keyword(KeywordIndexType::Text)
-            }
-            "semantic_index" => {
-                sql_unsupported!(
-                    !opts.is_empty(),
-                    "semantic_index does not take WITH options"
-                );
-                FieldIndex::semantic()
-            }
-            "vector_index" => {
-                let (metric,) = parse_kwargs!(&opts; metric: VectorDistanceMetric)?;
-                FieldIndex::vector(metric)
-            }
-            "multi_vector_index" => {
-                let (metric, quantization, width, top_k) = parse_kwargs!(
-                    &opts;
-                    metric: MultiVectorDistanceMetric;
-                    quantization: MultiVectorQuantization, width: u32, top_k: u32
-                )?;
-                sql_invalid!(
-                    metric != MultiVectorDistanceMetric::Maxsim,
-                    "multi_vector_index metric must be 'maxsim'"
-                );
-                FieldIndex::multi_vector(metric, quantization, width, top_k)
-            }
-            _ => sql_unsupported!(
-                "unknown index method `{method}`, expected: keyword_index | semantic_index | vector_index | multi_vector_index"
-            ),
-        };
-
-        Ok(Index {
-            table,
-            field,
-            index,
-        })
-    }
-}
-
-impl FromSql<SqlCreateIndex> for Statement {
-    fn from_sql(idx: SqlCreateIndex) -> Result<Self, Error> {
-        Ok(Statement::CreateIndex {
-            index: Index::from_sql(idx)?,
-        })
-    }
-}
-
 impl FromSql<ColumnDef> for FieldSpec {
     fn from_sql(column: ColumnDef) -> Result<Self, Error> {
         let data_type = FieldType::from_sql(column.data_type)?;
 
         let mut required = false;
+        let mut index = None;
         for option in column.options {
             match option.option {
                 ColumnOption::Null => {}
                 ColumnOption::NotNull => required = true,
+                ColumnOption::Check(SqlExpr::Function(func)) => {
+                    sql_invalid!(index.is_some(), "column has multiple INDEX definitions");
+                    index = Some(FieldIndex::from_sql(func)?);
+                }
                 ColumnOption::Default(_) => sql_unsupported!("DEFAULT constraint"),
                 ColumnOption::Unique { .. } => sql_unsupported!("UNIQUE constraint"),
                 ColumnOption::Check(_) => sql_unsupported!("CHECK constraint"),
@@ -173,7 +69,7 @@ impl FromSql<ColumnDef> for FieldSpec {
         Ok(FieldSpec {
             data_type: Some(data_type),
             required,
-            index: None,
+            index,
         })
     }
 }
@@ -271,5 +167,74 @@ impl FromSql<DataType> for FieldType {
 
             dt => sql_unsupported!("data type: {dt}"),
         }
+    }
+}
+
+impl FromSql<Function> for FieldIndex {
+    fn from_sql(func: Function) -> Result<Self, Error> {
+        let method = func.name.to_string().to_ascii_lowercase();
+
+        let opts: HashMap<String, String> = match func.args {
+            FunctionArguments::None => HashMap::new(),
+            FunctionArguments::List(list) => list
+                .args
+                .iter()
+                .map(|arg| match arg {
+                    FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::BinaryOp {
+                        left,
+                        op: BinaryOperator::Eq,
+                        right,
+                    })) => {
+                        let key = match left.as_ident() {
+                            Some(key) => key,
+                            None => sql_invalid!("expected identifier in INDEX option"),
+                        };
+                        let value = match right.as_string() {
+                            Some(value) => value,
+                            None => sql_invalid!("expected string in INDEX option"),
+                        };
+                        Ok((key, value))
+                    }
+                    other => {
+                        sql_invalid!("expected key = 'value' in INDEX options, got {other:?}")
+                    }
+                })
+                .collect::<Result<_, Error>>()?,
+            other => {
+                sql_invalid!("expected function argument list for index options, got {other:?}")
+            }
+        };
+
+        let index = match method.as_str() {
+            "keyword_index" => {
+                sql_unsupported!(!opts.is_empty(), "keyword_index does not take options");
+                FieldIndex::keyword(KeywordIndexType::Text)
+            }
+            "semantic_index" => {
+                sql_unsupported!(!opts.is_empty(), "semantic_index does not take options");
+                FieldIndex::semantic()
+            }
+            "vector_index" => {
+                let (metric,) = parse_kwargs!(&opts; metric: VectorDistanceMetric)?;
+                FieldIndex::vector(metric)
+            }
+            "multi_vector_index" => {
+                let (metric, quantization, width, top_k) = parse_kwargs!(
+                    &opts;
+                    metric: MultiVectorDistanceMetric;
+                    quantization: MultiVectorQuantization, width: u32, top_k: u32
+                )?;
+                sql_invalid!(
+                    metric != MultiVectorDistanceMetric::Maxsim,
+                    "multi_vector_index metric must be 'maxsim'"
+                );
+                FieldIndex::multi_vector(metric, quantization, width, top_k)
+            }
+            _ => sql_unsupported!(
+                "unknown index method `{method}`, expected: keyword_index | semantic_index | vector_index | multi_vector_index"
+            ),
+        };
+
+        Ok(index)
     }
 }

--- a/topk-sql/src/stmt/mod.rs
+++ b/topk-sql/src/stmt/mod.rs
@@ -5,7 +5,7 @@ use strum_macros::IntoStaticStr;
 use topk_rs::proto::v1::control::FieldSpec;
 use topk_rs::proto::v1::data::{Document, LogicalExpr, Query, Value};
 
-use crate::{Error, FromSql, Index, SqlExprExt, Table, sql_invalid, sql_unsupported};
+use crate::{Error, FromSql, SqlExprExt, Table, sql_invalid, sql_unsupported};
 
 mod create_table;
 mod delete;
@@ -19,74 +19,6 @@ mod show;
 mod update;
 mod variable;
 pub use variable::Variable;
-
-/// Convert a parsed SQL batch, folding consecutive `CREATE INDEX` into each
-/// preceding `CREATE TABLE` schema. Stray `CREATE INDEX` statements error.
-///
-/// Returns pairs of `(Statement, Option<SqlStatement>)` where the raw SQL is
-/// preserved only for `SELECT` queries (needed by callers for projection inference).
-pub fn aggregate_stmts(
-    batch: Vec<SqlStatement>,
-) -> Result<Vec<(Statement, Option<SqlStatement>)>, Error> {
-    let mut out = Vec::with_capacity(batch.len());
-
-    let mut iter = batch.into_iter().peekable();
-    while let Some(sql) = iter.next() {
-        let (stmt, raw) = match sql {
-            SqlStatement::CreateTable(ct) => {
-                let Statement::CreateTable {
-                    table,
-                    mut schema,
-                    if_not_exists,
-                } = Statement::try_from(ct)?
-                else {
-                    unreachable!()
-                };
-
-                while matches!(iter.peek(), Some(SqlStatement::CreateIndex(_))) {
-                    let index = match iter.next() {
-                        Some(SqlStatement::CreateIndex(idx)) => Index::from_sql(idx)?,
-                        _ => unreachable!(),
-                    };
-
-                    sql_invalid!(
-                        index.table != table,
-                        "CREATE INDEX references unknown table `{}`",
-                        index.table
-                    );
-                    let field = &index.field;
-                    let spec = match schema.get_mut(field) {
-                        Some(spec) => spec,
-                        None => sql_invalid!("CREATE INDEX references unknown field `{field}`"),
-                    };
-                    sql_invalid!(spec.index.is_some(), "field `{field}` already has an index");
-                    spec.index = Some(index.index);
-                }
-
-                (
-                    Statement::CreateTable {
-                        table,
-                        schema,
-                        if_not_exists,
-                    },
-                    None,
-                )
-            }
-            SqlStatement::CreateIndex(idx) => {
-                let index = Index::from_sql(idx)?;
-                let table = index.table;
-                sql_invalid!("CREATE INDEX references unknown table `{table}`");
-            }
-            other => {
-                let raw = matches!(other, SqlStatement::Query(_)).then(|| other.clone());
-                (Statement::try_from(other)?, raw)
-            }
-        };
-        out.push((stmt, raw));
-    }
-
-    Ok(out)
-}
 
 #[derive(Debug, Clone, PartialEq, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -144,10 +76,6 @@ pub enum Statement {
         /// Silently ignore if the table does not exist.
         if_exists: bool,
     },
-    CreateIndex {
-        /// Index to create.
-        index: Index,
-    },
 
     Explain {
         /// Statement to explain.
@@ -199,7 +127,6 @@ impl Statement {
             | Statement::DeletePartition { table }
             | Statement::CreateTable { table, .. }
             | Statement::DropTable { table, .. } => Some(table),
-            Statement::CreateIndex { index } => Some(&index.table),
             Statement::Explain { stmt, .. } => stmt.table(),
             _ => None,
         }
@@ -225,7 +152,6 @@ impl TryFrom<SqlStatement> for Statement {
             SqlStatement::Explain { .. } => explain::try_from_sql(stmt),
             SqlStatement::CreateTable(ct) => Statement::try_from(ct),
             SqlStatement::Drop { .. } => drop::try_from_sql(stmt),
-            SqlStatement::CreateIndex(idx) => Statement::from_sql(idx),
             other => Err(Error::Unsupported(format!("statement: {other:?}"))),
         }
     }
@@ -274,45 +200,5 @@ impl FromSql<SqlExpr> for RowFilter {
             SqlExpr::Nested(inner) => Self::from_sql(*inner),
             other => Ok(RowFilter::Expr(LogicalExpr::from_sql(other)?)),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::parse_sql;
-    use sqlparser::ast::Statement as SqlStatement;
-
-    use super::*;
-
-    fn parse_query(sql: &str) -> Statement {
-        let SqlStatement::Query(q) = parse_sql(sql).unwrap().remove(0) else {
-            panic!("expected query");
-        };
-        Statement::try_from(*q).unwrap()
-    }
-
-    #[test]
-    fn count_parses_to_count_statement() {
-        match parse_query("SELECT COUNT(*) FROM books") {
-            Statement::Count { alias, .. } => assert_eq!(alias, "_count"),
-            other => panic!("expected Count, got {other:?}"),
-        }
-
-        match parse_query("SELECT COUNT(*) AS n FROM books") {
-            Statement::Count { alias, .. } => assert_eq!(alias, "n"),
-            other => panic!("expected Count, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn standalone_create_index_reports_option_error_first() {
-        let sql = "\
-            CREATE INDEX ON books USING vector_index (embedding) \
-            WITH (metric = 'cosine', typo = 'oops')\
-        ";
-
-        let err = aggregate_stmts(crate::parse_sql(sql).unwrap()).unwrap_err();
-
-        assert_eq!(err.to_string(), "Invalid: unknown option `typo`");
     }
 }

--- a/topk-sql/src/table.rs
+++ b/topk-sql/src/table.rs
@@ -1,7 +1,6 @@
 use std::fmt::{self, Display};
 
 use sqlparser::ast::ObjectName;
-use topk_rs::proto::v1::control::FieldIndex;
 use topk_rs::{Client, CollectionClient};
 
 use crate::{Error, sql_invalid};
@@ -10,13 +9,6 @@ use crate::{Error, sql_invalid};
 pub enum Table {
     Collection(String),
     Partition(String, String),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Index {
-    pub table: Table,
-    pub field: String,
-    pub index: FieldIndex,
 }
 
 impl Display for Table {

--- a/topk-sql/tests/common/context.rs
+++ b/topk-sql/tests/common/context.rs
@@ -149,25 +149,20 @@ impl AsyncTestContext for BooksContext {
             .query(&format!(
                 r#"
             CREATE TABLE {table} (
-                title          TEXT NOT NULL,
+                title          TEXT NOT NULL             INDEX keyword_index(),
                 author         TEXT,
                 published_year INTEGER,
                 rating         FLOAT,
                 genre          TEXT,
                 in_print       BOOLEAN,
-                bio            TEXT,
-                embedding      f32_vector(4),
-                sparse_emb     f32_sparse_vector,
-                multi_emb      f32_matrix(4),
+                bio            TEXT                      INDEX semantic_index(),
+                embedding      f32_vector(4)             INDEX vector_index(metric = 'cosine'),
+                sparse_emb     f32_sparse_vector         INDEX vector_index(metric = 'dot_product'),
+                multi_emb      f32_matrix(4)             INDEX multi_vector_index(metric = 'maxsim'),
                 tags           TEXT[],
                 checksum       BYTEA,
                 metadata       JSONB
             );
-            CREATE INDEX ON {table} USING keyword_index      (title);
-            CREATE INDEX ON {table} USING semantic_index     (bio);
-            CREATE INDEX ON {table} USING vector_index       (embedding)  WITH (metric = 'cosine');
-            CREATE INDEX ON {table} USING vector_index       (sparse_emb) WITH (metric = 'dot_product');
-            CREATE INDEX ON {table} USING multi_vector_index (multi_emb)  WITH (metric = 'maxsim');
             "#
             ))
             .await

--- a/topk-sql/tests/test_create_table.rs
+++ b/topk-sql/tests/test_create_table.rs
@@ -26,9 +26,10 @@ use common::{Scope, TableScope};
     vec![doc!("label" => "hello")],
 )]
 #[case::indexes(
-    "CREATE TABLE {{table}} (title TEXT NOT NULL, embedding f32_vector(4));
-     CREATE INDEX ON {{table}} USING keyword_index (title);
-     CREATE INDEX ON {{table}} USING vector_index (embedding) WITH (metric = 'cosine')",
+    "CREATE TABLE {{table}} (
+        title     TEXT NOT NULL  INDEX keyword_index(),
+        embedding f32_vector(4)  INDEX vector_index(metric = 'cosine')
+    )",
     "INSERT INTO {{table}} (_id, title, embedding) VALUES ('doc', 'Hello World', f32_vector(ARRAY[1.0, 0.0, 0.0, 0.0]))",
     "SELECT _id, vector_distance(embedding, f32_vector(ARRAY[1.0, 0.0, 0.0, 0.0])) AS d FROM {{table}} ORDER BY d LIMIT 1",
     vec![doc!("_id" => "doc", "d" => 1.0_f32)],
@@ -62,11 +63,6 @@ async fn create_table_round_trip(
     "CREATE TABLE {{table}} (name TEXT NOT NULL)",
     "collection already exists"
 )]
-#[case::vector_index_unknown_option(
-    "CREATE TABLE {{table}} (embedding f32_vector(4))",
-    "CREATE INDEX ON {{table}} USING vector_index (embedding) WITH (metric = 'cosine', typo = 'oops')",
-    "Invalid: unknown option `typo`"
-)]
 #[tokio::test]
 async fn create_table_rejected(
     #[case] setup_sql: &str,
@@ -80,6 +76,23 @@ async fn create_table_rejected(
     })
     .await
     .unwrap_err();
+
+    assert_eq!(err.to_string(), expected);
+}
+
+#[rstest]
+#[case::unknown_option(
+    "CREATE TABLE {{table}} (
+        name TEXT NOT NULL,
+        embedding f32_vector(4) INDEX vector_index(metric = 'cosine', typo = 'oops')
+    )",
+    "Invalid: unknown option `typo`"
+)]
+#[tokio::test]
+async fn create_table_with_index_rejected(#[case] sql: &str, #[case] expected: &str) {
+    let err = TableScope::with_scope(async |ctx| ctx.sql(sql).await)
+        .await
+        .unwrap_err();
 
     assert_eq!(err.to_string(), expected);
 }


### PR DESCRIPTION
Replace `CREATE TABLE + CREATE INDEX` statement bundling with a native syntax for defining an index on a column:


```sql
CREATE TABLE books (
    title          TEXT NOT NULL               INDEX keyword_index(),
    bio            TEXT                        INDEX semantic_index(),
    embedding      f32_vector(4)               INDEX vector_index(metric = 'cosine'),
    sparse_emb     f32_sparse_vector           INDEX vector_index(metric = 'dot_product'),
    multi_emb      f32_matrix(4)               INDEX multi_vector_index(metric = 'maxsim'),
);
```