### PR TITLE
[sql] add missing `match`/`match_token` fns

### DIFF
--- a/topk-sql/README.md
+++ b/topk-sql/README.md
@@ -259,8 +259,23 @@ column `title`).
 | Arithmetic | `rating * 10 > 40` |
 | `CASE WHEN … THEN … ELSE … END` | — |
 | `contains(field, scalar)` | `contains(tags, 'classic')` |
+| `match(query [, field [, weight [, all]]])` | `match('hobbit rings', title)` |
+| `match_tokens(tokens [, field [, all]])` | `match_tokens(ARRAY['love', 'classic'], tags)` |
 | `match_all(field, query)` | `match_all(title, 'hobbit rings')` |
 | `match_any(field, query)` | `match_any(tags, ARRAY['love', 'classic'])` |
+
+`match(...)` and `match_tokens(...)` search keyword-indexed text and can be ranked
+with `bm25_score()`. Combine text searches with `AND` / `OR`; add metadata filters
+with `AND`:
+
+```sql
+WHERE (match('hobbit', title) OR match('rings', title))
+  AND published_year > 1940
+```
+
+`match(...) OR published_year = 1813` is not supported. Use `match_any(...)` and
+`match_all(...)` for boolean keyword predicates; they work in ordinary logical
+expressions but are not ranked by `bm25_score()`.
 
 Whole-value equality on complex types (e.g. `tags = ARRAY['a']`) is not supported.
 `contains` requires a scalar needle, not an array.
@@ -433,14 +448,18 @@ Scoring functions go in `SELECT` only — alias them, then reference the alias i
 |----------|--------|-------------|
 | `vector_distance(field, query [, skip_refine])` | SELECT | Dense or sparse ANN distance |
 | `multi_vector_distance(field, query [, candidates])` | SELECT | Multi-vector MaxSim distance |
-| `bm25_score([b, k1])` | SELECT | BM25 full-text score |
+| `bm25_score([b, k1])` | SELECT | Keyword relevance score for `match(...)` / `match_tokens(...)` |
 | `semantic_similarity(field, query)` | SELECT | Semantic embedding similarity |
 | `boost(score, condition, factor)` | SELECT / ORDER BY | Multiply score when condition is true |
 | `contains(field, scalar)` | WHERE | List membership or string substring |
-| `match_all(field, query)` | WHERE | All terms in query must match |
-| `match_any(field, query)` | WHERE | Any term in query must match |
+| `match(query [, field [, weight [, all]]])` | WHERE | Keyword text search; can be ranked with `bm25_score()` |
+| `match_tokens(tokens [, field [, all]])` | WHERE | Keyword token search; can be ranked with `bm25_score()` |
+| `match_all(field, query)` | WHERE | Boolean keyword predicate requiring all terms |
+| `match_any(field, query)` | WHERE | Boolean keyword predicate requiring any term |
 
 All scoring functions return `f32` (`FLOAT4` OID when projected without cast).
+`bm25_score()` requires at least one `match(...)` or `match_tokens(...)` text filter
+in `WHERE`.
 
 ### Example queries
 
@@ -478,8 +497,8 @@ SELECT
     title,
     bm25_score() AS bm25_score
 FROM books
-WHERE match_any(title, 'hobbit rings')
-ORDER BY bm25_score
+WHERE match('hobbit rings', title)
+ORDER BY bm25_score DESC
 LIMIT 5;
 
 -- Semantic similarity
@@ -499,5 +518,12 @@ SELECT
 FROM books
 WHERE match_any(title, 'tolkien')
 ORDER BY boost(vec_dist, in_print = true, 1.5)
