### PR TITLE
[proto/rs] timestamp type and datetime ops

### DIFF
--- a/protos/topk/control/v1/schema.proto
+++ b/protos/topk/control/v1/schema.proto
@@ -39,6 +39,7 @@ message FieldType {
     FieldTypeF8SparseVector f8_sparse_vector = 17;
     FieldTypeF16SparseVector f16_sparse_vector = 18;
     FieldTypeStruct struct = 19;
+    FieldTypeTimestamp timestamp = 20;
   }
 }
 
@@ -46,6 +47,7 @@ message FieldTypeText {}
 message FieldTypeInteger {}
 message FieldTypeFloat {}
 message FieldTypeBoolean {}
+message FieldTypeTimestamp {}
 
 message FieldTypeF32Vector {
   uint32 dimension = 1;

--- a/protos/topk/data/v1/expr/logical.proto
+++ b/protos/topk/data/v1/expr/logical.proto
@@ -51,6 +51,7 @@ message LogicalExpr {
       OP_MAX = 19;
       //
       OP_IN = 20;
+      OP_DATE_PART = 21;
     }
     Op op = 1;
     LogicalExpr left = 2;
@@ -63,6 +64,9 @@ message LogicalExpr {
       OP_UNSPECIFIED = 0;
       OP_CHOOSE = 1;
       OP_REGEXP_MATCH = 2;
+      OP_ELAPSED = 3;
+      OP_SATURATE = 4;
+      OP_DECAY = 5;
     }
     Op op = 1;
     LogicalExpr x = 2;

--- a/protos/topk/data/v1/value.proto
+++ b/protos/topk/data/v1/value.proto
@@ -30,6 +30,8 @@ message Value {
     Struct struct = 18;
     // Matrix
     Matrix matrix = 19;
+    // Timestamp (milliseconds since UNIX epoch)
+    int64 timestamp = 20;
   }
 }
 

--- a/topk-rs/Cargo.toml
+++ b/topk-rs/Cargo.toml
@@ -36,6 +36,7 @@ float8 = { version = "0.5.0", features = ["bytemuck"] }
 futures = { version = "0.3" }
 infer = "0.16"
 mime_guess = "2.0.5"
+chrono = { version = "0.4.35" }
 
 [dev-dependencies]
 test-context = { version = "0.3.0" }

