### PR TITLE
[es] track `hits.total`

### DIFF
--- a/topk-es/src/api/search.rs
+++ b/topk-es/src/api/search.rs
@@ -363,6 +363,7 @@ impl SearchResponse {
         index: &IndexName,
         hits: Vec<Hit>,
         aggregations: Option<HashMap<String, AggResult>>,
+        matched: &[u64],
     ) -> Self {
         let max_score = hits.iter().filter_map(|h| h.score).reduce(f32::max);
         Self {
@@ -370,9 +371,22 @@ impl SearchResponse {
             timed_out: false,
             shards: Shards::default(),
             hits: HitsWrapper {
-                total: Total {
-                    value: hits.len() as u64,
-                    relation: "eq",
+                total: match matched {
+                    // No matched documents
+                    [] => Total {
+                        value: hits.len() as u64,
+                        relation: "eq",
+                    },
+                    // Single retriever
+                    [matched] => Total {
+                        value: *matched,
+                        relation: "eq",
+                    },
+                    // Multiple retrievers
+                    m => Total {
+                        value: m.iter().copied().max().unwrap().max(hits.len() as u64),
+                        relation: "gte",
+                    },
                 },
                 max_score,
                 hits: hits

--- a/topk-es/src/api/search.rs
+++ b/topk-es/src/api/search.rs
@@ -372,10 +372,10 @@ impl SearchResponse {
             shards: Shards::default(),
             hits: HitsWrapper {
                 total: match matched {
-                    // No matched documents
+                    // No matched counts reported, so hits are only a lower bound
                     [] => Total {
                         value: hits.len() as u64,
-                        relation: "eq",
+                        relation: "gte",
                     },
                     // Single retriever
                     [matched] => Total {

--- a/topk-es/tests/aggs.rs
+++ b/topk-es/tests/aggs.rs
@@ -1,9 +1,9 @@
 mod common;
 
 use common::{BooksContext, TestScope};
-use test_macros::rstest_ctx;
 use serde_json::{json, Value};
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 #[test_context(BooksContext)]
 #[tokio::test]
@@ -37,7 +37,7 @@ async fn test_terms_agg_with_avg_sub_agg(books: &BooksContext) {
 
 #[test_context(BooksContext)]
 #[tokio::test]
-async fn bug_bare_metric_agg_with_size_zero(books: &BooksContext) {
+async fn test_bare_metric_agg_with_size_zero(books: &BooksContext) {
     let resp = books
         .search(json!({
             "size": 0,
@@ -47,7 +47,7 @@ async fn bug_bare_metric_agg_with_size_zero(books: &BooksContext) {
         .expect("search should succeed");
 
     assert_eq!(resp.hit_ids().len(), 0);
-    assert_eq!(resp.total(), 0);
+    assert_eq!(resp.total(), 10);
 
     let value = resp.agg_value("avg_rating");
     assert!((value - 4.12).abs() < 1e-6);

--- a/topk-es/tests/bulk.rs
+++ b/topk-es/tests/bulk.rs
@@ -1,10 +1,10 @@
 mod common;
 
 use common::{TestScope, TwoIndices};
-use test_macros::rstest_ctx;
 use elasticsearch::{http::StatusCode, params::Refresh, BulkOperation, BulkOperations, BulkParts};
 use serde_json::{json, Value};
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 #[test_context(TestScope)]
 #[tokio::test]

--- a/topk-es/tests/common/mod.rs
+++ b/topk-es/tests/common/mod.rs
@@ -334,6 +334,15 @@ impl TestErrorResponse {
 #[derive(Debug)]
 pub struct SearchResponse(pub Value);
 
+pub fn hit_ids(response: &Value) -> Vec<String> {
+    response["hits"]["hits"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|h| h["_id"].as_str().unwrap().to_string())
+        .collect()
+}
+
 impl std::ops::Deref for SearchResponse {
     type Target = Value;
 
@@ -349,10 +358,6 @@ impl std::fmt::Display for SearchResponse {
 }
 
 impl SearchResponse {
-    pub fn hit_ids(&self) -> Vec<String> {
-        hit_ids(&self.0)
-    }
-
     pub fn score(&self, id: &str) -> f64 {
         self.hit(id)["_score"].as_f64().unwrap()
     }
@@ -371,6 +376,10 @@ impl SearchResponse {
 
     pub fn total(&self) -> u64 {
         self.0["hits"]["total"]["value"].as_u64().unwrap()
+    }
+
+    pub fn total_relation(&self) -> &str {
+        self.0["hits"]["total"]["relation"].as_str().unwrap()
     }
 
     pub fn all_scores_null(&self) -> bool {
@@ -407,6 +416,10 @@ impl SearchResponse {
             .expect("aggregation buckets")
     }
 
+    pub fn hit_ids(&self) -> Vec<String> {
+        hit_ids(&self.0)
+    }
+
     fn hits(&self) -> &Vec<Value> {
         self.0["hits"]["hits"].as_array().unwrap()
     }
@@ -417,15 +430,6 @@ impl SearchResponse {
             .find(|h| h["_id"] == id)
             .unwrap_or_else(|| panic!("hit {id} not found: {}", self.0))
     }
-}
-
-pub fn hit_ids(response: &Value) -> Vec<String> {
-    response["hits"]["hits"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|h| h["_id"].as_str().unwrap().to_string())
-        .collect()
 }
 
 #[derive(Debug)]

--- a/topk-es/tests/count.rs
+++ b/topk-es/tests/count.rs
@@ -1,9 +1,9 @@
 mod common;
 
 use common::{BooksContext, TestScope};
-use test_macros::rstest_ctx;
 use elasticsearch::http::StatusCode;
 use serde_json::{json, Value};
+use test_macros::rstest_ctx;
 
 #[rstest_ctx(TestScope)]
 #[case::no_query(None, 0)]

--- a/topk-es/tests/doc.rs
+++ b/topk-es/tests/doc.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use common::TestScope;
-use test_macros::rstest_ctx;
 use elasticsearch::{
     http::StatusCode,
     indices::{IndicesCreateParts, IndicesDeleteParts, IndicesExistsParts},
@@ -9,6 +8,7 @@ use elasticsearch::{
 };
 use serde_json::{json, Value};
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 #[test_context(TestScope)]
 #[tokio::test]

--- a/topk-es/tests/keyword.rs
+++ b/topk-es/tests/keyword.rs
@@ -1,10 +1,10 @@
 mod common;
 
 use common::TestScope;
-use test_macros::rstest_ctx;
 use elasticsearch::http::StatusCode;
 use serde_json::json;
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 // A keyword field indexes the whole value as one verbatim term, so `match`
 // only matches the entire value — not a partial token, and case-sensitively.

--- a/topk-es/tests/knn.rs
+++ b/topk-es/tests/knn.rs
@@ -1,10 +1,10 @@
 mod common;
 
 use common::{BooksContext, TestScope};
-use test_macros::rstest_ctx;
 use elasticsearch::http::StatusCode;
 use serde_json::{json, Value};
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 async fn setup_hybrid_docs(scope: &TestScope) {
     scope
@@ -229,6 +229,65 @@ async fn test_knn_with_filter(scope: &TestScope) {
         vec!["2"],
         "filter should restrict candidates before ranking: {body}"
     );
+    assert_eq!(body.total(), 1, "{body}");
+}
+
+#[test_context(TestScope)]
+#[tokio::test]
+async fn dev_knn_total_reports_matched_count(scope: &TestScope) {
+    scope
+        .create_with_properties(json!({
+            "category": { "type": "keyword" },
+            "embedding": { "type": "dense_vector", "dims": 4, "similarity": "cosine" }
+        }))
+        .await;
+
+    scope
+        .index_docs([
+            (
+                "1",
+                json!({ "category": "a", "embedding": [1.0, 0.0, 0.0, 0.0] }),
+            ),
+            (
+                "2",
+                json!({ "category": "a", "embedding": [0.9, 0.1, 0.0, 0.0] }),
+            ),
+            (
+                "3",
+                json!({ "category": "a", "embedding": [0.0, 1.0, 0.0, 0.0] }),
+            ),
+            (
+                "4",
+                json!({ "category": "b", "embedding": [0.8, 0.2, 0.0, 0.0] }),
+            ),
+        ])
+        .await;
+
+    let body = scope
+        .search(json!({
+            "knn": {
+                "field": "embedding",
+                "query_vector": [1.0, 0.0, 0.0, 0.0],
+                "k": 1,
+                "filter": { "term": { "category": "a" } }
+            }
+        }))
+        .await
+        .expect("search should succeed");
+
+    assert_eq!(body.hit_ids(), vec!["1"], "{body}");
+    // ES reports `k` here; we deliberately report the filter match count.
+    assert_eq!(body.total(), 3, "{body}");
+    assert_eq!(body.total_relation(), "eq", "{body}");
+
+    // Unfiltered: every doc matches, so total is the corpus, not `k`.
+    let body = scope
+        .search(json!({
+            "knn": { "field": "embedding", "query_vector": [1.0, 0.0, 0.0, 0.0], "k": 1 }
+        }))
+        .await
+        .expect("search should succeed");
+    assert_eq!(body.total(), 4, "{body}");
 }
 
 #[test_context(TestScope)]
@@ -388,9 +447,10 @@ async fn dev_knn_query_rrf_unions_retrievers_without_phantom_hits(scope: &TestSc
     let ids = body.hit_ids();
     assert_eq!(
         body.total(),
-        3,
-        "fusion should union the retrievers (1 term + 2 knn), not the whole index: {body}"
+        7,
+        "unfiltered knn matches every doc, so its count dominates the gte bound: {body}"
     );
+    assert_eq!(body.total_relation(), "gte", "{body}");
     assert!(ids.contains(&"text".to_string()), "{body}");
     assert!(ids.contains(&"vec1".to_string()), "{body}");
     assert!(ids.contains(&"vec2".to_string()), "{body}");

--- a/topk-es/tests/mapping.rs
+++ b/topk-es/tests/mapping.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use common::TestScope;
-use test_macros::rstest_ctx;
 use elasticsearch::{
     http::StatusCode,
     indices::{IndicesCreateParts, IndicesExistsParts, IndicesGetMappingParts, IndicesGetParts},
@@ -9,6 +8,7 @@ use elasticsearch::{
 };
 use serde_json::{json, Value};
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 #[rstest_ctx(TestScope)]
 #[case::match_text(json!({ "match": { "title": "hello" } }))]

--- a/topk-es/tests/search.rs
+++ b/topk-es/tests/search.rs
@@ -1,10 +1,10 @@
 mod common;
 
 use common::{BooksContext, TestScope};
-use test_macros::rstest_ctx;
 use elasticsearch::http::StatusCode;
 use serde_json::{json, Value};
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 async fn setup_bool_scoring_docs(scope: &TestScope) {
     scope
@@ -317,7 +317,7 @@ async fn dev_range_array_bound_rejected_on_bare_index(scope: &TestScope) {
 
 #[test_context(TestScope)]
 #[tokio::test]
-async fn bug_size_limited_total_reports_returned_hits(scope: &TestScope) {
+async fn test_size_limited_total_reports_all_matches(scope: &TestScope) {
     scope.create().await;
 
     let docs: Vec<(String, Value)> = (0..5).map(|i| (i.to_string(), json!({ "n": i }))).collect();
@@ -331,12 +331,26 @@ async fn bug_size_limited_total_reports_returned_hits(scope: &TestScope) {
         .await
         .expect("search should succeed");
     assert_eq!(body.hit_ids().len(), 2, "{body}");
-    assert_eq!(body.total(), 2, "{body}");
+    assert_eq!(body.total(), 5, "{body}");
+    assert_eq!(body.total_relation(), "eq", "{body}");
+}
+
+#[test_context(BooksContext)]
+#[tokio::test]
+async fn test_term_query_total_reports_match_count(books: &BooksContext) {
+    let body = books
+        .search(json!({ "query": { "term": { "genre": "fiction" } }, "size": 2 }))
+        .await
+        .expect("search should succeed");
+    assert_eq!(body.hit_ids().len(), 2, "{body}");
+    // 4 fiction books: total is the match count, not hits (2) or corpus (10).
+    assert_eq!(body.total(), 4, "{body}");
+    assert_eq!(body.total_relation(), "eq", "{body}");
 }
 
 #[test_context(TestScope)]
 #[tokio::test]
-async fn bug_size_zero_returns_no_hits(scope: &TestScope) {
+async fn test_size_zero_returns_no_hits_but_full_total(scope: &TestScope) {
     scope.create().await;
 
     scope.index_docs([("1", json!({ "n": 1 }))]).await;
@@ -346,7 +360,7 @@ async fn bug_size_zero_returns_no_hits(scope: &TestScope) {
         .await
         .expect("size: 0 should succeed, not be rejected");
     assert_eq!(body.hit_ids().len(), 0, "{body}");
-    assert_eq!(body.total(), 0, "{body}");
+    assert_eq!(body.total(), 1, "{body}");
 }
 
 // ES serves `_search` over GET as well as POST, body in either.
@@ -569,6 +583,11 @@ async fn test_from_size_pagination(
         .await
         .expect("search should succeed");
     assert_eq!(body.hit_ids(), expected, "{body}");
+    assert_eq!(
+        body.total(),
+        4,
+        "total spans all matches across pages: {body}"
+    );
 }
 
 #[test_context(TestScope)]

--- a/topk-es/tests/semantic.rs
+++ b/topk-es/tests/semantic.rs
@@ -1,10 +1,10 @@
 mod common;
 
 use common::TestScope;
-use test_macros::rstest_ctx;
 use elasticsearch::http::StatusCode;
 use serde_json::{json, Value};
 use test_context::test_context;
+use test_macros::rstest_ctx;
 
 #[test_context(TestScope)]
 #[tokio::test]
@@ -33,6 +33,7 @@ async fn test_semantic_with_sort_orders_by_field(scope: &TestScope) {
         .expect("search should succeed");
 
     assert_eq!(body.hit_ids(), vec!["b", "a"], "{body}");
+    assert_eq!(body.total(), 2, "{body}");
     assert!(body.all_scores_null());
 }
 
@@ -75,6 +76,7 @@ async fn test_knn_with_semantic_query_combines_retrievers(scope: &TestScope) {
     let ids = body.hit_ids();
     assert!(ids.contains(&"vec".to_string()));
     assert!(ids.contains(&"sem".to_string()));
+    assert_eq!(body.total(), 2, "{body}");
 }
 
 #[rstest_ctx(TestScope)]

--- a/topk-js/src/schema/data_type.rs
+++ b/topk-js/src/schema/data_type.rs
@@ -215,6 +215,9 @@ impl From<topk_rs::proto::v1::control::FieldType> for DataType {
                         value_type: matrix.value_type().into(),
                     }
                 }
+                topk_rs::proto::v1::control::field_type::DataType::Timestamp(_) => {
+                    unimplemented!("timestamp: see #530")
+                }
             },
             None => unreachable!("Invalid data type proto"),
         }

--- a/topk-py/src/schema/data_type.rs
+++ b/topk-py/src/schema/data_type.rs
@@ -281,6 +281,9 @@ impl From<topk_rs::proto::v1::control::field_type::DataType> for DataType {
                 dimension: matrix.dimension,
                 value_type: matrix.value_type().into(),
             },
+            topk_rs::proto::v1::control::field_type::DataType::Timestamp(_) => {
+                unimplemented!("timestamp: see #530")
+            }
         }
     }
 }

--- a/topk-rs/src/client/collection.rs
+++ b/topk-rs/src/client/collection.rs
@@ -1,19 +1,20 @@
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use futures::{Stream, TryStreamExt};
 use futures_util::{StreamExt, TryFutureExt};
 use prost::Message;
 use tokio::sync::OnceCell;
 use tonic::transport::Channel;
+use tonic::{Response, Streaming};
 
 use crate::create_client;
 use crate::error::Error;
 use crate::proto::v1::data::partition_service_client::PartitionServiceClient;
 use crate::proto::v1::data::query_service_client::QueryServiceClient;
 use crate::proto::v1::data::write_service_client::WriteServiceClient;
-use crate::proto::v1::data::DeletePartitionRequest;
 use crate::proto::v1::data::ListPartitionsRequest;
 use crate::proto::v1::data::Partition;
 use crate::proto::v1::data::Query;
@@ -23,9 +24,50 @@ use crate::proto::v1::data::{ConsistencyLevel, GetRequest};
 use crate::proto::v1::data::{
     DeleteDocumentsRequest, Document, QueryRequest, UpsertDocumentsRequest, Value,
 };
+use crate::proto::v1::data::{DeletePartitionRequest, DocumentData};
 
 use super::config::ClientConfig;
 use super::retry::call_with_retry;
+
+pub struct DocumentStream {
+    // Underying stream
+    stream: Pin<Box<dyn Stream<Item = Result<Document, Error>> + Send>>,
+    // Number of matched candidate documents
+    matched_count: Option<u64>,
+}
+
+impl DocumentStream {
+    pub fn new(response: Response<Streaming<DocumentData>>) -> Self {
+        let matched_count = response
+            .metadata()
+            .get("x-topk-matched-count")
+            .and_then(|v| v.to_str().ok()?.parse().ok());
+
+        let stream = response
+            .into_inner()
+            .map(|result| match Document::decode(result?.data) {
+                Ok(doc) => Ok(doc),
+                Err(e) => Err(Error::MalformedResponse(e.to_string())),
+            });
+
+        Self {
+            stream: Box::pin(stream),
+            matched_count,
+        }
+    }
+
+    pub fn matched_count(&self) -> Option<u64> {
+        self.matched_count
+    }
+}
+
+impl Stream for DocumentStream {
+    type Item = Result<Document, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.stream.as_mut().poll_next(cx)
+    }
+}
 
 #[derive(Clone)]
 pub struct CollectionClient {
@@ -165,10 +207,10 @@ impl CollectionClient {
         query: Query,
         lsn: Option<String>,
         consistency: Option<ConsistencyLevel>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Document, Error>> + Send>>, Error> {
+    ) -> Result<DocumentStream, Error> {
         let client = create_client!(QueryServiceClient, self.read, self.config).await?;
 
-        let stream = call_with_retry(&self.config.retry_config(), || {
+        let response = call_with_retry(&self.config.retry_config(), || {
             let mut client = client.clone();
             let query = query.clone();
             let lsn = lsn.clone();
@@ -186,15 +228,9 @@ impl CollectionClient {
                     .await
             }
         })
-        .await?
-        .into_inner();
+        .await?;
 
-        let stream = stream.map(|result| match Document::decode(result?.data) {
-            Ok(doc) => Ok(doc),
-            Err(e) => Err(Error::MalformedResponse(e.to_string())),
-        });
-
-        Ok(Box::pin(stream))
+        Ok(DocumentStream::new(response))
     }
 
     /// Upsert documents into the collection.

--- a/topk-rs/src/client/mod.rs
+++ b/topk-rs/src/client/mod.rs
@@ -11,6 +11,7 @@ pub use datasets::DatasetsClient;
 
 mod collection;
 pub use collection::CollectionClient;
+pub use collection::DocumentStream;
 
 mod dataset;
 pub use dataset::DatasetClient;

--- a/topk-rs/tests/test_query_matched.rs
+++ b/topk-rs/tests/test_query_matched.rs
@@ -1,0 +1,90 @@
+use futures::TryStreamExt;
+use test_context::test_context;
+
+use topk_rs::data::literal;
+use topk_rs::proto::v1::data::stage::sort_stage::SortOrder;
+use topk_rs::query::{field, filter, fns, select};
+
+mod utils;
+use utils::dataset;
+use utils::ProjectTestContext;
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_matched_count_reported_for_sorted(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let stream = ctx
+        .client
+        .collection(&collection.name)
+        .query_stream(
+            filter(field("published_year").gte(literal(1950_u32)))
+                .sort("published_year")
+                .limit(2),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    // 5 books from 1950 on; matched is the filter count, not hits or corpus.
+    assert_eq!(stream.matched_count(), Some(5));
+
+    let docs = stream
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("could not collect");
+    assert_eq!(docs.len(), 2);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_matched_count_reported_for_vector(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let stream = ctx
+        .client
+        .collection(&collection.name)
+        .query_stream(
+            select([(
+                "summary_distance",
+                fns::vector_distance("summary_embedding", vec![2.0; 16]),
+            )])
+            .filter(field("published_year").gte(literal(1950_u32)))
+            .sort((field("summary_distance"), SortOrder::Asc))
+            .limit(2),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    // 5 books from 1950 on; the count survives the candidate-topk -> rerank -> sort rewrite.
+    assert_eq!(stream.matched_count(), Some(5));
+
+    let docs = stream
+        .try_collect::<Vec<_>>()
+        .await
+        .expect("could not collect");
+    assert_eq!(docs.len(), 2);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_matched_count_absent_for_unsorted(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let stream = ctx
+        .client
+        .collection(&collection.name)
+        .query_stream(
+            filter(field("published_year").gte(literal(1950_u32))).limit(2),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    // A bare limit exits early, so no complete count exists to report.
+    assert_eq!(stream.matched_count(), None);
+}

--- a/topk-sql/src/expr/filter.rs
+++ b/topk-sql/src/expr/filter.rs
@@ -52,10 +52,7 @@ impl FromSql<SqlExpr> for TextExpr {
     fn from_sql(expr: SqlExpr) -> Result<TextExpr, Error> {
         match expr {
             SqlExpr::Nested(inner) => FromSql::from_sql(*inner),
-            SqlExpr::Function(func)
-                if func.name().eq_ignore_ascii_case("match")
-                    || func.name().eq_ignore_ascii_case("match_tokens") =>
-            {
+            SqlExpr::Function(func) if is_text_fn(&func.name()) => {
                 match Expr::try_from(func.clone())? {
                     Expr::Text(expr) => Ok(expr),
                     _ => sql_invalid!("Expected match or match_tokens function"),
@@ -120,10 +117,13 @@ fn contains_text_expr(expr: &SqlExpr) -> bool {
 fn is_text_expr(expr: &SqlExpr) -> bool {
     match expr {
         SqlExpr::Nested(inner) => is_text_expr(inner),
-        SqlExpr::Function(func) => {
-            let name = func.name();
-            name.eq_ignore_ascii_case("match") || name.eq_ignore_ascii_case("match_tokens")
-        }
+        SqlExpr::Function(func) => is_text_fn(&func.name()),
         _ => false,
     }
+}
+
+fn is_text_fn(name: &str) -> bool {
+    ["match", "match_tokens", "should"]
+        .iter()
+        .any(|f| name.eq_ignore_ascii_case(f))
 }

--- a/topk-sql/src/stmt/select.rs
+++ b/topk-sql/src/stmt/select.rs
@@ -24,9 +24,8 @@ fn is_aggregate_fn(func: &SqlFunction) -> bool {
 
 fn is_count_star(func: &SqlFunction) -> bool {
     func.is_count()
-        && func.matches_args(|args| {
-            matches!(args, [FunctionArg::Unnamed(FunctionArgExpr::Wildcard)])
-        })
+        && func
+            .matches_args(|args| matches!(args, [FunctionArg::Unnamed(FunctionArgExpr::Wildcard)]))
 }
 
 /// Lowers a `GROUP BY` query into a `group_by` stage (plus an optional `HAVING` filter stage)


### PR DESCRIPTION
`hits.total` now reports the true match count, not the number of returned hits