+LIMIT 5;
+
+-- Boolean keyword predicates
+SELECT _id, title
+FROM books
+WHERE match_all(title, ARRAY['lord', 'rings'])
+   OR match_any(tags, ARRAY['classic', 'adventure'])
 LIMIT 5;
 ```

--- a/topk-sql/src/expr/filter.rs
+++ b/topk-sql/src/expr/filter.rs
@@ -1,51 +1,129 @@
-use sqlparser::ast::{BinaryOperator, Expr as SqlExpr};
+use std::ops::ControlFlow;
+
+use sqlparser::ast::{BinaryOperator, Expr as SqlExpr, visit_expressions};
 
 use topk_rs::proto::v1::data::{LogicalExpr, TextExpr, stage::filter_stage::FilterExpr};
 
-use crate::{Error, FromSql, SqlFn, SqlFunctionExt, sql_invalid};
+use super::Expr;
+use crate::{Error, FromSql, SqlFunctionExt, sql_invalid, sql_unsupported};
 
-impl FromSql<SqlExpr> for FilterExpr {
-    fn from_sql(expr: SqlExpr) -> Result<FilterExpr, Error> {
-        match try_text_filter(&expr)? {
-            Some(expr) => Ok(FilterExpr::text(expr)),
-            None => Ok(FilterExpr::logical(LogicalExpr::from_sql(expr)?)),
+impl FromSql<SqlExpr> for Vec<FilterExpr> {
+    fn from_sql(expr: SqlExpr) -> Result<Vec<FilterExpr>, Error> {
+        let mut text: Option<TextExpr> = None;
+        let mut logical = Vec::new();
+
+        // Split the expression on AND operators and separate text and logical expressions
+        // This works naturally in other SDKs as `.filter()` accepts `LogicalExpr | TextExpr`.
+        for conjunct in split_binary(expr, BinaryOperator::And) {
+            if contains_text_expr(&conjunct) {
+                text = Some(match text {
+                    Some(left) => left.and(TextExpr::from_sql(conjunct)?),
+                    None => TextExpr::from_sql(conjunct)?,
+                });
+            } else {
+                logical.push(conjunct);
+            }
+        }
+
+        // Collect logical expressions into an AND chain
+        let logical = logical.into_iter().reduce(|left, right| SqlExpr::BinaryOp {
+            left: Box::new(left),
+            op: BinaryOperator::And,
+            right: Box::new(right),
+        });
+
+        // Group text and logical expressions. Order doesn't matter as they are combined with AND.
+        let filters = {
+            let mut filters = Vec::with_capacity(2);
+            if let Some(expr) = text {
+                filters.push(FilterExpr::text(expr));
+            }
+            if let Some(expr) = logical {
+                filters.push(FilterExpr::logical(LogicalExpr::from_sql(expr)?));
+            }
+            filters
+        };
+
+        Ok(filters)
+    }
+}
+
+impl FromSql<SqlExpr> for TextExpr {
+    fn from_sql(expr: SqlExpr) -> Result<TextExpr, Error> {
+        match expr {
+            SqlExpr::Nested(inner) => FromSql::from_sql(*inner),
+            SqlExpr::Function(func)
+                if func.name().eq_ignore_ascii_case("match")
+                    || func.name().eq_ignore_ascii_case("match_tokens") =>
+            {
+                match Expr::try_from(func.clone())? {
+                    Expr::Text(expr) => Ok(expr),
+                    _ => sql_invalid!("Expected match or match_tokens function"),
+                }
+            }
+            SqlExpr::Function(_) => sql_invalid!("Expected match or match_tokens function"),
+
+            SqlExpr::BinaryOp { left, op, right }
+                if matches!(op, BinaryOperator::And | BinaryOperator::Or) =>
+            {
+                sql_unsupported!(
+                    contains_text_expr(&left) != contains_text_expr(&right),
+                    "match/match_tokens can only be combined with logical filters using AND"
+                );
+
+                let left = TextExpr::from_sql(*left)?;
+                let right = TextExpr::from_sql(*right)?;
+
+                let expr = match op {
+                    BinaryOperator::And => left.and(right),
+                    BinaryOperator::Or => left.or(right),
+                    _ => sql_invalid!("Expected AND or OR operator in text filter"),
+                };
+
+                Ok(expr)
+            }
+
+            _ => sql_invalid!("Expected match or match_tokens function"),
         }
     }
 }
 
-fn try_text_filter(expr: &SqlExpr) -> Result<Option<TextExpr>, Error> {
+fn split_binary(expr: SqlExpr, op: BinaryOperator) -> Vec<SqlExpr> {
     match expr {
-        SqlExpr::Nested(inner) => try_text_filter(inner),
-        SqlExpr::Function(func) => match func.name().as_str() {
-            "match_all" | "match_any" => match SqlFn::try_from(func.clone()) {
-                Ok(SqlFn::TextMatch { text, .. }) => Ok(text),
-                _ => sql_invalid!("Expected match_all or match_any function"),
-            },
-            _ => Ok(None),
-        },
-
-        SqlExpr::BinaryOp { left, op, right }
-            if matches!(op, BinaryOperator::And | BinaryOperator::Or) =>
-        {
-            let left = match try_text_filter(left)? {
-                Some(left) => left,
-                None => return Ok(None),
-            };
-            let right = match try_text_filter(right)? {
-                Some(right) => right,
-                None => return Ok(None),
-            };
-
-            // Build expr
-            let expr = match op {
-                BinaryOperator::And => left.and(right),
-                BinaryOperator::Or => left.or(right),
-                _ => return Ok(None),
-            };
-
-            Ok(Some(expr))
+        SqlExpr::Nested(inner) => split_binary(*inner, op),
+        SqlExpr::BinaryOp {
+            left,
+            op: expr_op,
+            right,
+        } if expr_op == op => {
+            let mut exprs = split_binary(*left, op.clone());
+            exprs.extend(split_binary(*right, op));
+            exprs
         }
+        expr => vec![expr.clone()],
+    }
+}
 
-        _ => Ok(None),
+fn contains_text_expr(expr: &SqlExpr) -> bool {
+    matches!(
+        visit_expressions(expr, |expr| {
+            if is_text_expr(expr) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        }),
+        ControlFlow::Break(())
+    )
+}
+
+fn is_text_expr(expr: &SqlExpr) -> bool {
+    match expr {
+        SqlExpr::Nested(inner) => is_text_expr(inner),
+        SqlExpr::Function(func) => {
+            let name = func.name();
+            name.eq_ignore_ascii_case("match") || name.eq_ignore_ascii_case("match_tokens")
+        }
+        _ => false,
     }
 }

--- a/topk-sql/src/expr/function.rs
+++ b/topk-sql/src/expr/function.rs
@@ -9,32 +9,7 @@ use crate::expr::Expr;
 use crate::ext::{SqlExprExt, SqlFunctionExt};
 use crate::{Error, FromSql, sql_invalid, sql_unsupported};
 
-#[derive(Clone, Debug)]
-pub enum SqlFn {
-    Literal(Value),
-    Logical(LogicalExpr),
-    TextMatch {
-        logical: LogicalExpr,
-        text: Option<TextExpr>,
-    },
-    Function(FunctionExpr),
-}
-
-impl From<SqlFn> for Expr {
-    fn from(func: SqlFn) -> Expr {
-        match func {
-            SqlFn::Literal(value) => Expr::Literal(value),
-            SqlFn::Logical(expr) => Expr::Logical(expr),
-            SqlFn::TextMatch {
-                text: Some(expr), ..
-            } => Expr::Text(expr),
-            SqlFn::TextMatch { logical: expr, .. } => Expr::Logical(expr),
-            SqlFn::Function(expr) => Expr::Function(expr),
-        }
-    }
-}
-
-impl TryFrom<SqlFunction> for SqlFn {
+impl TryFrom<SqlFunction> for Expr {
     type Error = Error;
 
     fn try_from(func: SqlFunction) -> Result<Self, Self::Error> {
@@ -62,20 +37,14 @@ impl TryFrom<SqlFunction> for SqlFn {
             }
             "match_all" => {
                 let [left, right]: [SqlExpr; 2] = exact(args, &name)?;
-                let text = text_match(&left, &right, true);
-                Self::TextMatch {
-                    logical: LogicalExpr::from_sql(left)?.match_all(LogicalExpr::from_sql(right)?),
-                    text,
-                }
+                Self::Logical(LogicalExpr::from_sql(left)?.match_all(LogicalExpr::from_sql(right)?))
             }
             "match_any" => {
                 let [left, right]: [SqlExpr; 2] = exact(args, &name)?;
-                let text = text_match(&left, &right, false);
-                Self::TextMatch {
-                    logical: LogicalExpr::from_sql(left)?.match_any(LogicalExpr::from_sql(right)?),
-                    text,
-                }
+                Self::Logical(LogicalExpr::from_sql(left)?.match_any(LogicalExpr::from_sql(right)?))
             }
+            "match" => Self::Text(text_match(args, &name)?),
+            "match_tokens" => Self::Text(text_match_tokens(args, &name)?),
             "boost" => {
                 let [score, cond, factor]: [SqlExpr; 3] = exact(args, &name)?;
                 let score = LogicalExpr::from_sql(score)?;
@@ -226,14 +195,6 @@ impl TryFrom<SqlFunction> for SqlFn {
     }
 }
 
-impl TryFrom<SqlFunction> for Expr {
-    type Error = Error;
-
-    fn try_from(func: SqlFunction) -> Result<Self, Self::Error> {
-        Ok(SqlFn::try_from(func)?.into())
-    }
-}
-
 fn unary(args: Vec<SqlExpr>, sig: &str) -> Result<LogicalExpr, Error> {
     let [arg]: [SqlExpr; 1] = exact(args, sig)?;
     LogicalExpr::from_sql(arg)
@@ -244,30 +205,119 @@ fn binary(args: Vec<SqlExpr>, sig: &str) -> Result<(LogicalExpr, LogicalExpr), E
     Ok((LogicalExpr::from_sql(left)?, LogicalExpr::from_sql(right)?))
 }
 
-fn text_match(field: &SqlExpr, query: &SqlExpr, all: bool) -> Option<TextExpr> {
-    let field = Some(field.as_ident()?);
-    let value = Value::from_sql(query.clone()).ok()?;
-    let terms = match value.value? {
-        value::Value::String(token) => vec![Term {
+fn text_match(args: Vec<SqlExpr>, name: &str) -> Result<TextExpr, Error> {
+    let (query, field, weight, all) = match args.len() {
+        1 => {
+            let [query]: [SqlExpr; 1] = exact(args, name)?;
+            (query, None, 1.0, false)
+        }
+        2 => {
+            let [query, field]: [SqlExpr; 2] = exact(args, name)?;
+            (query, optional_field(field, name)?, 1.0, false)
+        }
+        3 => {
+            let [query, field, weight]: [SqlExpr; 3] = exact(args, name)?;
+            (
+                query,
+                optional_field(field, name)?,
+                f32_literal(weight)?,
+                false,
+            )
+        }
+        4 => {
+            let [query, field, weight, all]: [SqlExpr; 4] = exact(args, name)?;
+            let all = all
+                .as_bool()
+                .ok_or_else(|| Error::Invalid(format!("{name}: all must be a bool literal")))?;
+            (
+                query,
+                optional_field(field, name)?,
+                f32_literal(weight)?,
+                all,
+            )
+        }
+        n => sql_invalid!("{name}: expected 1..=4 args, got {n}"),
+    };
+
+    let token = query
+        .as_string()
+        .ok_or_else(|| Error::Invalid(format!("{name}: query must be a string literal")))?;
+
+    Ok(TextExpr::terms(
+        all,
+        vec![Term {
             token,
             field,
-            weight: 1.0,
+            weight,
         }],
-        value::Value::List(values) => match values.values? {
-            list::Values::String(tokens) => tokens
-                .values
-                .into_iter()
-                .map(|token| Term {
-                    token,
-                    field: field.clone(),
-                    weight: 1.0,
-                })
-                .collect(),
-            _ => return None,
-        },
-        _ => return None,
+    ))
+}
+
+fn text_match_tokens(args: Vec<SqlExpr>, name: &str) -> Result<TextExpr, Error> {
+    let (tokens, field, all) = match args.len() {
+        1 => {
+            let [tokens]: [SqlExpr; 1] = exact(args, name)?;
+            (tokens, None, false)
+        }
+        2 => {
+            let [tokens, field]: [SqlExpr; 2] = exact(args, name)?;
+            (tokens, optional_field(field, name)?, false)
+        }
+        3 => {
+            let [tokens, field, all]: [SqlExpr; 3] = exact(args, name)?;
+            let all = all
+                .as_bool()
+                .ok_or_else(|| Error::Invalid(format!("{name}: all must be a bool literal")))?;
+            (tokens, optional_field(field, name)?, all)
+        }
+        n => sql_invalid!("{name}: expected 1..=3 args, got {n}"),
     };
-    Some(TextExpr::terms(all, terms))
+
+    let value = Value::from_sql(tokens)?;
+    let tokens = match value.value {
+        Some(value::Value::List(values)) => match values.values {
+            Some(list::Values::String(tokens)) => tokens.values,
+            _ => {
+                return Err(Error::Invalid(format!(
+                    "{name}: tokens must be an array of strings"
+                )));
+            }
+        },
+        _ => {
+            return Err(Error::Invalid(format!(
+                "{name}: tokens must be an array of strings"
+            )));
+        }
+    };
+
+    Ok(TextExpr::terms(
+        all,
+        tokens
+            .into_iter()
+            .map(|token| Term {
+                token,
+                field: field.clone(),
+                weight: 1.0,
+            })
+            .collect(),
+    ))
+}
+
+fn optional_field(expr: SqlExpr, name: &str) -> Result<Option<String>, Error> {
+    if let Ok(value) = Value::from_sql(expr.clone()) {
+        if value.as_null().is_some() {
+            return Ok(None);
+        }
+        if let Some(field) = value.as_string() {
+            return Ok(Some(field.to_string()));
+        }
+    }
+
+    expr.as_ident().map(Some).ok_or_else(|| {
+        Error::Invalid(format!(
+            "{name}: field must be an identifier, string, or NULL"
+        ))
+    })
 }
 
 fn f32_literal(expr: SqlExpr) -> Result<f32, Error> {
@@ -281,9 +331,9 @@ fn f32_literal(expr: SqlExpr) -> Result<f32, Error> {
 impl FromSql<SqlFunction> for Value {
     fn from_sql(func: SqlFunction) -> Result<Value, Error> {
         let name = func.name();
-        match SqlFn::try_from(func)? {
-            SqlFn::Literal(v) => Ok(v),
-            SqlFn::Logical(_) | SqlFn::TextMatch { .. } | SqlFn::Function(_) => {
+        match Expr::try_from(func)? {
+            Expr::Literal(v) => Ok(v),
+            Expr::Logical(_) | Expr::Text(_) | Expr::Function(_) => {
                 sql_unsupported!("`{name}` does not produce a Value")
             }
         }
@@ -293,10 +343,14 @@ impl FromSql<SqlFunction> for Value {
 impl FromSql<SqlFunction> for LogicalExpr {
     fn from_sql(func: SqlFunction) -> Result<LogicalExpr, Error> {
         let name = func.name();
-        match SqlFn::try_from(func)? {
-            SqlFn::Logical(expr) | SqlFn::TextMatch { logical: expr, .. } => Ok(expr),
-            SqlFn::Literal(value) => Ok(LogicalExpr::literal(value)),
-            SqlFn::Function(_) => sql_unsupported!(
+        match Expr::try_from(func)? {
+            Expr::Logical(expr) => Ok(expr),
+            Expr::Literal(value) => Ok(LogicalExpr::literal(value)),
+            Expr::Text(_) => sql_unsupported!(
+                "`{name}` is a text filter function — only valid in WHERE (e.g. \
+                 `WHERE {name}('query', field)`)"
+            ),
+            Expr::Function(_) => sql_unsupported!(
                 "`{name}` is a search function — only valid at the top of a SELECT projection \
                  item (e.g. `SELECT {name}(…) AS s FROM c ORDER BY s LIMIT k`)"
             ),

--- a/topk-sql/src/expr/mod.rs
+++ b/topk-sql/src/expr/mod.rs
@@ -7,8 +7,7 @@ mod select;
 mod typed;
 mod value;
 
-pub use function::SqlFn;
-
+#[derive(Clone, Debug)]
 pub enum Expr {
     Literal(Value),
     Logical(LogicalExpr),

--- a/topk-sql/src/expr/select.rs
+++ b/topk-sql/src/expr/select.rs
@@ -2,18 +2,19 @@ use sqlparser::ast::Expr as SqlExpr;
 use topk_rs::proto::v1::data::LogicalExpr;
 use topk_rs::proto::v1::data::stage::select_stage::SelectExpr;
 
-use super::SqlFn;
-use crate::{Error, FromSql};
+use super::Expr;
+use crate::{Error, FromSql, sql_unsupported};
 
 impl FromSql<SqlExpr> for SelectExpr {
     fn from_sql(expr: SqlExpr) -> Result<SelectExpr, Error> {
         match expr {
-            SqlExpr::Function(func) => match SqlFn::try_from(func)? {
-                SqlFn::Function(func) => Ok(SelectExpr::function(func)),
-                SqlFn::Logical(expr) | SqlFn::TextMatch { logical: expr, .. } => {
-                    Ok(SelectExpr::logical(expr))
+            SqlExpr::Function(func) => match Expr::try_from(func)? {
+                Expr::Function(func) => Ok(SelectExpr::function(func)),
+                Expr::Logical(expr) => Ok(SelectExpr::logical(expr)),
+                Expr::Literal(value) => Ok(SelectExpr::logical(LogicalExpr::literal(value))),
+                Expr::Text(_) => {
+                    sql_unsupported!("`match` is a text filter function — only valid in WHERE")
                 }
-                SqlFn::Literal(value) => Ok(SelectExpr::logical(LogicalExpr::literal(value))),
             },
             SqlExpr::Cast { expr, .. } => Ok(SelectExpr::from_sql(*expr)?),
             other => Ok(SelectExpr::logical(LogicalExpr::from_sql(other)?)),

--- a/topk-sql/src/lib.rs
+++ b/topk-sql/src/lib.rs
@@ -14,7 +14,7 @@ pub use ext::{
 };
 
 mod expr;
-pub use expr::{Expr, SqlFn};
+pub use expr::Expr;
 
 mod stmt;
 pub use stmt::{RowFilter, Statement, Variable};

--- a/topk-sql/src/stmt/select.rs
+++ b/topk-sql/src/stmt/select.rs
@@ -62,7 +62,11 @@ impl TryFrom<SqlQuery> for Statement {
 
         // parse WHERE
         if let Some(where_clause) = select.selection {
-            stages.push(Stage::filter(FilterExpr::from_sql(where_clause)?));
+            stages.extend(
+                Vec::<FilterExpr>::from_sql(where_clause)?
+                    .into_iter()
+                    .map(Stage::filter),
+            );
         }
 
         if select.projection.len() == 1 {

--- a/topk-sql/tests/common/context.rs
+++ b/topk-sql/tests/common/context.rs
@@ -159,7 +159,7 @@ impl AsyncTestContext for BooksContext {
                 embedding      f32_vector(4)             INDEX vector_index(metric = 'cosine'),
                 sparse_emb     f32_sparse_vector         INDEX vector_index(metric = 'dot_product'),
                 multi_emb      f32_matrix(4)             INDEX multi_vector_index(metric = 'maxsim'),
-                tags           TEXT[],
+                tags           TEXT[]                    INDEX keyword_index(),
                 checksum       BYTEA,
                 metadata       JSONB
             );

--- a/topk-sql/tests/test_select.rs
+++ b/topk-sql/tests/test_select.rs
@@ -285,10 +285,44 @@ async fn where_regex(#[case] query: &str, #[case] expected: HashSet<&str>) {
 #[case::natural_log("SELECT _id FROM {{table}} WHERE LN(rating) > 1.5", ids!["lotr", "harry"])]
 #[case::exponential("SELECT _id FROM {{table}} WHERE EXP(rating) > 89.0", ids!["lotr", "harry"])]
 #[case::coalesce("SELECT _id FROM {{table}} WHERE COALESCE(rating, 0) >= 4.5", ids!["lotr", "harry"])]
+#[case::match_text_unqualified("SELECT _id FROM {{table}} WHERE match('rings')", ids!["lotr"])]
+#[case::match_text("SELECT _id FROM {{table}} WHERE match('hobbit rings', title)", ids!["hobbit", "lotr"])]
+#[case::match_text_and(
+    "SELECT _id FROM {{table}} WHERE match('lord', title) AND match('rings', title)",
+    ids!["lotr"],
+)]
+#[case::match_text_nested_or_with_logical(
+    "SELECT _id FROM {{table}} WHERE (match('hobbit', title) OR match('rings', title)) AND published_year > 1940",
+    ids!["lotr"],
+)]
+#[case::match_text_nested_or_and(
+    "SELECT _id FROM {{table}} WHERE match('hobbit', title) OR (match('lord', title) AND match('rings', title))",
+    ids!["hobbit", "lotr"],
+)]
+#[case::match_text_all(
+    "SELECT _id FROM {{table}} WHERE match('kill mockingbird', title, 1.0, true)",
+    ids!["mockingbird"],
+)]
+#[case::match_tokens(
+    "SELECT _id FROM {{table}} WHERE match_tokens(ARRAY['hobbit', 'rings'], title)",
+    ids!["hobbit", "lotr"],
+)]
+#[case::match_tokens_all(
+    "SELECT _id FROM {{table}} WHERE match_tokens(ARRAY['lord', 'rings'], title, true)",
+    ids!["lotr"],
+)]
 #[case::match_all("SELECT _id FROM {{table}} WHERE match_all(title, 'kill')", ids!["mockingbird"])]
+#[case::match_all_tokens(
+    "SELECT _id FROM {{table}} WHERE match_all(tags, ARRAY['epic', 'tolkien'])",
+    ids!["lotr"],
+)]
 #[case::match_any(
     "SELECT _id FROM {{table}} WHERE match_any(title, 'hobbit rings')",
     ids!["hobbit", "lotr"],
+)]
+#[case::match_any_tokens(
+    "SELECT _id FROM {{table}} WHERE match_any(tags, ARRAY['adventure', 'epic'])",
+    ids!["hobbit", "lotr", "moby"],
 )]
 #[case::boost_score(
     "SELECT _id, BOOST(rating, in_print = true, 1.5) AS score FROM {{table}} ORDER BY score DESC LIMIT 2",
@@ -406,12 +440,20 @@ async fn limit_caps_results(#[case] query: &str, #[case] expected_len: usize) {
 
 #[rstest]
 #[case::default_args(
-    "SELECT _id, bm25_score() AS score FROM {{table}} WHERE match_any(title, 'rings') ORDER BY score DESC LIMIT 3",
+    "SELECT _id, bm25_score() AS score FROM {{table}} WHERE match('rings', title) ORDER BY score DESC LIMIT 3",
     ids!["lotr"],
 )]
 #[case::custom_args(
-    "SELECT _id, bm25_score(0.75, 1.2) AS score FROM {{table}} WHERE match_any(title, 'rings') ORDER BY score DESC LIMIT 3",
+    "SELECT _id, bm25_score(0.75, 1.2) AS score FROM {{table}} WHERE match('rings', title) ORDER BY score DESC LIMIT 3",
     ids!["lotr"],
+)]
+#[case::with_logical_filter(
+    "SELECT _id, bm25_score() AS score FROM {{table}} WHERE match('hobbit rings', title) AND published_year > 1950 ORDER BY score DESC LIMIT 3",
+    ids!["lotr"],
+)]
+#[case::match_tokens_filter(
+    "SELECT _id, bm25_score() AS score FROM {{table}} WHERE match_tokens(ARRAY['hobbit', 'rings'], title) ORDER BY score DESC LIMIT 3",
+    ids!["hobbit", "lotr"],
 )]
 #[tokio::test]
 async fn bm25_search(#[case] query: &str, #[case] expected: HashSet<&str>) {
@@ -419,6 +461,34 @@ async fn bm25_search(#[case] query: &str, #[case] expected: HashSet<&str>) {
         .await
         .unwrap();
     assert_eq!(ids(&rows), expected);
+}
+
+#[tokio::test]
+async fn bm25_match_weight_orders_results() {
+    let rows = BooksContext::with_scope(async |ctx| {
+        ctx.sql(
+            "SELECT _id, bm25_score() AS score FROM {{table}} \
+             WHERE match('rings', title, 10.0) OR match('hobbit', title, 1.0) \
+             ORDER BY score DESC LIMIT 2",
+        )
+        .await
+    })
+    .await
+    .unwrap();
+
+    let actual = rows.iter().map(|row| row.id().unwrap()).collect::<Vec<_>>();
+    assert_eq!(actual, vec!["lotr", "hobbit"]);
+}
+
+#[tokio::test]
+async fn text_filter_or_text_filter() {
+    let rows = BooksContext::with_scope(async |ctx| {
+        ctx.sql("SELECT _id FROM {{table}} WHERE match('hobbit', title) OR match('rings', title)")
+            .await
+    })
+    .await
+    .unwrap();
+    assert_eq!(ids(&rows), ids!["hobbit", "lotr"]);
 }
 
 #[tokio::test]
@@ -804,6 +874,30 @@ async fn semantic_similarity_search() {
 #[case::bm25_three_args(
     "SELECT bm25_score(0.75, 1.2, 0.5) AS s FROM {{table}} ORDER BY s LIMIT 5",
     "Invalid: bm25_score: expected 0 or 2 args, got 3"
+)]
+#[case::bm25_with_boolean_match(
+    "SELECT _id, bm25_score() AS score FROM {{table}} WHERE match_any(title, 'rings') ORDER BY score DESC LIMIT 3",
+    "Invalid argument: Invalid query: Query must have at least one text filter to compute bm25 scores"
+)]
+#[case::match_or_logical(
+    "SELECT _id FROM {{table}} WHERE match('rings', title) OR published_year = 1813",
+    "Unsupported: match/match_tokens can only be combined with logical filters using AND"
+)]
+#[case::match_tokens_or_logical(
+    "SELECT _id FROM {{table}} WHERE match_tokens(ARRAY['rings'], title) OR published_year = 1813",
+    "Unsupported: match/match_tokens can only be combined with logical filters using AND"
+)]
+#[case::match_non_string_query(
+    "SELECT _id FROM {{table}} WHERE match(123, title)",
+    "Invalid: match: query must be a string literal"
+)]
+#[case::match_non_bool_all(
+    "SELECT _id FROM {{table}} WHERE match('rings', title, 1.0, 'yes')",
+    "Invalid: match: all must be a bool literal"
+)]
+#[case::match_tokens_non_string_array(
+    "SELECT _id FROM {{table}} WHERE match_tokens(ARRAY[1, 2], title)",
+    "Invalid: match_tokens: tokens must be an array of strings"
 )]
 #[case::vector_distance_in_where(
     "SELECT _id FROM {{table}} WHERE vector_distance(embedding, f32_vector(ARRAY[1.0, 0.0, 0.0, 0.0])) > 0",


### PR DESCRIPTION
Adding `match`/`match_tokens` fns used for filtering + bm25 scoring. 

In py/js SDKs, the `filter()` function takes `LogicalExpr | TextExpr`. To achieve this in SQL, we have to split `WHERE` expression on `AND`s and check each term separately. This amounts to translating `logical_filter && text_filter && logical_filter` into `.filter(logical).filter(text).filter(logical).