### PR TITLE
[ci] skip `no-commit-to-branch` hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
 
       - name: Run pre-commit
         run: uvx pre-commit run --all-files --show-diff-on-failure --color always
+        env:
+          SKIP: no-commit-to-branch
 
   pinact:
     runs-on: ubuntu-latest


### PR DESCRIPTION
pre-commit job fails on `main` since #531 — `no-commit-to-branch` is a local guard that fails by definition when HEAD is main. Skip just that hook, keep the rest.