### PR TITLE
[proto] drop timestamp value

### DIFF
--- a/protos/topk/data/v1/value.proto
+++ b/protos/topk/data/v1/value.proto
@@ -30,8 +30,6 @@ message Value {
     Struct struct = 18;
     // Matrix
     Matrix matrix = 19;
-    // Timestamp (milliseconds since UNIX epoch)
-    int64 timestamp = 20;
   }
 }
 

--- a/topk-rs/src/json.rs
+++ b/topk-rs/src/json.rs
@@ -228,7 +228,6 @@ impl TryFrom<TopkValue> for serde_json::Value {
             Some(value::Value::I64(v)) => Ok(Self::from(v)),
             Some(value::Value::F32(v)) => number(v),
             Some(value::Value::F64(v)) => number(v),
-            Some(value::Value::Timestamp(v)) => Ok(Self::from(v)),
             Some(value::Value::Binary(v)) => {
                 Ok(Self::Array(v.into_iter().map(Self::from).collect()))
             }

--- a/topk-rs/src/proto/data/v1/data_ext/value.rs
+++ b/topk-rs/src/proto/data/v1/data_ext/value.rs
@@ -197,7 +197,7 @@ impl Value {
     /// Create a timestamp from the provided value
     pub fn timestamp(value: impl IntoTimestamp) -> Self {
         Value {
-            value: Some(value::Value::Timestamp(value.timestamp_ms())),
+            value: Some(value::Value::I64(value.timestamp_ms())),
         }
     }
 
@@ -208,7 +208,6 @@ impl Value {
             Some(value::Value::U64(value)) if *value <= (i64::MAX as u64) => Some(*value as i64),
             Some(value::Value::I32(value)) => Some(*value as i64),
             Some(value::Value::I64(value)) => Some(*value),
-            Some(value::Value::Timestamp(value)) => Some(*value),
             _ => None,
         }
     }
@@ -386,7 +385,6 @@ impl value::Value {
             value::Value::F32(_) => "f32".to_string(),
             value::Value::F64(_) => "f64".to_string(),
             value::Value::String(_) => "string".to_string(),
-            value::Value::Timestamp(_) => "timestamp".to_string(),
             value::Value::Binary(v) => {
                 format!("binary({})", v.len())
             }


### PR DESCRIPTION
Timestamps are internally stored as `i64`. Drop the `timestamp` value variant to ensure it round-trips through `client -> execution -> result`.