### PR TITLE
[rs] `should` text expression

### DIFF
--- a/protos/topk/data/v1/expr/text.proto
+++ b/protos/topk/data/v1/expr/text.proto
@@ -13,6 +13,7 @@ message TextExpr {
   message TextTermsExpr {
     bool all = 1;
     repeated Term terms = 2;
+    bool should = 3;
   }
 
   message TextAndExpr {

--- a/topk-rs/src/lib.rs
+++ b/topk-rs/src/lib.rs
@@ -126,6 +126,14 @@ pub mod query {
         )
     }
 
+    pub fn should(text: impl Into<String>, field: Option<&str>, weight: Option<f32>) -> TextExpr {
+        TextExpr::should(vec![Term {
+            token: text.into(),
+            field: field.map(|s| s.to_string()),
+            weight: weight.unwrap_or(1.0),
+        }])
+    }
+
     pub trait AsTerm {
         fn as_term(self) -> (String, f32);
     }

--- a/topk-rs/src/proto/data/v1/query_ext/expr_ext/text.rs
+++ b/topk-rs/src/proto/data/v1/query_ext/expr_ext/text.rs
@@ -8,6 +8,17 @@ impl TextExpr {
         TextExpr {
             expr: Some(text_expr::Expr::Terms(text_expr::TextTermsExpr {
                 all,
+                should: false,
+                terms,
+            })),
+        }
+    }
+
+    pub fn should(terms: Vec<Term>) -> Self {
+        TextExpr {
+            expr: Some(text_expr::Expr::Terms(text_expr::TextTermsExpr {
+                all: false,
+                should: true,
                 terms,
             })),
         }

--- a/topk-rs/tests/test_query_text.rs
+++ b/topk-rs/tests/test_query_text.rs
@@ -4,7 +4,7 @@ use topk_rs::{
     data::literal,
     doc,
     proto::v1::control::{FieldIndex, FieldSpec, KeywordIndexType},
-    query::{field, filter, fns, r#match, select},
+    query::{field, filter, fns, r#match, select, should},
     schema, Error,
 };
 use utils::dataset;
@@ -123,6 +123,60 @@ async fn test_query_text_filter_stop_word(ctx: &mut ProjectTestContext) {
         .expect("could not query");
 
     assert_doc_ids!(result, Vec::<String>::new());
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_text_should_does_not_filter(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            select([("bm25", fns::bm25_score(None, None))])
+                .filter(should("love", Some("summary"), None))
+                .sort(field("bm25"), false)
+                .limit(100),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(result.len(), 10);
+    assert_doc_ids!(&result[..2], ["pride", "gatsby"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_text_should_boosts_bm25_score(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    // the should term only affects ranking - the result set is gated by "love" alone
+    for (boost, expected) in [
+        ("wealth", ["gatsby", "pride"]),
+        ("marriage", ["pride", "gatsby"]),
+    ] {
+        let result = ctx
+            .client
+            .collection(&collection.name)
+            .query(
+                select([("bm25", fns::bm25_score(None, None))])
+                    .filter(
+                        r#match("love", Some("summary"), None, false)
+                            .and(should(boost, Some("summary"), None)),
+                    )
+                    .sort(field("bm25"), false)
+                    .limit(100),
+                None,
+                None,
+            )
+            .await
+            .expect("could not query");
+
+        assert_doc_ids_ordered!(result, expected);
+    }
 }
 
 #[test_context(ProjectTestContext)]


### PR DESCRIPTION
`should(): TextExpr` allows _scoring without filtering_.

Previously, it was impossible to get a text score for a document without excluding documents that don't match the text query from the result set. 

### Example

```rust
// Gate the result set on "love", but let "wealth" boost the score of
// documents that also mention it — without excluding those that don't:
collection.query(
    select([("bm25", fns::bm25_score(None, None))])
        .filter(
            r#match("love", Some("summary"), None, false)
                .and(should("wealth", Some("summary"), None)),
        )
        .sort(field("bm25"), false)
        .limit(10),
    None,
    None,
)
```

A `should`-only filter matches the entire collection — it ranks documents by BM25 without excluding anything.