### PR TITLE
[topk-rs] expect unauthenticated on invalid api key

### DIFF
--- a/topk-rs/tests/test_client.rs
+++ b/topk-rs/tests/test_client.rs
@@ -24,7 +24,7 @@ async fn test_invalid_api_key() {
         .await
         .expect_err("should not be able to list collections");
 
-    assert!(matches!(response, Error::PermissionDenied));
+    assert!(matches!(response, Error::Unauthenticated(_)));
 }
 
 #[test_context(ProjectTestContext)]


### PR DESCRIPTION
Rejected api keys now come back as HTTP 401 / gRPC `UNAUTHENTICATED` instead of 403 / `PERMISSION_DENIED` (topk-io/ddb#1834). Update the assertion to match.