### PR TITLE
[topk-sql] regex

### DIFF
--- a/topk-sql/src/expr/function.rs
+++ b/topk-sql/src/expr/function.rs
@@ -6,6 +6,7 @@ use topk_rs::proto::v1::data::{
 
 use super::typed::{ElemType, TypedValues, coerce_i64s};
 use crate::expr::Expr;
+use crate::expr::regexp;
 use crate::ext::{SqlExprExt, SqlFunctionExt};
 use crate::{Error, FromSql, sql_invalid, sql_unsupported};
 
@@ -42,6 +43,30 @@ impl TryFrom<SqlFunction> for Expr {
             "match_any" => {
                 let [left, right]: [SqlExpr; 2] = exact(args, &name)?;
                 Self::Logical(LogicalExpr::from_sql(left)?.match_any(LogicalExpr::from_sql(right)?))
+            }
+            "regexp_like" => {
+                let (string, pattern, pg_flags) = match args.len() {
+                    2 => {
+                        let [string, pattern]: [SqlExpr; 2] = exact(args, &name)?;
+                        (string, pattern, None)
+                    }
+                    3 => {
+                        let [string, pattern, flags]: [SqlExpr; 3] = exact(args, &name)?;
+                        (string, pattern, Some(flags))
+                    }
+                    n => sql_invalid!("{name}: expected 2..=3 args, got {n}"),
+                };
+                let pattern = pattern.as_string().ok_or_else(|| {
+                    Error::Invalid(format!("{name}: pattern must be a string literal"))
+                })?;
+                let pg_flags = match pg_flags {
+                    Some(flags) => flags.as_string().ok_or_else(|| {
+                        Error::Invalid(format!("{name}: flags must be a string literal"))
+                    })?,
+                    None => String::new(),
+                };
+                let (pattern, flags) = regexp::translate(&pattern, &pg_flags)?;
+                Self::Logical(LogicalExpr::from_sql(string)?.regexp_match(pattern, flags))
             }
             "match" => Self::Text(text_match(args, &name)?),
             "match_tokens" => Self::Text(text_match_tokens(args, &name)?),

--- a/topk-sql/src/expr/logical.rs
+++ b/topk-sql/src/expr/logical.rs
@@ -1,6 +1,7 @@
 use sqlparser::ast::{BinaryOperator, Expr as SqlExpr, UnaryOperator};
 use topk_rs::proto::v1::data::{LogicalExpr, Value};
 
+use crate::expr::regexp;
 use crate::{Error, FromSql, SqlExprExt, sql_invalid, sql_unsupported};
 
 impl FromSql<SqlExpr> for LogicalExpr {
@@ -27,11 +28,28 @@ impl FromSql<SqlExpr> for LogicalExpr {
             },
 
             SqlExpr::BinaryOp { left, op, right } => {
-                if matches!(op, BinaryOperator::PGRegexMatch) {
+                // (pg_flags, negated)
+                let regexp_op = match op {
+                    BinaryOperator::PGRegexMatch => Some(("", false)),
+                    BinaryOperator::PGRegexIMatch => Some(("i", false)),
+                    BinaryOperator::PGRegexNotMatch => Some(("", true)),
+                    BinaryOperator::PGRegexNotIMatch => Some(("i", true)),
+                    _ => None,
+                };
+                if let Some((pg_flags, negated)) = regexp_op {
                     let pat = right.as_string().ok_or(Error::Unsupported(
                         "regex pattern must be a string literal".to_string(),
                     ))?;
-                    return Ok(LogicalExpr::from_sql(*left)?.regexp_match::<String>(pat, None));
+                    let (pattern, flags) = regexp::translate(&pat, pg_flags)?;
+                    let expr = LogicalExpr::from_sql(*left)?;
+                    let matches = expr.clone().regexp_match(pattern, flags);
+                    // PG's negated operators return NULL for NULL input, which
+                    // filters the row out; a bare NOT would match it instead.
+                    return Ok(if negated {
+                        expr.is_not_null().and(LogicalExpr::not(matches))
+                    } else {
+                        matches
+                    });
                 }
 
                 let l = LogicalExpr::from_sql(*left)?;

--- a/topk-sql/src/expr/mod.rs
+++ b/topk-sql/src/expr/mod.rs
@@ -3,6 +3,7 @@ use topk_rs::proto::v1::data::{FunctionExpr, LogicalExpr, TextExpr, Value};
 mod filter;
 mod function;
 mod logical;
+mod regexp;
 mod select;
 mod typed;
 mod value;

--- a/topk-sql/src/expr/regexp.rs
+++ b/topk-sql/src/expr/regexp.rs
@@ -1,0 +1,128 @@
+use crate::Error;
+
+// Translates a Postgres-style regexp (pattern, flags) pair into Rust regex.
+pub fn translate(pattern: &str, pg_flags: &str) -> Result<(String, Option<String>), Error> {
+    let mut case_insensitive = false;
+    let mut dot_matches_newline = true; // PG default
+    let mut line_anchors = false;
+    let mut expanded = false;
+    let mut literal = false;
+
+    for c in pg_flags.chars() {
+        match c {
+            'i' => case_insensitive = true,
+            'c' => case_insensitive = false,
+            's' => {
+                dot_matches_newline = true;
+                line_anchors = false;
+            }
+            'n' | 'm' => {
+                dot_matches_newline = false;
+                line_anchors = true;
+            }
+            'p' => {
+                dot_matches_newline = false;
+                line_anchors = false;
+            }
+            'w' => {
+                dot_matches_newline = true;
+                line_anchors = true;
+            }
+            'x' => expanded = true,
+            't' => expanded = false,
+            'q' => literal = true,
+            'g' => {
+                return Err(Error::Invalid(
+                    "regexp_like() does not support the \"global\" option".to_string(),
+                ));
+            }
+            'b' | 'e' => {
+                return Err(Error::Unsupported(format!(
+                    "regular expression option \"{c}\" is not supported"
+                )));
+            }
+            other => {
+                return Err(Error::Invalid(format!(
+                    "invalid regular expression option: \"{other}\""
+                )));
+            }
+        }
+    }
+
+    let pattern = if literal {
+        regex::escape(pattern)
+    } else {
+        pattern.to_string()
+    };
+
+    let mut flags = String::new();
+    if dot_matches_newline {
+        flags.push('s');
+    }
+    if line_anchors {
+        flags.push('m');
+    }
+    if case_insensitive {
+        flags.push('i');
+    }
+    // `q` makes the whole pattern literal, so expanded-whitespace mode must
+    // not apply — escaped patterns keep their whitespace significant.
+    if expanded && !literal {
+        flags.push('x');
+    }
+
+    let composed = if flags.is_empty() {
+        pattern.clone()
+    } else {
+        format!("(?{flags}){pattern}")
+    };
+    // Reactor validates too, but only when the expression reaches an executor
+    // compile — validating here makes invalid patterns error unconditionally,
+    // like PG, even for queries that short-circuit before execution.
+    regex::Regex::new(&composed)
+        .map_err(|e| Error::Invalid(format!("invalid regular expression: {e}")))?;
+
+    let flags = if flags.is_empty() { None } else { Some(flags) };
+
+    Ok((pattern, flags))
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::default("foo", "", "foo", Some("s"))]
+    #[case::case_insensitive("foo", "i", "foo", Some("si"))]
+    #[case::case_sensitive_wins("foo", "ic", "foo", Some("s"))]
+    #[case::newline_sensitive("foo", "n", "foo", Some("m"))]
+    #[case::partial_newline("foo", "p", "foo", None)]
+    #[case::inverse_partial("foo", "w", "foo", Some("sm"))]
+    #[case::last_newline_wins("foo", "ns", "foo", Some("s"))]
+    #[case::expanded("f o o", "x", "f o o", Some("sx"))]
+    #[case::tight_wins("foo", "xt", "foo", Some("s"))]
+    #[case::literal("a.b*", "q", "a\\.b\\*", Some("s"))]
+    #[case::literal_ignores_expanded("a b", "qx", "a b", Some("s"))]
+    fn test_translate(
+        #[case] pattern: &str,
+        #[case] pg_flags: &str,
+        #[case] expected_pattern: &str,
+        #[case] expected_flags: Option<&str>,
+    ) {
+        let (pattern, flags) = translate(pattern, pg_flags).unwrap();
+        assert_eq!(pattern, expected_pattern);
+        assert_eq!(flags.as_deref(), expected_flags);
+    }
+
+    #[rstest]
+    #[case::global("foo", "g")]
+    #[case::bre("foo", "b")]
+    #[case::unknown("foo", "z")]
+    #[case::backreference("(a)\\1", "")]
+    fn test_translate_invalid(#[case] pattern: &str, #[case] pg_flags: &str) {
+        let err = translate(pattern, pg_flags).expect_err("translate should fail");
+        assert!(matches!(err, Error::Invalid(..) | Error::Unsupported(..)));
+    }
+}

--- a/topk-sql/src/stmt/select.rs
+++ b/topk-sql/src/stmt/select.rs
@@ -143,7 +143,9 @@ impl TryFrom<SqlQuery> for Statement {
             .flatten();
 
         let (limit, offset) = match query.limit_clause {
-            Some(LimitClause::OffsetCommaLimit { .. }) => unreachable!("postgres dialect does not support `LIMIT offset, limit` should be rejected upstream"),
+            Some(LimitClause::OffsetCommaLimit { .. }) => unreachable!(
+                "postgres dialect does not support `LIMIT offset, limit` should be rejected upstream"
+            ),
             Some(LimitClause::LimitOffset { limit, offset, .. }) => {
                 let limit = limit
                     .map(|ref expr| {

--- a/topk-sql/tests/common/client.rs
+++ b/topk-sql/tests/common/client.rs
@@ -21,7 +21,8 @@ impl SqlClient {
             .unwrap_or("5432".to_string())
             .parse::<u16>()?;
         let user = std::env::var("POSTGRES_USER").unwrap_or_else(|_| "default".to_string());
-        let password = std::env::var("POSTGRES_PASSWORD")?;
+        let password =
+            std::env::var("POSTGRES_PASSWORD").or_else(|_| std::env::var("TOPK_API_KEY"))?;
         let ssl = std::env::var("POSTGRES_SSL").unwrap_or_else(|_| "prefer".to_string());
 
         let opts = PgConnectOptions::new()

--- a/topk-sql/tests/common/client.rs
+++ b/topk-sql/tests/common/client.rs
@@ -21,8 +21,7 @@ impl SqlClient {
             .unwrap_or("5432".to_string())
             .parse::<u16>()?;
         let user = std::env::var("PGUSER").unwrap_or_else(|_| "default".to_string());
-        let password =
-            std::env::var("PGPASSWORD").or_else(|_| std::env::var("TOPK_API_KEY"))?;
+        let password = std::env::var("PGPASSWORD").or_else(|_| std::env::var("TOPK_API_KEY"))?;
         let database = std::env::var("PGDATABASE").unwrap_or_else(|_| "default".to_string());
         let ssl = std::env::var("PGSSLMODE").unwrap_or_else(|_| "prefer".to_string());
 

--- a/topk-sql/tests/common/client.rs
+++ b/topk-sql/tests/common/client.rs
@@ -16,21 +16,22 @@ pub(crate) struct SqlClient {
 
 impl SqlClient {
     pub(crate) async fn from_env() -> anyhow::Result<Self> {
-        let host = std::env::var("POSTGRES_HOST").unwrap_or_else(|_| "localhost".to_string());
-        let port = std::env::var("POSTGRES_PORT")
+        let host = std::env::var("PGHOST").unwrap_or_else(|_| "localhost".to_string());
+        let port = std::env::var("PGPORT")
             .unwrap_or("5432".to_string())
             .parse::<u16>()?;
-        let user = std::env::var("POSTGRES_USER").unwrap_or_else(|_| "default".to_string());
+        let user = std::env::var("PGUSER").unwrap_or_else(|_| "default".to_string());
         let password =
-            std::env::var("POSTGRES_PASSWORD").or_else(|_| std::env::var("TOPK_API_KEY"))?;
-        let ssl = std::env::var("POSTGRES_SSL").unwrap_or_else(|_| "prefer".to_string());
+            std::env::var("PGPASSWORD").or_else(|_| std::env::var("TOPK_API_KEY"))?;
+        let database = std::env::var("PGDATABASE").unwrap_or_else(|_| "default".to_string());
+        let ssl = std::env::var("PGSSLMODE").unwrap_or_else(|_| "prefer".to_string());
 
         let opts = PgConnectOptions::new()
             .host(&host)
             .port(port)
             .username(&user)
             .password(&password)
-            .database("default")
+            .database(&database)
             .ssl_mode(PgSslMode::from_str(&ssl)?);
 
         let pool = PgPoolOptions::new()

--- a/topk-sql/tests/test_regex.rs
+++ b/topk-sql/tests/test_regex.rs
@@ -1,0 +1,61 @@
+use std::collections::HashSet;
+
+use rstest::rstest;
+
+mod common;
+use common::{BooksContext, Scope, TableScope, ids};
+
+#[rstest]
+#[case::prefix("SELECT _id FROM {{table}} WHERE _id ~ '^h'", ids!["hobbit", "harry"])]
+#[case::case_insensitive("SELECT _id FROM {{table}} WHERE author ~ '(?i)tolkien'", ids!["hobbit", "lotr"])]
+#[case::suffix("SELECT _id FROM {{table}} WHERE _id ~ 'r$'", ids!["nineteen_eighty_four", "catcher", "lotr"])]
+#[case::alternation("SELECT _id FROM {{table}} WHERE _id ~ '^(harry|hobbit)$'", ids!["harry", "hobbit"])]
+#[case::char_class("SELECT _id FROM {{table}} WHERE _id ~ '^[a-c]'", ids!["alchemist", "catcher"])]
+#[case::imatch("SELECT _id FROM {{table}} WHERE author ~* 'tolkien'", ids!["hobbit", "lotr"])]
+#[case::not_match(
+    "SELECT _id FROM {{table}} WHERE author !~ '^T'",
+    ids!["mockingbird", "nineteen_eighty_four", "pride", "gatsby", "catcher", "harry", "alchemist", "moby"],
+)]
+#[case::regexp_like("SELECT _id FROM {{table}} WHERE regexp_like(_id, '^h')", ids!["hobbit", "harry"])]
+#[case::regexp_like_flags(
+    "SELECT _id FROM {{table}} WHERE regexp_like(author, 'tolkien', 'i')",
+    ids!["hobbit", "lotr"],
+)]
+#[tokio::test]
+async fn where_regex(#[case] query: &str, #[case] expected: HashSet<&str>) {
+    let rows = BooksContext::with_scope(async |ctx| ctx.sql(query).await)
+        .await
+        .unwrap();
+    assert_eq!(ids(&rows), expected);
+}
+
+#[rstest]
+#[case::backreference("SELECT _id FROM {{table}} WHERE author ~ '(a)\\1'")]
+#[case::global_flag("SELECT _id FROM {{table}} WHERE regexp_like(author, 'a', 'g')")]
+#[tokio::test]
+async fn where_regex_invalid(#[case] query: &str) {
+    BooksContext::with_scope(async |ctx| ctx.sql(query).await)
+        .await
+        .expect_err("query should fail");
+}
+
+#[rstest]
+#[case::dot_matches_newline("WHERE note ~ 'line1.line2'", ids!["multiline"])]
+#[case::newline_sensitive("WHERE regexp_like(note, '^line2$', 'n')", ids!["multiline"])]
+#[case::not_match_skips_null("WHERE note !~ 'line1'", ids!["plain"])]
+#[tokio::test]
+async fn where_regex_newlines_and_nulls(#[case] filter: &str, #[case] expected: HashSet<&str>) {
+    let rows = TableScope::with_scope(async |ctx| {
+        ctx.sql("CREATE TABLE {{table}} (note TEXT)").await?;
+        ctx.sql(
+            "INSERT INTO {{table}} (_id, note) VALUES \
+             ('multiline', 'line1\nline2'), ('missing', NULL), ('plain', 'other')",
+        )
+        .await?;
+        ctx.sql(&format!("SELECT _id FROM {{{{table}}}} {filter}"))
+            .await
+    })
+    .await
+    .unwrap();
+    assert_eq!(ids(&rows), expected);
+}

--- a/topk-sql/tests/test_select.rs
+++ b/topk-sql/tests/test_select.rs
@@ -415,7 +415,10 @@ async fn sort_limit_offset() {
     .await
     .unwrap();
     let actual = rows.iter().map(|row| row.id().unwrap()).collect::<Vec<_>>();
-    assert_eq!(actual, vec!["hobbit", "nineteen_eighty_four", "catcher", "lotr"]);
+    assert_eq!(
+        actual,
+        vec!["hobbit", "nineteen_eighty_four", "catcher", "lotr"]
+    );
 }
 
 #[rstest]

--- a/topk-sql/tests/test_select.rs
+++ b/topk-sql/tests/test_select.rs
@@ -190,52 +190,6 @@ async fn where_in(#[case] query: &str, #[case] expected: HashSet<&str>) {
 }
 
 #[rstest]
-#[case::prefix("WHERE _id LIKE 'h%'", ids!["hobbit", "harry"])]
-#[case::contains("WHERE _id LIKE '%ob%'", ids!["hobbit", "moby"])]
-#[case::exact("WHERE _id LIKE 'gatsby'", ids!["gatsby"])]
-#[case::field_prefix("WHERE author LIKE 'T%'", ids!["hobbit", "lotr"])]
-#[case::field_contains("WHERE title LIKE '%Lord%'", ids!["lotr"])]
-#[case::field_exact("WHERE genre LIKE 'romance'", ids!["pride"])]
-#[tokio::test]
-async fn where_like(#[case] query: &str, #[case] expected: HashSet<&str>) {
-    let rows = BooksContext::with_scope(async |ctx| {
-        ctx.sql(format!("SELECT _id FROM {{{{table}}}} {query}"))
-            .await
-    })
-    .await
-    .unwrap();
-    assert_eq!(ids(&rows), expected);
-}
-
-#[rstest]
-#[case::list_member("WHERE contains(tags, 'tolkien')", ids!["hobbit", "lotr"])]
-#[case::string_substring("WHERE contains(title, 'Lord')", ids!["lotr"])]
-#[tokio::test]
-async fn where_contains(#[case] query: &str, #[case] expected: HashSet<&str>) {
-    let rows = BooksContext::with_scope(async |ctx| {
-        ctx.sql(format!("SELECT _id FROM {{{{table}}}} {query}"))
-            .await
-    })
-    .await
-    .unwrap();
-    assert_eq!(ids(&rows), expected);
-}
-
-#[rstest]
-#[case::prefix("SELECT _id FROM {{table}} WHERE _id ~ '^h'", ids!["hobbit", "harry"])]
-#[case::case_insensitive("SELECT _id FROM {{table}} WHERE author ~ '(?i)tolkien'", ids!["hobbit", "lotr"])]
-#[case::suffix("SELECT _id FROM {{table}} WHERE _id ~ 'r$'", ids!["nineteen_eighty_four", "catcher", "lotr"])]
-#[case::alternation("SELECT _id FROM {{table}} WHERE _id ~ '^(harry|hobbit)$'", ids!["harry", "hobbit"])]
-#[case::char_class("SELECT _id FROM {{table}} WHERE _id ~ '^[a-c]'", ids!["alchemist", "catcher"])]
-#[tokio::test]
-async fn where_regex(#[case] query: &str, #[case] expected: HashSet<&str>) {
-    let rows = BooksContext::with_scope(async |ctx| ctx.sql(query).await)
-        .await
-        .unwrap();
-    assert_eq!(ids(&rows), expected);
-}
-
-#[rstest]
 #[case::add_expr(
     "SELECT _id FROM {{table}} WHERE published_year + 100 > 2050",
     ids!["mockingbird", "catcher", "lotr", "harry", "alchemist"],


### PR DESCRIPTION
Add proper regex handling to topk-sql: `~`, `~*`, `!~`, `!~*` and `regexp_like(str, pattern[, flags])` are now supported.