### PR TITLE
[py/js] unknown proto variants

### DIFF
--- a/docs/sdk/topk-js/Namespace.data.mdx
+++ b/docs/sdk/topk-js/Namespace.data.mdx
@@ -523,6 +523,14 @@ Usually created using data constructors such as [`f32_sparse_vector()`](#f32spar
 Instances of the `Struct` class are used to represent nested object values in TopK.
 Usually created using the [`struct()`](https://docs.topk.io/sdk/topk-js/data#struct-2) helper.
 
+***
+
+### UnknownValue
+
+**`Internal`**
+
+Placeholder for a value this version of the SDK cannot represent.
+
 ## Type Aliases
 
 ### MatrixValueType

--- a/docs/sdk/topk-py/data.mdx
+++ b/docs/sdk/topk-py/data.mdx
@@ -32,6 +32,12 @@ title: topk_sdk.data
     Instances of the `Struct` class are used to represent nested object values in TopK.
     Usually created using the [`struct()`](#struct) helper.
 
+### UnknownValue
+
+*Internal*
+
+    Placeholder for a value this version of the SDK cannot represent.
+
 ## Functions
 
 ### f8_vector()

--- a/topk-js/index.d.ts
+++ b/topk-js/index.d.ts
@@ -471,6 +471,16 @@ export declare namespace data {
     toString(): string
   }
   /**
+   * @internal
+   * Placeholder for a value this version of the SDK cannot represent.
+   */
+  export class UnknownValue {
+    /** @ignore */
+    constructor()
+    /** @ignore */
+    toString(): string
+  }
+  /**
    * Creates a [List](https://docs.topk.io/sdk/topk-js/data#List) type containing a binary vector. This function is an alias for [binaryList()](https://docs.topk.io/sdk/topk-js/data#binarylist).
    *
    * Example:
@@ -1135,6 +1145,7 @@ export declare namespace schema {
     | { type: 'List', valueType: ListValueType }
     | { type: 'Struct', fields: Record<string, FieldSpec> }
     | { type: 'Matrix', dimension: number, valueType: MatrixValueType }
+    | { type: 'Unknown' }
   /**
    * Creates a [FieldSpec](https://docs.topk.io/sdk/topk-js/schema#FieldSpec) type for `f16_vector` values.
    *
@@ -1199,6 +1210,7 @@ export declare namespace schema {
     | { type: 'VectorIndex', metric: VectorDistanceMetric }
     | { type: 'SemanticIndex' }
     | { type: 'MultiVectorIndex', metric: MultiVectorDistanceMetric, quantization?: MultiVectorQuantization, width?: number, topK?: number }
+    | { type: 'Unknown' }
   /**
    * Creates a [FieldSpec](https://docs.topk.io/sdk/topk-js/schema#FieldSpec) type for `float` values.
    *

--- a/topk-js/lib/data.d.ts
+++ b/topk-js/lib/data.d.ts
@@ -20,4 +20,5 @@ export declare const SparseVector: typeof data.SparseVector;
 export declare const matrix: typeof data.matrix;
 export declare const Matrix: typeof data.Matrix;
 export declare const Struct: typeof data.Struct;
+export declare const UnknownValue: typeof data.UnknownValue;
 export declare type MatrixValueType = data.MatrixValueType;

--- a/topk-js/lib/data.js
+++ b/topk-js/lib/data.js
@@ -20,3 +20,4 @@ exports.SparseVector = data.SparseVector;
 exports.matrix = data.matrix;
 exports.Matrix = data.Matrix;
 exports.Struct = data.Struct;
+exports.UnknownValue = data.UnknownValue;

--- a/topk-js/src/client/mod.rs
+++ b/topk-js/src/client/mod.rs
@@ -263,7 +263,8 @@ impl Client {
                                 Some(Message::Progress(p)) => {
                                     Ok(Either::B(Progress { update: p.update }))
                                 }
-                                None => Err("Invalid proto: AskResult has no message".to_string()),
+                                // A message type this SDK version does not know: skip it.
+                                None => continue,
                             },
                             Err(error) => Err(format!("stream error: {error}")),
                         };

--- a/topk-js/src/data/collection.rs
+++ b/topk-js/src/data/collection.rs
@@ -59,7 +59,10 @@ pub struct CollectionFieldSpec {
 impl From<topk_rs::proto::v1::control::FieldSpec> for CollectionFieldSpec {
     fn from(field_spec: topk_rs::proto::v1::control::FieldSpec) -> Self {
         Self {
-            data_type: field_spec.data_type.unwrap().into(),
+            data_type: field_spec
+                .data_type
+                .map(DataType::from)
+                .unwrap_or(DataType::Unknown),
             required: field_spec.required,
             index: field_spec.index.map(|index| index.into()),
         }

--- a/topk-js/src/data/mod.rs
+++ b/topk-js/src/data/mod.rs
@@ -15,6 +15,9 @@ pub use matrix::MatrixValueType;
 mod r#struct;
 pub use r#struct::Struct;
 
+mod unknown;
+pub use unknown::{UnknownValue, UNSUPPORTED};
+
 mod value;
 pub use value::NativeValue;
 pub use value::Value;

--- a/topk-js/src/data/unknown.rs
+++ b/topk-js/src/data/unknown.rs
@@ -1,0 +1,25 @@
+use napi_derive::napi;
+
+pub const UNSUPPORTED: &str = "not supported by this version of topk-js, upgrade to use it";
+
+/// @internal
+/// Placeholder for a value this version of the SDK cannot represent.
+#[derive(Debug, Clone, PartialEq)]
+#[napi(namespace = "data")]
+pub struct UnknownValue {}
+
+/// @internal
+#[napi(namespace = "data")]
+impl UnknownValue {
+    /// @ignore
+    #[napi(constructor)]
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// @ignore
+    #[napi]
+    pub fn to_string(&self) -> String {
+        format!("UnknownValue({UNSUPPORTED})")
+    }
+}

--- a/topk-js/src/data/value.rs
+++ b/topk-js/src/data/value.rs
@@ -4,6 +4,7 @@ use crate::data::{
     matrix::{Matrix, MatrixValueType, MatrixValues},
     r#struct::Struct,
     vector::{SparseVectorData, SparseVectorUnion},
+    UnknownValue, UNSUPPORTED,
 };
 use napi::{bindgen_prelude::*, sys::napi_is_buffer};
 use std::{collections::HashMap, ffi::CString, ptr};
@@ -79,6 +80,7 @@ pub enum Value {
     List(List),
     Matrix(Matrix),
     Struct(HashMap<String, Value>),
+    Unknown,
 }
 
 impl From<i64> for Value {
@@ -207,6 +209,8 @@ impl From<Value> for topk_rs::proto::v1::data::Value {
             Value::Struct(fields) => topk_rs::proto::v1::data::Value::r#struct(
                 fields.into_iter().map(|(k, v)| (k, v.into())),
             ),
+            // unreachable: `FromNapiValue` rejects the sentinel on the way in
+            Value::Unknown => unreachable!(),
         }
     }
 }
@@ -251,7 +255,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                         ),
                     })
                 }
-                None => unreachable!("Invalid vector proto"),
+                None => return Value::Unknown,
             },
             // Sparse vectors
             Some(topk_rs::proto::v1::data::value::Value::SparseVector(sparse_vector)) => {
@@ -289,7 +293,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                             values: values.iter().map(|&x| x as f32).collect(),
                         })
                     }
-                    None => unreachable!("Invalid sparse vector proto"),
+                    None => return Value::Unknown,
                 })
             }
             Some(topk_rs::proto::v1::data::value::Value::List(list)) => Value::List(List {
@@ -308,10 +312,14 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                     Some(topk_rs::proto::v1::data::list::Values::String(v)) => {
                         Values::String(v.values)
                     }
-                    None => unreachable!("Invalid list proto"),
+                    None => return Value::Unknown,
                 },
             }),
             Some(topk_rs::proto::v1::data::value::Value::Matrix(matrix)) => {
+                assert!(
+                    matrix.num_cols > 0,
+                    "invalid matrix: num_cols must be non-zero"
+                );
                 let num_cols = matrix.num_cols;
                 let values = match matrix.values {
                     Some(topk_rs::proto::v1::data::matrix::Values::F32(v)) => {
@@ -329,7 +337,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                     Some(topk_rs::proto::v1::data::matrix::Values::I8(v)) => {
                         MatrixValues::I8(v.into())
                     }
-                    None => unreachable!("Invalid matrix proto"),
+                    None => return Value::Unknown,
                 };
 
                 Value::Matrix(Matrix { num_cols, values })
@@ -337,7 +345,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
             Some(topk_rs::proto::v1::data::value::Value::Struct(s)) => {
                 Value::Struct(s.fields.into_iter().map(|(k, v)| (k, v.into())).collect())
             }
-            None => unreachable!("Invalid value proto"),
+            None => Value::Unknown,
         }
     }
 }
@@ -361,6 +369,12 @@ impl FromNapiValue for Value {
 
         if let Ok(struct_value) = crate::try_cast_ref!(env, value, Struct) {
             return Ok(Value::Struct(struct_value.fields.clone()));
+        }
+
+        if crate::try_cast_ref!(env, value, UnknownValue).is_ok() {
+            return Err(napi::Error::from_reason(format!(
+                "cannot write `UnknownValue`: {UNSUPPORTED}"
+            )));
         }
 
         let mut result: i32 = 0;
@@ -568,6 +582,7 @@ impl ToNapiValue for Value {
 
                 Ok(object)
             }
+            Value::Unknown => UnknownValue::to_napi_value(env, UnknownValue {}),
         }
     }
 }

--- a/topk-js/src/schema/data_type.rs
+++ b/topk-js/src/schema/data_type.rs
@@ -1,5 +1,9 @@
-use napi_derive::napi;
 use std::collections::HashMap;
+
+use napi_derive::napi;
+
+use topk_rs::proto::v1::control::field_type_list::ListValueType as ListValueTypePb;
+use topk_rs::proto::v1::control::field_type_matrix::MatrixValueType as MatrixValueTypePb;
 
 use crate::schema::field_spec::FieldSpec;
 
@@ -45,6 +49,7 @@ pub enum DataType {
         dimension: u32,
         value_type: MatrixValueType,
     },
+    Unknown,
 }
 
 #[napi(string_enum = "lowercase", namespace = "schema")]
@@ -87,31 +92,6 @@ impl From<MatrixValueType> for topk_rs::proto::v1::control::field_type_matrix::M
     }
 }
 
-impl From<topk_rs::proto::v1::control::field_type_matrix::MatrixValueType> for MatrixValueType {
-    fn from(value: topk_rs::proto::v1::control::field_type_matrix::MatrixValueType) -> Self {
-        match value {
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::F32 => {
-                MatrixValueType::F32
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::F16 => {
-                MatrixValueType::F16
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::F8 => {
-                MatrixValueType::F8
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::U8 => {
-                MatrixValueType::U8
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::I8 => {
-                MatrixValueType::I8
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::Unspecified => {
-                unreachable!("Invalid matrix value type")
-            }
-        }
-    }
-}
-
 impl From<ListValueType> for topk_rs::proto::v1::control::FieldTypeList {
     fn from(value: ListValueType) -> Self {
         match value {
@@ -131,24 +111,6 @@ impl From<ListValueType> for topk_rs::proto::v1::control::FieldTypeList {
     }
 }
 
-impl From<topk_rs::proto::v1::control::field_type_list::ListValueType> for ListValueType {
-    fn from(value: topk_rs::proto::v1::control::field_type_list::ListValueType) -> Self {
-        match value {
-            topk_rs::proto::v1::control::field_type_list::ListValueType::Integer => {
-                ListValueType::Integer
-            }
-            topk_rs::proto::v1::control::field_type_list::ListValueType::Float => {
-                ListValueType::Float
-            }
-            topk_rs::proto::v1::control::field_type_list::ListValueType::String => {
-                ListValueType::Text
-            }
-            topk_rs::proto::v1::control::field_type_list::ListValueType::Unspecified => {
-                unreachable!("Invalid list value type")
-            }
-        }
-    }
-}
 impl From<topk_rs::proto::v1::control::FieldType> for DataType {
     fn from(field_type: topk_rs::proto::v1::control::FieldType) -> Self {
         match field_type.data_type {
@@ -204,7 +166,12 @@ impl From<topk_rs::proto::v1::control::FieldType> for DataType {
                 }
                 topk_rs::proto::v1::control::field_type::DataType::Bytes(_) => DataType::Bytes,
                 topk_rs::proto::v1::control::field_type::DataType::List(list) => DataType::List {
-                    value_type: list.value_type().into(),
+                    value_type: match list.value_type() {
+                        ListValueTypePb::Integer => ListValueType::Integer,
+                        ListValueTypePb::Float => ListValueType::Float,
+                        ListValueTypePb::String => ListValueType::Text,
+                        ListValueTypePb::Unspecified => return DataType::Unknown,
+                    },
                 },
                 topk_rs::proto::v1::control::field_type::DataType::Struct(s) => DataType::Struct {
                     fields: s.fields.into_iter().map(|(k, v)| (k, v.into())).collect(),
@@ -212,14 +179,21 @@ impl From<topk_rs::proto::v1::control::FieldType> for DataType {
                 topk_rs::proto::v1::control::field_type::DataType::Matrix(matrix) => {
                     DataType::Matrix {
                         dimension: matrix.dimension,
-                        value_type: matrix.value_type().into(),
+                        value_type: match matrix.value_type() {
+                            MatrixValueTypePb::F32 => MatrixValueType::F32,
+                            MatrixValueTypePb::F16 => MatrixValueType::F16,
+                            MatrixValueTypePb::F8 => MatrixValueType::F8,
+                            MatrixValueTypePb::U8 => MatrixValueType::U8,
+                            MatrixValueTypePb::I8 => MatrixValueType::I8,
+                            MatrixValueTypePb::Unspecified => return DataType::Unknown,
+                        },
                     }
                 }
                 topk_rs::proto::v1::control::field_type::DataType::Timestamp(_) => {
                     unimplemented!("timestamp: see #530")
                 }
             },
-            None => unreachable!("Invalid data type proto"),
+            None => DataType::Unknown,
         }
     }
 }

--- a/topk-js/src/schema/field_index.rs
+++ b/topk-js/src/schema/field_index.rs
@@ -1,6 +1,14 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
+use crate::data::UNSUPPORTED;
+use topk_rs::proto::v1::control::{
+    KeywordIndexType as KeywordIndexTypePb,
+    MultiVectorDistanceMetric as MultiVectorDistanceMetricPb,
+    MultiVectorQuantization as MultiVectorQuantizationPb,
+    VectorDistanceMetric as VectorDistanceMetricPb,
+};
+
 /// @internal
 /// @hideconstructor
 #[napi(namespace = "schema")]
@@ -24,6 +32,7 @@ pub enum FieldIndexUnion {
         width: Option<u32>,
         top_k: Option<u32>,
     },
+    Unknown {},
 }
 
 impl FieldIndex {
@@ -33,6 +42,10 @@ impl FieldIndex {
 
     pub(crate) fn keyword_index(index_type: KeywordIndexType) -> Self {
         Self(FieldIndexUnion::KeywordIndex { index_type })
+    }
+
+    pub(crate) fn unknown() -> Self {
+        Self(FieldIndexUnion::Unknown {})
     }
 
     pub(crate) fn semantic_index() -> Self {
@@ -83,18 +96,6 @@ impl From<KeywordIndexType> for topk_rs::proto::v1::control::KeywordIndexType {
     }
 }
 
-impl From<topk_rs::proto::v1::control::KeywordIndexType> for KeywordIndexType {
-    fn from(index_type: topk_rs::proto::v1::control::KeywordIndexType) -> Self {
-        match index_type {
-            topk_rs::proto::v1::control::KeywordIndexType::Text => KeywordIndexType::Text,
-            topk_rs::proto::v1::control::KeywordIndexType::Exact => KeywordIndexType::Exact,
-            topk_rs::proto::v1::control::KeywordIndexType::Unspecified => {
-                unreachable!("Invalid proto: Unspecified keyword index type")
-            }
-        }
-    }
-}
-
 #[napi(string_enum = "snake_case", namespace = "schema")]
 #[derive(Clone, Debug)]
 pub enum VectorDistanceMetric {
@@ -102,28 +103,6 @@ pub enum VectorDistanceMetric {
     Euclidean,
     DotProduct,
     Hamming,
-}
-
-impl From<topk_rs::proto::v1::control::VectorDistanceMetric> for VectorDistanceMetric {
-    fn from(metric: topk_rs::proto::v1::control::VectorDistanceMetric) -> Self {
-        match metric {
-            topk_rs::proto::v1::control::VectorDistanceMetric::Cosine => {
-                VectorDistanceMetric::Cosine
-            }
-            topk_rs::proto::v1::control::VectorDistanceMetric::Euclidean => {
-                VectorDistanceMetric::Euclidean
-            }
-            topk_rs::proto::v1::control::VectorDistanceMetric::DotProduct => {
-                VectorDistanceMetric::DotProduct
-            }
-            topk_rs::proto::v1::control::VectorDistanceMetric::Hamming => {
-                VectorDistanceMetric::Hamming
-            }
-            topk_rs::proto::v1::control::VectorDistanceMetric::Unspecified => {
-                unreachable!("Invalid proto: Unspecified vector distance metric")
-            }
-        }
-    }
 }
 
 impl From<VectorDistanceMetric> for topk_rs::proto::v1::control::VectorDistanceMetric {
@@ -161,19 +140,6 @@ impl From<MultiVectorDistanceMetric> for topk_rs::proto::v1::control::MultiVecto
     }
 }
 
-impl From<topk_rs::proto::v1::control::MultiVectorDistanceMetric> for MultiVectorDistanceMetric {
-    fn from(metric: topk_rs::proto::v1::control::MultiVectorDistanceMetric) -> Self {
-        match metric {
-            topk_rs::proto::v1::control::MultiVectorDistanceMetric::Maxsim => {
-                MultiVectorDistanceMetric::Maxsim
-            }
-            topk_rs::proto::v1::control::MultiVectorDistanceMetric::Unspecified => {
-                unreachable!("Invalid proto: Unspecified multi-vector distance metric")
-            }
-        }
-    }
-}
-
 #[napi(string_enum, namespace = "schema")]
 #[derive(Clone, Debug)]
 pub enum MultiVectorQuantization {
@@ -201,25 +167,6 @@ impl From<MultiVectorQuantization> for topk_rs::proto::v1::control::MultiVectorQ
     }
 }
 
-impl From<topk_rs::proto::v1::control::MultiVectorQuantization> for MultiVectorQuantization {
-    fn from(quantization: topk_rs::proto::v1::control::MultiVectorQuantization) -> Self {
-        match quantization {
-            topk_rs::proto::v1::control::MultiVectorQuantization::Binary1bit => {
-                MultiVectorQuantization::Binary1bit
-            }
-            topk_rs::proto::v1::control::MultiVectorQuantization::Binary2bit => {
-                MultiVectorQuantization::Binary2bit
-            }
-            topk_rs::proto::v1::control::MultiVectorQuantization::Scalar => {
-                MultiVectorQuantization::Scalar
-            }
-            topk_rs::proto::v1::control::MultiVectorQuantization::Unspecified => {
-                panic!("Invalid proto: Unspecified multi-vector quantization")
-            }
-        }
-    }
-}
-
 impl From<topk_rs::proto::v1::control::FieldIndex> for FieldIndexUnion {
     fn from(field_index: topk_rs::proto::v1::control::FieldIndex) -> Self {
         FieldIndex::from(field_index).0
@@ -231,40 +178,60 @@ impl From<topk_rs::proto::v1::control::FieldIndex> for FieldIndex {
         match field_index.index {
             Some(i) => match i {
                 topk_rs::proto::v1::control::field_index::Index::KeywordIndex(k) => {
-                    FieldIndex::keyword_index(
-                        topk_rs::proto::v1::control::KeywordIndexType::try_from(k.index_type)
-                            .expect("Unsupported keyword index type")
-                            .into(),
-                    )
+                    match k.index_type() {
+                        KeywordIndexTypePb::Text => {
+                            FieldIndex::keyword_index(KeywordIndexType::Text)
+                        }
+                        KeywordIndexTypePb::Exact => {
+                            FieldIndex::keyword_index(KeywordIndexType::Exact)
+                        }
+                        KeywordIndexTypePb::Unspecified => return FieldIndex::unknown(),
+                    }
                 }
                 topk_rs::proto::v1::control::field_index::Index::VectorIndex(v) => {
-                    FieldIndex::vector_index(
-                        topk_rs::proto::v1::control::VectorDistanceMetric::try_from(v.metric)
-                            .expect("Unsupported vector distance metric")
-                            .into(),
-                    )
+                    match v.metric() {
+                        VectorDistanceMetricPb::Cosine => {
+                            FieldIndex::vector_index(VectorDistanceMetric::Cosine)
+                        }
+                        VectorDistanceMetricPb::Euclidean => {
+                            FieldIndex::vector_index(VectorDistanceMetric::Euclidean)
+                        }
+                        VectorDistanceMetricPb::DotProduct => {
+                            FieldIndex::vector_index(VectorDistanceMetric::DotProduct)
+                        }
+                        VectorDistanceMetricPb::Hamming => {
+                            FieldIndex::vector_index(VectorDistanceMetric::Hamming)
+                        }
+                        VectorDistanceMetricPb::Unspecified => return FieldIndex::unknown(),
+                    }
                 }
                 topk_rs::proto::v1::control::field_index::Index::SemanticIndex(_) => {
                     FieldIndex::semantic_index()
                 }
                 topk_rs::proto::v1::control::field_index::Index::MultiVectorIndex(mvi) => {
-                    FieldIndex::multi_vector_index(
-                        topk_rs::proto::v1::control::MultiVectorDistanceMetric::try_from(
-                            mvi.metric,
-                        )
-                        .expect("Unsupported multi-vector distance metric")
-                        .into(),
-                        mvi.quantization.map(|q| {
-                            topk_rs::proto::v1::control::MultiVectorQuantization::try_from(q)
-                                .expect("Unsupported multi-vector quantization")
-                                .into()
-                        }),
-                        mvi.width,
-                        mvi.top_k,
-                    )
+                    let metric = match mvi.metric() {
+                        MultiVectorDistanceMetricPb::Maxsim => MultiVectorDistanceMetric::Maxsim,
+                        MultiVectorDistanceMetricPb::Unspecified => return FieldIndex::unknown(),
+                    };
+                    let quantization = match mvi.quantization {
+                        None => None,
+                        Some(q) => match MultiVectorQuantizationPb::try_from(q) {
+                            Ok(MultiVectorQuantizationPb::Binary1bit) => {
+                                Some(MultiVectorQuantization::Binary1bit)
+                            }
+                            Ok(MultiVectorQuantizationPb::Binary2bit) => {
+                                Some(MultiVectorQuantization::Binary2bit)
+                            }
+                            Ok(MultiVectorQuantizationPb::Scalar) => {
+                                Some(MultiVectorQuantization::Scalar)
+                            }
+                            _ => return FieldIndex::unknown(),
+                        },
+                    };
+                    FieldIndex::multi_vector_index(metric, quantization, mvi.width, mvi.top_k)
                 }
             },
-            None => unreachable!("Invalid field index proto"),
+            None => FieldIndex::unknown(),
         }
     }
 }
@@ -292,6 +259,9 @@ impl From<FieldIndex> for topk_rs::proto::v1::control::FieldIndex {
                 width,
                 top_k,
             ),
+            FieldIndexUnion::Unknown {} => {
+                panic!("cannot write an unknown field index: {UNSUPPORTED}")
+            }
         }
     }
 }

--- a/topk-js/src/schema/field_spec.rs
+++ b/topk-js/src/schema/field_spec.rs
@@ -4,6 +4,7 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
 use super::{data_type::DataType, field_index::FieldIndex};
+use crate::data::UNSUPPORTED;
 
 /// @internal
 /// @hideconstructor
@@ -133,6 +134,9 @@ impl From<FieldSpec> for topk_rs::proto::v1::control::FieldSpec {
                         dimension,
                         value_type.into(),
                     ),
+                    DataType::Unknown => {
+                        panic!("cannot write an unknown field type: {UNSUPPORTED}")
+                    }
                 }),
             }),
             required: field_spec.required,
@@ -147,7 +151,7 @@ impl From<topk_rs::proto::v1::control::FieldSpec> for FieldSpec {
             data_type: proto
                 .data_type
                 .map(DataType::from)
-                .expect("data_type is required"),
+                .unwrap_or(DataType::Unknown),
             required: proto.required,
             index: proto.index.map(|idx| idx.into()),
         }

--- a/topk-js/src/schema/field_spec.rs
+++ b/topk-js/src/schema/field_spec.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use super::{data_type::DataType, field_index::FieldIndex};
+use super::{data_type::DataType, field_index::FieldIndex, field_index::FieldIndexUnion};
 use crate::data::UNSUPPORTED;
 
 /// @internal
@@ -23,6 +23,17 @@ impl FieldSpec {
             data_type,
             required: false,
             index: None,
+        }
+    }
+
+    pub fn has_unknown(&self) -> bool {
+        matches!(
+            self.index,
+            Some(FieldIndex(FieldIndexUnion::Unknown { .. }))
+        ) || match &self.data_type {
+            DataType::Unknown => true,
+            DataType::Struct { fields } => fields.values().any(FieldSpec::has_unknown),
+            _ => false,
         }
     }
 }
@@ -164,6 +175,11 @@ impl FromNapiValue for FieldSpec {
         value: napi::sys::napi_value,
     ) -> Result<Self> {
         if let Ok(field_spec) = crate::try_cast_ref!(env, value, FieldSpec) {
+            if field_spec.has_unknown() {
+                return Err(napi::Error::from_reason(format!(
+                    "cannot write an unknown field type or index: {UNSUPPORTED}"
+                )));
+            }
             return Ok(field_spec.clone());
         }
 

--- a/topk-js/tests/test_collection_upsert.spec.ts
+++ b/topk-js/tests/test_collection_upsert.spec.ts
@@ -358,6 +358,16 @@ describe("Upsert", () => {
 
     expect(obj["x"].string_list).toEqual([]);
   });
+
+  it("should reject an UnknownValue", async () => {
+    const ctx = getContext();
+
+    await expect(
+      ctx.client
+        .collection(ctx.scope("test"))
+        .upsert([{ _id: "x", field: new data.UnknownValue() }])
+    ).rejects.toThrow("not supported by this version of topk-js");
+  });
 });
 
 function normalizeF32SparseValues(obj: Record<string, number>, precision = 5) {

--- a/topk-js/tests/test_collection_upsert.spec.ts
+++ b/topk-js/tests/test_collection_upsert.spec.ts
@@ -362,11 +362,11 @@ describe("Upsert", () => {
   it("should reject an UnknownValue", async () => {
     const ctx = getContext();
 
-    await expect(
-      ctx.client
+    await expect(async () => {
+      await ctx.client
         .collection(ctx.scope("test"))
-        .upsert([{ _id: "x", field: new data.UnknownValue() }])
-    ).rejects.toThrow("not supported by this version of topk-js");
+        .upsert([{ _id: "x", field: new data.UnknownValue() }]);
+    }).rejects.toThrow("not supported by this version of topk-js");
   });
 });
 

--- a/topk-py/Cargo.toml
+++ b/topk-py/Cargo.toml
@@ -17,3 +17,6 @@ half = { version = "2.7.1", features = ["bytemuck"] }
 float8 = { version = "0.5.0", features = ["bytemuck"] }
 futures-util = { version = "0.3.31" }
 bytes = { version = "1.8.0" }
+
+[dev-dependencies]
+rstest = { version = "0.23.0" }

--- a/topk-py/src/client/async/ask.rs
+++ b/topk-py/src/client/async/ask.rs
@@ -86,14 +86,8 @@ pub fn ask(
                             break;
                         }
                     },
-                    None => {
-                        let _ = tx
-                            .send(Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                                "Invalid proto: AskResult has no message",
-                            )))
-                            .await;
-                        break;
-                    }
+                    // A message type this SDK version does not know: skip it.
+                    None => continue,
                 },
                 Err(e) => {
                     let _ = tx.send(Err(RustError(e.into()).into())).await;

--- a/topk-py/src/client/sync/ask.rs
+++ b/topk-py/src/client/sync/ask.rs
@@ -81,14 +81,8 @@ pub fn ask(
                             break;
                         }
                     },
-                    None => {
-                        let _ = tx
-                            .send(Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                                "Invalid proto: AskResult has no message",
-                            )))
-                            .await;
-                        break;
-                    }
+                    // A message type this SDK version does not know: skip it.
+                    None => continue,
                 },
                 Err(e) => {
                     let _ = tx.send(Err(RustError(e.into()).into())).await;

--- a/topk-py/src/data/mod.rs
+++ b/topk-py/src/data/mod.rs
@@ -7,6 +7,7 @@ use pyo3::types::{PyBytes, PyList};
 use crate::data::list::List;
 use crate::data::matrix::Matrix;
 use crate::data::r#struct::Struct;
+use crate::data::unknown::UnknownValue;
 use crate::data::value::Value;
 use crate::data::vector::{F32SparseVector, SparseVector, U8SparseVector};
 
@@ -19,6 +20,7 @@ pub mod list_entry;
 pub mod matrix;
 pub mod partition;
 pub mod r#struct;
+pub mod unknown;
 pub mod value;
 pub mod vector;
 
@@ -34,6 +36,7 @@ pub fn pymodule(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SparseVector>()?;
     m.add_class::<Matrix>()?;
     m.add_class::<Struct>()?;
+    m.add_class::<UnknownValue>()?;
 
     // (Dense) Vectors
     m.add_wrapped(wrap_pyfunction!(f8_vector))?;

--- a/topk-py/src/data/unknown.rs
+++ b/topk-py/src/data/unknown.rs
@@ -1,0 +1,19 @@
+use pyo3::prelude::*;
+
+pub const UNSUPPORTED: &str = "not supported by this version of topk-sdk, upgrade to use it";
+
+#[pyclass(frozen, eq)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnknownValue {}
+
+#[pymethods]
+impl UnknownValue {
+    #[new]
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn __repr__(&self) -> String {
+        format!("UnknownValue({UNSUPPORTED})")
+    }
+}

--- a/topk-py/src/data/value.rs
+++ b/topk-py/src/data/value.rs
@@ -11,6 +11,7 @@ use crate::data::{
     list::{List, Values},
     matrix::{Matrix, MatrixValues},
     r#struct::Struct,
+    unknown::{UnknownValue, UNSUPPORTED},
     vector::F32SparseVector,
 };
 use crate::error::InvalidArgumentError;
@@ -29,6 +30,7 @@ pub enum Value {
     List(List),
     Matrix(Matrix),
     Struct(HashMap<String, Value>),
+    Unknown,
 }
 
 impl FromPyObject<'_, '_> for Value {
@@ -36,7 +38,11 @@ impl FromPyObject<'_, '_> for Value {
 
     fn extract(obj: Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
         // NOTE: it's safe to use `downcast` for custom types
-        if let Ok(v) = obj.cast::<List>() {
+        if let Ok(_) = obj.cast::<UnknownValue>() {
+            Err(PyTypeError::new_err(format!(
+                "cannot write `UnknownValue`: {UNSUPPORTED}"
+            )))
+        } else if let Ok(v) = obj.cast::<List>() {
             Ok(Value::List(v.borrow().clone()))
         } else if let Ok(v) = obj.cast::<Struct>() {
             Ok(Value::Struct(v.borrow().fields.clone()))
@@ -259,6 +265,7 @@ impl<'py> IntoPyObject<'py> for Value {
                 }
                 Ok(dict.into_py_any(py)?.into_bound(py))
             }
+            Value::Unknown => Ok(UnknownValue {}.into_py_any(py)?.into_bound(py)),
         }
     }
 }
@@ -291,7 +298,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                         values: Values::U8(v.values),
                     })
                 }
-                t => unreachable!("Unknown vector type: {:?}", t),
+                _ => return Value::Unknown,
             },
             Some(topk_rs::proto::v1::data::value::Value::SparseVector(sv)) => {
                 Value::SparseVector(match sv.values {
@@ -328,7 +335,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                             values: values.iter().map(|&x| x as f32).collect(),
                         }
                     }
-                    None => unreachable!("Invalid sparse vector proto"),
+                    None => return Value::Unknown,
                 })
             }
             Some(topk_rs::proto::v1::data::value::Value::List(l)) => Value::List(List {
@@ -367,12 +374,14 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                     Some(topk_rs::proto::v1::data::list::Values::String(values)) => {
                         Values::String(values.values)
                     }
-                    None => {
-                        unreachable!("Invalid list proto: {:?}", l)
-                    }
+                    None => return Value::Unknown,
                 },
             }),
             Some(topk_rs::proto::v1::data::value::Value::Matrix(matrix)) => {
+                assert!(
+                    matrix.num_cols > 0,
+                    "invalid matrix: num_cols must be non-zero"
+                );
                 let matrix_values = match &matrix.values {
                     Some(topk_rs::proto::v1::data::matrix::Values::F32(v)) => {
                         MatrixValues::F32(v.to_owned().into())
@@ -389,9 +398,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                     Some(topk_rs::proto::v1::data::matrix::Values::I8(v)) => {
                         MatrixValues::I8(v.to_owned().into())
                     }
-                    None => {
-                        unreachable!("Invalid matrix proto: {:?}", matrix)
-                    }
+                    None => return Value::Unknown,
                 };
                 Value::Matrix(Matrix {
                     num_cols: matrix.num_cols,
@@ -404,7 +411,7 @@ impl From<topk_rs::proto::v1::data::Value> for Value {
                     .map(|(k, v)| (k, Value::from(v)))
                     .collect(),
             ),
-            None => Value::Null(),
+            None => Value::Unknown,
         }
     }
 }
@@ -462,6 +469,55 @@ impl From<Value> for topk_rs::proto::v1::data::Value {
             Value::Struct(fields) => topk_rs::proto::v1::data::Value::r#struct(
                 fields.into_iter().map(|(k, v)| (k, v.into())),
             ),
+            // unreachable: `FromPyObject` rejects the sentinel on the way in
+            Value::Unknown => unreachable!(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use topk_rs::proto::v1::data as pb;
+
+    #[rstest]
+    #[case::top_level_oneof(pb::Value { value: None })]
+    #[case::nested_list(pb::Value {
+        value: Some(pb::value::Value::List(pb::List { values: None })),
+    })]
+    fn unknown_value_decodes_to_unknown(#[case] proto: pb::Value) {
+        assert_eq!(Value::from(proto), Value::Unknown);
+    }
+
+    #[test]
+    #[should_panic(expected = "num_cols must be non-zero")]
+    fn zero_column_matrix_is_rejected() {
+        let proto = pb::Value {
+            value: Some(pb::value::Value::Matrix(pb::Matrix {
+                num_cols: 0,
+                values: Some(pb::matrix::Values::F32(pb::matrix::F32 {
+                    values: vec![1.0],
+                })),
+                ..Default::default()
+            })),
+        };
+
+        let _ = Value::from(proto);
+    }
+
+    #[test]
+    fn unknown_struct_field_degrades_only_that_field() {
+        let proto = pb::Value::r#struct([
+            ("known".to_string(), pb::Value::i64(1)),
+            ("unknown".to_string(), pb::Value { value: None }),
+        ]);
+
+        let fields = match Value::from(proto) {
+            Value::Struct(fields) => fields,
+            other => panic!("expected struct, got {other:?}"),
+        };
+        assert_eq!(fields["known"], Value::Int(1));
+        assert_eq!(fields["unknown"], Value::Unknown);
     }
 }

--- a/topk-py/src/schema/data_type.rs
+++ b/topk-py/src/schema/data_type.rs
@@ -2,6 +2,10 @@ use std::collections::HashMap;
 
 use pyo3::prelude::*;
 
+use topk_rs::proto::v1::control::field_type_list::ListValueType as ListValueTypePb;
+use topk_rs::proto::v1::control::field_type_matrix::MatrixValueType as MatrixValueTypePb;
+
+use crate::data::unknown::UNSUPPORTED;
 use crate::schema::field_spec::FieldSpec;
 
 #[pyclass(eq)]
@@ -45,6 +49,7 @@ pub enum DataType {
         dimension: u32,
         value_type: MatrixValueType,
     },
+    Unknown(),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -87,31 +92,6 @@ impl From<MatrixValueType> for topk_rs::proto::v1::control::field_type_matrix::M
     }
 }
 
-impl From<topk_rs::proto::v1::control::field_type_matrix::MatrixValueType> for MatrixValueType {
-    fn from(value: topk_rs::proto::v1::control::field_type_matrix::MatrixValueType) -> Self {
-        match value {
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::F32 => {
-                MatrixValueType::F32
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::F16 => {
-                MatrixValueType::F16
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::F8 => {
-                MatrixValueType::F8
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::U8 => {
-                MatrixValueType::U8
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::I8 => {
-                MatrixValueType::I8
-            }
-            topk_rs::proto::v1::control::field_type_matrix::MatrixValueType::Unspecified => {
-                unreachable!("Invalid matrix value type")
-            }
-        }
-    }
-}
-
 impl From<ListValueType> for topk_rs::proto::v1::control::FieldTypeList {
     fn from(value: ListValueType) -> Self {
         match value {
@@ -127,25 +107,6 @@ impl From<ListValueType> for topk_rs::proto::v1::control::FieldTypeList {
                 value_type: topk_rs::proto::v1::control::field_type_list::ListValueType::String
                     as i32,
             },
-        }
-    }
-}
-
-impl From<topk_rs::proto::v1::control::field_type_list::ListValueType> for ListValueType {
-    fn from(value: topk_rs::proto::v1::control::field_type_list::ListValueType) -> Self {
-        match value {
-            topk_rs::proto::v1::control::field_type_list::ListValueType::Integer => {
-                ListValueType::Integer
-            }
-            topk_rs::proto::v1::control::field_type_list::ListValueType::Float => {
-                ListValueType::Float
-            }
-            topk_rs::proto::v1::control::field_type_list::ListValueType::String => {
-                ListValueType::Text
-            }
-            topk_rs::proto::v1::control::field_type_list::ListValueType::Unspecified => {
-                unreachable!("Invalid list value type")
-            }
         }
     }
 }
@@ -206,6 +167,7 @@ impl Into<topk_rs::proto::v1::control::field_type::DataType> for DataType {
                 dimension,
                 value_type.into(),
             ),
+            DataType::Unknown() => panic!("cannot write an unknown field type: {UNSUPPORTED}"),
         }
     }
 }
@@ -272,18 +234,47 @@ impl From<topk_rs::proto::v1::control::field_type::DataType> for DataType {
             }
             topk_rs::proto::v1::control::field_type::DataType::Bytes(_) => DataType::Bytes(),
             topk_rs::proto::v1::control::field_type::DataType::List(list) => DataType::List {
-                value_type: list.value_type().into(),
+                value_type: match list.value_type() {
+                    ListValueTypePb::Integer => ListValueType::Integer,
+                    ListValueTypePb::Float => ListValueType::Float,
+                    ListValueTypePb::String => ListValueType::Text,
+                    ListValueTypePb::Unspecified => return DataType::Unknown(),
+                },
             },
             topk_rs::proto::v1::control::field_type::DataType::Struct(s) => DataType::Struct {
                 fields: s.fields.into_iter().map(|(k, v)| (k, v.into())).collect(),
             },
             topk_rs::proto::v1::control::field_type::DataType::Matrix(matrix) => DataType::Matrix {
                 dimension: matrix.dimension,
-                value_type: matrix.value_type().into(),
+                value_type: match matrix.value_type() {
+                    MatrixValueTypePb::F32 => MatrixValueType::F32,
+                    MatrixValueTypePb::F16 => MatrixValueType::F16,
+                    MatrixValueTypePb::F8 => MatrixValueType::F8,
+                    MatrixValueTypePb::U8 => MatrixValueType::U8,
+                    MatrixValueTypePb::I8 => MatrixValueType::I8,
+                    MatrixValueTypePb::Unspecified => return DataType::Unknown(),
+                },
             },
             topk_rs::proto::v1::control::field_type::DataType::Timestamp(_) => {
                 unimplemented!("timestamp: see #530")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use topk_rs::proto::v1::control as pb;
+
+    #[rstest]
+    #[case::list_value_type(pb::field_type::DataType::List(pb::FieldTypeList { value_type: 9999 }))]
+    #[case::matrix_value_type(pb::field_type::DataType::Matrix(pb::FieldTypeMatrix {
+        value_type: 9999,
+        ..Default::default()
+    }))]
+    fn unknown_sub_enum_collapses_to_unknown(#[case] proto: pb::field_type::DataType) {
+        assert_eq!(DataType::from(proto), DataType::Unknown());
     }
 }

--- a/topk-py/src/schema/field_index.rs
+++ b/topk-py/src/schema/field_index.rs
@@ -1,5 +1,9 @@
 use pyo3::prelude::*;
 
+use crate::data::unknown::UNSUPPORTED;
+
+use topk_rs::proto::v1::control::MultiVectorQuantization as MultiVectorQuantizationPb;
+
 #[pyclass(eq)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldIndex {
@@ -16,6 +20,7 @@ pub enum FieldIndex {
         width: Option<u32>,
         top_k: Option<u32>,
     },
+    Unknown(),
 }
 
 #[pyclass(eq, eq_int)]
@@ -78,19 +83,6 @@ impl From<MultiVectorDistanceMetric> for topk_rs::proto::v1::control::MultiVecto
     }
 }
 
-impl From<topk_rs::proto::v1::control::MultiVectorDistanceMetric> for MultiVectorDistanceMetric {
-    fn from(metric: topk_rs::proto::v1::control::MultiVectorDistanceMetric) -> Self {
-        match metric {
-            topk_rs::proto::v1::control::MultiVectorDistanceMetric::Maxsim => {
-                MultiVectorDistanceMetric::Maxsim
-            }
-            topk_rs::proto::v1::control::MultiVectorDistanceMetric::Unspecified => {
-                unreachable!("Invalid multi-vector distance metric")
-            }
-        }
-    }
-}
-
 #[pyclass(eq, eq_int)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum MultiVectorQuantization {
@@ -136,13 +128,18 @@ impl Into<topk_rs::proto::v1::control::FieldIndex> for FieldIndex {
                 width,
                 top_k,
             ),
+            FieldIndex::Unknown() => panic!("cannot write an unknown field index: {UNSUPPORTED}"),
         }
     }
 }
 
 impl From<topk_rs::proto::v1::control::FieldIndex> for FieldIndex {
     fn from(proto: topk_rs::proto::v1::control::FieldIndex) -> Self {
-        match proto.index.expect("index is required") {
+        let index = match proto.index {
+            Some(index) => index,
+            None => return FieldIndex::Unknown(),
+        };
+        match index {
             topk_rs::proto::v1::control::field_index::Index::KeywordIndex(keyword_index) => {
                 FieldIndex::KeywordIndex {
                     index_type: match keyword_index.index_type() {
@@ -152,7 +149,7 @@ impl From<topk_rs::proto::v1::control::FieldIndex> for FieldIndex {
                         topk_rs::proto::v1::control::KeywordIndexType::Exact => {
                             KeywordIndexType::Exact
                         }
-                        t => panic!("unsupported keyword index: {:?}", t),
+                        _ => return FieldIndex::Unknown(),
                     },
                 }
             }
@@ -171,7 +168,7 @@ impl From<topk_rs::proto::v1::control::FieldIndex> for FieldIndex {
                         topk_rs::proto::v1::control::VectorDistanceMetric::Hamming => {
                             VectorDistanceMetric::Hamming
                         }
-                        m => panic!("unsupported vector metric {:?}", m),
+                        _ => return FieldIndex::Unknown(),
                     },
                 }
             }
@@ -184,24 +181,54 @@ impl From<topk_rs::proto::v1::control::FieldIndex> for FieldIndex {
                         topk_rs::proto::v1::control::MultiVectorDistanceMetric::Maxsim => {
                             MultiVectorDistanceMetric::Maxsim
                         }
-                        m => panic!("unsupported multi-vector metric {:?}", m),
+                        _ => return FieldIndex::Unknown(),
                     },
-                    quantization: match mvi.quantization() {
-                        topk_rs::proto::v1::control::MultiVectorQuantization::Binary1bit => {
-                            Some(MultiVectorQuantization::Binary1bit)
-                        }
-                        topk_rs::proto::v1::control::MultiVectorQuantization::Binary2bit => {
-                            Some(MultiVectorQuantization::Binary2bit)
-                        }
-                        topk_rs::proto::v1::control::MultiVectorQuantization::Scalar => {
-                            Some(MultiVectorQuantization::Scalar)
-                        }
-                        _ => None,
+                    quantization: match mvi.quantization {
+                        Some(q) => match MultiVectorQuantizationPb::try_from(q) {
+                            Ok(MultiVectorQuantizationPb::Binary1bit) => {
+                                Some(MultiVectorQuantization::Binary1bit)
+                            }
+                            Ok(MultiVectorQuantizationPb::Binary2bit) => {
+                                Some(MultiVectorQuantization::Binary2bit)
+                            }
+                            Ok(MultiVectorQuantizationPb::Scalar) => {
+                                Some(MultiVectorQuantization::Scalar)
+                            }
+                            _ => return FieldIndex::Unknown(),
+                        },
+                        // `None` means unset, not an unrecognised value
+                        None => None,
                     },
                     width: mvi.width,
                     top_k: mvi.top_k,
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use topk_rs::proto::v1::control as pb;
+
+    #[rstest]
+    #[case::outer_oneof(pb::FieldIndex { index: None })]
+    #[case::vector_metric(pb::FieldIndex {
+        index: Some(pb::field_index::Index::VectorIndex(pb::VectorIndex {
+            metric: 9999,
+            ..Default::default()
+        })),
+    })]
+    #[case::quantization(pb::FieldIndex {
+        index: Some(pb::field_index::Index::MultiVectorIndex(pb::MultiVectorIndex {
+            metric: pb::MultiVectorDistanceMetric::Maxsim as i32,
+            quantization: Some(9999),
+            ..Default::default()
+        })),
+    })]
+    fn unknown_field_index_decodes_to_unknown(#[case] proto: pb::FieldIndex) {
+        assert_eq!(FieldIndex::from(proto), FieldIndex::Unknown());
     }
 }

--- a/topk-py/src/schema/field_spec.rs
+++ b/topk-py/src/schema/field_spec.rs
@@ -51,6 +51,17 @@ impl FieldSpec {
     }
 }
 
+impl FieldSpec {
+    pub fn has_unknown(&self) -> bool {
+        matches!(self.index, Some(FieldIndex::Unknown()))
+            || match &self.data_type {
+                DataType::Unknown() => true,
+                DataType::Struct { fields } => fields.values().any(FieldSpec::has_unknown),
+                _ => false,
+            }
+    }
+}
+
 impl Into<topk_rs::proto::v1::control::FieldSpec> for FieldSpec {
     fn into(self) -> topk_rs::proto::v1::control::FieldSpec {
         topk_rs::proto::v1::control::FieldSpec {
@@ -72,5 +83,35 @@ impl From<topk_rs::proto::v1::control::FieldSpec> for FieldSpec {
             required: proto.required,
             index: proto.index.map(|i| i.into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use topk_rs::proto::v1::control as pb;
+
+    fn spec(data_type: pb::FieldType, index: Option<pb::FieldIndex>) -> pb::FieldSpec {
+        pb::FieldSpec {
+            data_type: Some(data_type),
+            required: false,
+            index,
+        }
+    }
+
+    #[rstest]
+    #[case::known(spec(pb::FieldType::text(), None), false)]
+    #[case::unknown_type(spec(pb::FieldType { data_type: None }, None), true)]
+    #[case::unknown_index(
+        spec(pb::FieldType::text(), Some(pb::FieldIndex { index: None })),
+        true
+    )]
+    #[case::unknown_nested_in_struct(
+        spec(pb::FieldType::r#struct([("created_at", spec(pb::FieldType { data_type: None }, None))]), None),
+        true
+    )]
+    fn detects_unknown(#[case] proto: pb::FieldSpec, #[case] expected: bool) {
+        assert_eq!(FieldSpec::from(proto).has_unknown(), expected);
     }
 }

--- a/topk-py/src/schema/field_spec.rs
+++ b/topk-py/src/schema/field_spec.rs
@@ -67,10 +67,11 @@ impl From<topk_rs::proto::v1::control::FieldSpec> for FieldSpec {
             data_type: proto
                 .data_type
                 .and_then(|d| d.data_type)
-                .map(|d| d.into())
-                .expect("data_type is required"),
+                .map(DataType::from)
+                .unwrap_or(DataType::Unknown()),
             required: proto.required,
             index: proto.index.map(|i| i.into()),
         }
     }
 }
+

--- a/topk-py/src/schema/field_spec.rs
+++ b/topk-py/src/schema/field_spec.rs
@@ -74,4 +74,3 @@ impl From<topk_rs::proto::v1::control::FieldSpec> for FieldSpec {
         }
     }
 }
-

--- a/topk-py/src/schema/mod.rs
+++ b/topk-py/src/schema/mod.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use pyo3::prelude::*;
 use topk_rs::proto::v1::control::FieldSpec as FieldSpecPb;
 
+use crate::data::unknown::UNSUPPORTED;
 use crate::schema::{data_type::DataType, field_index::FieldIndex, field_spec::FieldSpec};
 
 pub mod data_type;
@@ -17,6 +18,11 @@ impl<'a, 'py> FromPyObject<'a, 'py> for SchemaFieldSpec {
 
     fn extract(ob: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
         if let Ok(fs) = ob.extract::<PyRef<FieldSpec>>() {
+            if fs.has_unknown() {
+                return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                    "cannot write an unknown field type or index: {UNSUPPORTED}"
+                )));
+            }
             return Ok(SchemaFieldSpec((*fs).clone()));
         }
         if let Ok(dict) = ob.cast::<pyo3::types::PyDict>() {

--- a/topk-py/tests/test_collection_upsert.py
+++ b/topk-py/tests/test_collection_upsert.py
@@ -376,3 +376,10 @@ def test_upsert_empty_string_list_with_helper(ctx: ProjectContext):
     obj = ctx.client.collection(collection.name).get(["x"], lsn=lsn)
 
     assert obj["x"]["string_list"] == []
+
+
+def test_upsert_rejects_unknown_value(ctx: ProjectContext):
+    with pytest.raises(TypeError, match="not supported by this version of topk-sdk"):
+        ctx.client.collection("missing").upsert(
+            [{"_id": "one", "field": data.UnknownValue()}]
+        )

--- a/topk-py/topk_sdk/data/__init__.pyi
+++ b/topk-py/topk_sdk/data/__init__.pyi
@@ -46,8 +46,7 @@ class UnknownValue:
     """
     *Internal*
 
-    Placeholder for a value whose type is not supported by this version of the SDK.
-    Reading one is safe; writing it back is rejected.
+    Placeholder for a value this version of the SDK cannot represent.
     """
 
     ...

--- a/topk-py/topk_sdk/data/__init__.pyi
+++ b/topk-py/topk_sdk/data/__init__.pyi
@@ -42,6 +42,16 @@ class Struct:
 
     ...
 
+class UnknownValue:
+    """
+    *Internal*
+
+    Placeholder for a value whose type is not supported by this version of the SDK.
+    Reading one is safe; writing it back is rejected.
+    """
+
+    ...
+
 def f8_vector(data: builtins.list[float]) -> List:
     """
     Create a [List](https://docs.topk.io/sdk/topk-py/data#List) type containing a 8-bit float vector.

--- a/topk-rs/src/proto/mod.rs
+++ b/topk-rs/src/proto/mod.rs
@@ -8,3 +8,35 @@ pub mod v1 {
     pub use super::ctx::v1 as ctx;
     pub use super::data::v1 as data;
 }
+
+#[cfg(test)]
+mod tests {
+    use prost::{
+        encoding::{encode_key, encode_varint, WireType},
+        Message,
+    };
+
+    use super::v1::control::{field_type_list::ListValueType, FieldType, FieldTypeList};
+    use super::v1::data::Value;
+
+    #[test]
+    fn unknown_oneof_variant_decodes_as_none() {
+        let mut buf = Vec::new();
+        encode_key(9999, WireType::Varint, &mut buf);
+        encode_varint(1, &mut buf);
+
+        assert_eq!(Value::decode(&buf[..]).unwrap().value, None);
+        assert_eq!(FieldType::decode(&buf[..]).unwrap().data_type, None);
+    }
+
+    #[test]
+    fn unknown_enum_value_decodes_as_unspecified() {
+        let mut buf = Vec::new();
+        encode_key(1, WireType::Varint, &mut buf);
+        encode_varint(9999, &mut buf);
+
+        let list = FieldTypeList::decode(&buf[..]).unwrap();
+        assert_eq!(list.value_type, 9999);
+        assert_eq!(list.value_type(), ListValueType::Unspecified);
+    }
+}


### PR DESCRIPTION
Old SDKs abort on data from a newer server — prost drops unknown fields, the oneof decodes as `None`, the exhaustive match panics. topk-py was worse: it mapped that `None` to `Value::Null()`, so read-modify-write silently nulled the field (upsert is full-replace).

Adds `Unknown` to `Value`, `DataType` and `FieldIndex`; sub-enums collapse into them. Values project to natives, so they get an `UnknownValue` sentinel, rejected on write. Decode no longer panics; write path unchanged.