--- a/topk-rs/build.rs
+++ b/topk-rs/build.rs
@@ -95,6 +95,7 @@ fn build_topk_v1_protos() {
         "topk.control.v1.FieldTypeBytes",
         "topk.control.v1.FieldTypeList",
         "topk.control.v1.FieldTypeStruct",
+        "topk.control.v1.FieldTypeTimestamp",
         // indexes
         "topk.control.v1.FieldIndex",
         "topk.control.v1.FieldIndex.index",

--- a/topk-rs/src/json.rs
+++ b/topk-rs/src/json.rs
@@ -228,6 +228,7 @@ impl TryFrom<TopkValue> for serde_json::Value {
             Some(value::Value::I64(v)) => Ok(Self::from(v)),
             Some(value::Value::F32(v)) => number(v),
             Some(value::Value::F64(v)) => number(v),
+            Some(value::Value::Timestamp(v)) => Ok(Self::from(v)),
             Some(value::Value::Binary(v)) => {
                 Ok(Self::Array(v.into_iter().map(Self::from).collect()))
             }

--- a/topk-rs/src/proto/control/v1/field_spec_ext.rs
+++ b/topk-rs/src/proto/control/v1/field_spec_ext.rs
@@ -43,6 +43,14 @@ impl FieldSpec {
         }
     }
 
+    pub fn timestamp(required: bool) -> FieldSpec {
+        FieldSpec {
+            data_type: Some(FieldType::timestamp()),
+            required,
+            index: None,
+        }
+    }
+
     pub fn bytes(required: bool) -> FieldSpec {
         FieldSpec {
             data_type: Some(FieldType::bytes()),

--- a/topk-rs/src/proto/control/v1/field_type_ext.rs
+++ b/topk-rs/src/proto/control/v1/field_type_ext.rs
@@ -29,6 +29,12 @@ impl FieldType {
         }
     }
 
+    pub fn timestamp() -> Self {
+        FieldType {
+            data_type: Some(field_type::DataType::Timestamp(FieldTypeTimestamp {})),
+        }
+    }
+
     pub fn bytes() -> Self {
         FieldType {
             data_type: Some(field_type::DataType::Bytes(FieldTypeBytes {})),

--- a/topk-rs/src/proto/control/v1/mod.rs
+++ b/topk-rs/src/proto/control/v1/mod.rs
@@ -12,6 +12,7 @@ impl field_type::DataType {
             field_type::DataType::Integer(..) => "integer".to_string(),
             field_type::DataType::Float(..) => "float".to_string(),
             field_type::DataType::Boolean(..) => "boolean".to_string(),
+            field_type::DataType::Timestamp(..) => "timestamp".to_string(),
             // Dense vector
             field_type::DataType::F32Vector(..) => "vector<f32>".to_string(),
             field_type::DataType::F16Vector(..) => "vector<f16>".to_string(),

--- a/topk-rs/src/proto/data/v1/data_ext/mod.rs
+++ b/topk-rs/src/proto/data/v1/data_ext/mod.rs
@@ -1,10 +1,42 @@
 use bytemuck::allocation::cast_vec;
+use chrono::{DateTime, TimeZone};
 
 use crate::proto::data::v1::{list, matrix};
 
 mod document;
 mod sparse_vector;
 mod value;
+
+// Timestamp
+
+pub trait IntoTimestamp {
+    /// Convert the value to milliseconds since UNIX epoch.
+    fn timestamp_ms(self) -> i64;
+}
+
+impl IntoTimestamp for u32 {
+    fn timestamp_ms(self) -> i64 {
+        self as i64
+    }
+}
+
+impl IntoTimestamp for i32 {
+    fn timestamp_ms(self) -> i64 {
+        self as i64
+    }
+}
+
+impl IntoTimestamp for i64 {
+    fn timestamp_ms(self) -> i64 {
+        self
+    }
+}
+
+impl<TZ: TimeZone> IntoTimestamp for DateTime<TZ> {
+    fn timestamp_ms(self) -> i64 {
+        self.to_utc().timestamp_millis()
+    }
+}
 
 // List values
 

--- a/topk-rs/src/proto/data/v1/data_ext/value.rs
+++ b/topk-rs/src/proto/data/v1/data_ext/value.rs
@@ -1,10 +1,11 @@
 use bytemuck::{cast_slice, cast_vec};
 use bytes::Bytes;
+use chrono::{DateTime, TimeZone, Utc};
 use float8::F8E4M3;
 use std::collections::HashMap;
 
 use crate::proto::data::v1::{
-    data_ext::{IntoListValues, IntoMatrixValues},
+    data_ext::{IntoListValues, IntoMatrixValues, IntoTimestamp},
     list, matrix, sparse_vector, value, vector, List, Matrix, Null, SparseVector, Struct, Value,
 };
 
@@ -193,6 +194,31 @@ impl Value {
         }
     }
 
+    /// Create a timestamp from the provided value
+    pub fn timestamp(value: impl IntoTimestamp) -> Self {
+        Value {
+            value: Some(value::Value::Timestamp(value.timestamp_ms())),
+        }
+    }
+
+    /// Get the timestamp as milliseconds since UNIX epoch.
+    pub fn as_timestamp(&self) -> Option<i64> {
+        match &self.value {
+            Some(value::Value::U32(value)) => Some(*value as i64),
+            Some(value::Value::U64(value)) if *value <= (i64::MAX as u64) => Some(*value as i64),
+            Some(value::Value::I32(value)) => Some(*value as i64),
+            Some(value::Value::I64(value)) => Some(*value),
+            Some(value::Value::Timestamp(value)) => Some(*value),
+            _ => None,
+        }
+    }
+
+    /// Get the timestamp field as [`DateTime<Utc>`].
+    pub fn as_datetime(&self) -> Option<DateTime<Utc>> {
+        self.as_timestamp()
+            .and_then(|timestamp| DateTime::from_timestamp_millis(timestamp))
+    }
+
     /// Create a struct value from a map of values.
     pub fn r#struct<K: Into<String>>(values: impl IntoIterator<Item = (K, Value)>) -> Self {
         Value {
@@ -360,6 +386,7 @@ impl value::Value {
             value::Value::F32(_) => "f32".to_string(),
             value::Value::F64(_) => "f64".to_string(),
             value::Value::String(_) => "string".to_string(),
+            value::Value::Timestamp(_) => "timestamp".to_string(),
             value::Value::Binary(v) => {
                 format!("binary({})", v.len())
             }
@@ -467,6 +494,12 @@ impl From<f32> for Value {
 impl From<f64> for Value {
     fn from(value: f64) -> Self {
         Value::f64(value)
+    }
+}
+
+impl<TZ: TimeZone> From<DateTime<TZ>> for Value {
+    fn from(value: DateTime<TZ>) -> Self {
+        Value::timestamp(value)
     }
 }
 

--- a/topk-rs/src/proto/data/v1/query_ext/expr_ext/logical.rs
+++ b/topk-rs/src/proto/data/v1/query_ext/expr_ext/logical.rs
@@ -155,6 +155,18 @@ impl LogicalExpr {
         Self::binary(binary_op::Op::Sub, self, right)
     }
 
+    pub fn min(self, right: impl Into<LogicalExpr>) -> Self {
+        Self::binary(binary_op::Op::Min, self, right)
+    }
+
+    pub fn max(self, right: impl Into<LogicalExpr>) -> Self {
+        Self::binary(binary_op::Op::Max, self, right)
+    }
+
+    pub fn date_part(self, part: impl Into<String>) -> Self {
+        Self::binary(binary_op::Op::DatePart, self, part.into())
+    }
+
     // Ternary operators
 
     #[inline(always)]
@@ -203,12 +215,31 @@ impl LogicalExpr {
         self.mul(condition.into().choose(boost.into(), 1))
     }
 
-    pub fn min(self, right: impl Into<LogicalExpr>) -> Self {
-        Self::binary(binary_op::Op::Min, self, right)
+    pub fn elapsed(self, end: impl Into<LogicalExpr>, interval: impl Into<String>) -> Self {
+        Self::ternary(
+            ternary_op::Op::Elapsed,
+            self,
+            end.into(),
+            LogicalExpr::literal(interval.into()),
+        )
     }
 
-    pub fn max(self, right: impl Into<LogicalExpr>) -> Self {
-        Self::binary(binary_op::Op::Max, self, right)
+    pub fn saturate(self, mid: f32, exp: f32) -> Self {
+        Self::ternary(
+            ternary_op::Op::Saturate,
+            self,
+            LogicalExpr::literal(mid),
+            LogicalExpr::literal(exp),
+        )
+    }
+
+    pub fn decay(self, mid: f32, exp: f32) -> Self {
+        Self::ternary(
+            ternary_op::Op::Decay,
+            self,
+            LogicalExpr::literal(mid),
+            LogicalExpr::literal(exp),
+        )
     }
 
     pub fn nary(

--- a/topk-rs/tests/test_query_hybrid.rs
+++ b/topk-rs/tests/test_query_hybrid.rs
@@ -1,3 +1,4 @@
+use chrono::{TimeZone, Utc};
 use test_context::test_context;
 use topk_rs::data::literal;
 use topk_rs::proto::v1::data::stage::sort_stage::SortOrder;
@@ -118,4 +119,39 @@ async fn test_query_hybrid_coalesce_score(ctx: &mut ProjectTestContext) {
     // Adding the nullable_score without coalescing would exclude "pride" and "gatsby" from
     // the result set, even though they are the closest candidates based on summary_score.
     assert_doc_ids_ordered!(&result, ["gatsby", "catcher", "pride"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_hybrid_recency_boost(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let now = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            select([(
+                "recency_score",
+                field("published_ts")
+                    .elapsed(literal(now), "day")
+                    .saturate(65.0 * 365.0, 5.0),
+            )])
+            .select([(
+                "summary_distance",
+                fns::vector_distance("summary_embedding", vec![2.3f32; 16]),
+            )])
+            .sort((
+                field("summary_distance").mul(field("recency_score")),
+                SortOrder::Asc,
+            ))
+            .limit(3),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids_ordered!(&result, ["1984", "harry", "pride"]);
 }

--- a/topk-rs/tests/test_query_timestamp.rs
+++ b/topk-rs/tests/test_query_timestamp.rs
@@ -1,0 +1,114 @@
+use chrono::{TimeZone, Utc};
+use test_context::test_context;
+
+use topk_rs::{
+    data::literal,
+    doc,
+    proto::v1::data::AggregateExpr,
+    query::{field, filter, select, SortOrder},
+};
+
+mod utils;
+use utils::{dataset, ProjectTestContext};
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_filter_timestamp(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            filter(
+                field("published_ts")
+                    .lt(literal(Utc.with_ymd_and_hms(1929, 1, 1, 0, 0, 0).unwrap())),
+            )
+            .limit(20),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["pride", "moby", "gatsby"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_date_part_eq_field(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            filter(
+                field("published_ts")
+                    .date_part("year")
+                    .eq(field("published_year")),
+            )
+            .count(),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    let count = result[0].fields["_count"].as_u64().unwrap();
+    assert_eq!(count, 10);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_date_part_lt_literal(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            filter(field("published_ts").date_part("month").lt(literal(6))).limit(10),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_doc_ids!(result, ["gatsby", "pride", "alchemist"]);
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_query_date_part_group_by(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            select([("_id", field("_id"))])
+                .group_by(
+                    [("published_month", field("published_ts").date_part("month"))],
+                    [("count", AggregateExpr::count(None))],
+                )
+                .sort([(field("published_month"), SortOrder::Asc)])
+                .limit(20),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    assert_eq!(
+        result,
+        vec![
+            doc!("published_month" => 1i32, "count" => 2u64),
+            doc!("published_month" => 4i32, "count" => 1u64),
+            doc!("published_month" => 6i32, "count" => 2u64),
+            doc!("published_month" => 7i32, "count" => 3u64),
+            doc!("published_month" => 9i32, "count" => 1u64),
+            doc!("published_month" => 10i32, "count" => 1u64),
+        ],
+    );
+}

--- a/topk-rs/tests/utils/dataset/books.rs
+++ b/topk-rs/tests/utils/dataset/books.rs
@@ -1,4 +1,6 @@
 use crate::utils::ProjectTestContext;
+use chrono::TimeZone;
+use chrono::Utc;
 use float8::F8E4M3;
 use std::collections::HashMap;
 use topk_rs::proto::v1::control::field_type_list::ListValueType;
@@ -49,6 +51,7 @@ pub fn schema() -> HashMap<String, FieldSpec> {
     schema!(
         "title" => FieldSpec::text(true).with_index(FieldIndex::keyword(KeywordIndexType::Text)),
         "published_year" => FieldSpec::integer(true),
+        "published_ts" => FieldSpec::timestamp(true),
         "summary" => FieldSpec::text(true).with_index(FieldIndex::keyword(KeywordIndexType::Text)),
         "summary_embedding" => FieldSpec::f32_vector(16, true).with_index(FieldIndex::vector(VectorDistanceMetric::Euclidean)),
         "nullable_embedding" => FieldSpec::f32_vector(4, false).with_index(FieldIndex::vector(VectorDistanceMetric::Euclidean)),
@@ -72,6 +75,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "mockingbird",
             "title" => "To Kill a Mockingbird",
             "published_year" => 1960 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1960, 7, 11, 0, 0, 0).unwrap(),
             "summary" => "A young girl confronts racial injustice in the Deep South through the eyes of her lawyer father.",
             "summary_embedding" => vec![1.0; 16],
             "nullable_embedding" => vec![1.0; 4],
@@ -91,6 +95,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "1984",
             "title" => "1984",
             "published_year" => 1949 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1949, 6, 8, 0, 0, 0).unwrap(),
             "summary" => "A totalitarian regime uses surveillance and mind control to oppress its citizens.",
             "summary_embedding" => vec![2.0; 16],
             "nullable_embedding" => vec![2.0; 4],
@@ -109,6 +114,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "pride",
             "title" => "Pride and Prejudice",
             "published_year" => 1813 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1813, 1, 28, 0, 0, 0).unwrap(),
             "rating" => 4,
             "summary" => "A witty exploration of love, social class, and marriage in 19th-century England.",
             "summary_embedding" => vec![3.0; 16],
@@ -125,6 +131,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "gatsby",
             "title" => "The Great Gatsby",
             "published_year" => 1925 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1925, 4, 10, 0, 0, 0).unwrap(),
             "rating" => 3,
             "summary" => "A mysterious millionaire navigates love and wealth in the Roaring Twenties.",
             "summary_embedding" => vec![4.0; 16],
@@ -141,6 +148,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "catcher",
             "title" => "The Catcher in the Rye",
             "published_year" => 1951 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1951, 7, 16, 0, 0, 0).unwrap(),
             "summary" => "A rebellious teenager struggles with alienation and identity in mid-20th-century America.",
             "summary_embedding" => vec![5.0; 16],
             "nullable_embedding" => vec![5.0; 4],
@@ -159,6 +167,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "moby",
             "title" => "Moby-Dick",
             "published_year" => 1851 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1851, 10, 18, 0, 0, 0).unwrap(),
             "rating" => 5,
             "summary" => "A sailor's obsessive quest to hunt a great white whale leads to tragic consequences.",
             "summary_embedding" => vec![6.0; 16],
@@ -175,6 +184,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "hobbit",
             "title" => "The Hobbit",
             "published_year" => 1937 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1937, 9, 21, 0, 0, 0).unwrap(),
             "rating" => 3,
             "summary" => "A reluctant hobbit embarks on a quest to help a group of dwarves reclaim their mountain home.",
             "summary_embedding" => vec![7.0; 16],
@@ -188,6 +198,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "harry",
             "title" => "Harry Potter and the Sorcerer's Stone",
             "published_year" => 1997 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1997, 6, 26, 0, 0, 0).unwrap(),
             "summary" => "A young wizard discovers his magical heritage and attends a school for witchcraft and wizardry.",
             "summary_embedding" => vec![8.0; 16],
             "nullable_embedding" => vec![8.0; 4],
@@ -205,6 +216,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "lotr",
             "title" => "The Lord of the Rings: The Fellowship of the Ring",
             "published_year" => 1954 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1954, 7, 29, 0, 0, 0).unwrap(),
             "summary" => "A group of unlikely heroes sets out to destroy a powerful, evil ring.",
             "summary_embedding" => vec![9.0; 16],
             "scalar_i8_embedding" => Value::list(vec![-100i8; 4]),
@@ -219,6 +231,7 @@ pub fn docs() -> Vec<Document> {
             "_id" => "alchemist",
             "title" => "The Alchemist",
             "published_year" => 1988 as u32,
+            "published_ts" => Utc.with_ymd_and_hms(1988, 1, 1, 0, 0, 0).unwrap(),
             "summary" => "A shepherd boy journeys to fulfill his destiny and discover the meaning of life.",
             "summary_embedding" => vec![10.0; 16],
             "sparse_f32_embedding" => Value::f32_sparse_vector(vec![10,11,12], vec![1.0, 2.0, 3.0]),


### PR DESCRIPTION
- Add `timestamp()` field type
- Add `date_part` and `elapsed` fns for timestamp fields
- Add `decay` and `saturate` fns for bounded score boosting