### PR TITLE
[proto] exact keyword index type

### DIFF
--- a/protos/topk/control/v1/schema.proto
+++ b/protos/topk/control/v1/schema.proto
@@ -119,8 +119,10 @@ enum KeywordIndexType {
   KEYWORD_INDEX_TYPE_UNSPECIFIED = 0;
   // Keyword index
   KEYWORD_INDEX_TYPE_TEXT = 1;
-  // KEYWORD_INDEX_TYPE_CODE = 2;
-  // KEYWORD_INDEX_TYPE_LOG = 3;
+  // Exact keyword index
+  KEYWORD_INDEX_TYPE_EXACT = 2;
+  // KEYWORD_INDEX_TYPE_CODE = 3;
+  // KEYWORD_INDEX_TYPE_LOG = 4;
 }
 
 // Multi-vector index specification

--- a/topk-rs/tests/test_query_text.rs
+++ b/topk-rs/tests/test_query_text.rs
@@ -419,6 +419,56 @@ async fn test_query_text_with_updates(ctx: &mut ProjectTestContext) {
 
 #[test_context(ProjectTestContext)]
 #[tokio::test]
+async fn test_query_text_exact_keyword(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(
+            ctx.wrap("exact_keyword"),
+            schema!(
+                "tag" => FieldSpec::text(true).with_index(FieldIndex::keyword(KeywordIndexType::Exact)),
+            ),
+            None,
+        )
+        .await
+        .expect("could not create collection");
+
+    let lsn = ctx
+        .client
+        .collection(&collection.name)
+        .upsert(vec![
+            doc!("_id" => "nyc", "tag" => "New York City"),
+            doc!("_id" => "camel", "tag" => "CamelCase"),
+        ])
+        .await
+        .expect("upsert failed");
+
+    // The whole value is one verbatim term: only full-value matches hit;
+    // partial tokens and case-normalized values do not.
+    for (token, expected) in [
+        ("New York City", vec!["nyc"]),
+        ("York", vec![]),
+        ("new york city", vec![]),
+        ("CamelCase", vec!["camel"]),
+        ("camelcase", vec![]),
+    ] {
+        let res = ctx
+            .client
+            .collection(&collection.name)
+            .query(
+                filter(r#match(token, Some("tag"), None, false)).limit(10),
+                Some(lsn.clone()),
+                None,
+            )
+            .await
+            .expect("query returned error");
+
+        assert_doc_ids!(res, expected);
+    }
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
 async fn test_query_text_deep_recursion_limit(ctx: &mut ProjectTestContext) {
     let collection = dataset::books::setup(ctx).await;
 


### PR DESCRIPTION
Add support for `type=exact` keyword indexes. As opposed to `type=text` (default), exact indexes skip tokenization and output a single term holding the full input value. 

Example for a document `{ tag: "New York City" }`:
* `type=text` (default): `match("york") -> found, `match("New York")` -> found, `match("New York City")` -> found
* `type=exact`: `match("york")` -> not found, `match("New York")` -> not found, `match("New York City")` -> found
