### PR TITLE
[sql,es] widen index + table names

### DIFF
--- a/topk-es/src/api/path.rs
+++ b/topk-es/src/api/path.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::Error;
 
 static VALID_INDEX_NAME: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[a-z][a-z0-9_-]{0,127}$").unwrap());
+    LazyLock::new(|| Regex::new(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,254}$").unwrap());
 
 #[repr(transparent)]
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
@@ -25,8 +25,8 @@ impl TryFrom<String> for IndexName {
     fn try_from(index: String) -> Result<Self, Self::Error> {
         if !VALID_INDEX_NAME.is_match(&index) {
             return Err(Error::InvalidIndexName(format!(
-                "\"{index}\": must start with a lowercase letter and contain only lowercase \
-                 letters, digits, underscores, and dashes (max 128 characters)"
+                "\"{index}\": must start with a letter or digit and contain only letters, \
+                 digits, underscores, dashes, and dots (max 255 characters)"
             )));
         }
 
@@ -133,6 +133,44 @@ impl Deref for DocId {
 #[derive(Deserialize)]
 struct DocPath {
     id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::plain("books")]
+    #[case::dashed("books-v2")]
+    #[case::underscored("books_v2")]
+    #[case::dated_logs("logs-2026.07.29")]
+    #[case::leading_digit("2026-logs")]
+    #[case::all_digits("1234")]
+    #[case::uppercase("Books")]
+    #[case::trailing_dot("logs-2026.07.29.")]
+    #[case::max_length(&"a".repeat(255))]
+    fn index_name_ok(#[case] index: &str) {
+        assert_eq!(
+            IndexName::try_from(index.to_string()).unwrap().as_str(),
+            index
+        );
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::leading_dash("-books")]
+    #[case::leading_underscore("_books")]
+    #[case::leading_dot(".books")]
+    #[case::plus("books+v2")]
+    #[case::space("books v2")]
+    #[case::comma("books,logs")]
+    #[case::wildcard("books*")]
+    #[case::too_long(&"a".repeat(256))]
+    fn index_name_rejected(#[case] index: &str) {
+        assert!(IndexName::try_from(index.to_string()).is_err());
+    }
 }
 
 #[async_trait]

--- a/topk-sql/src/lib.rs
+++ b/topk-sql/src/lib.rs
@@ -125,17 +125,60 @@ pub fn convert_sql(
 // so the rest of the pipeline sees only the canonical `collection$partition` form (a `$`-
 // qualified identifier, which PostgreSQL dialects accept).
 fn rewrite_partition_syntax(sql: &str) -> std::borrow::Cow<'_, str> {
-    static RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?i)\b([\w.]+)\s+PARTITION\s+(\w+)\b").unwrap());
+    static RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r#"(?i)'[^']*'|("[^"]+"|[\w.-]+)\s+PARTITION\s+([\w-]+)\b"#).unwrap()
+    });
 
     RE.replace_all(sql, |caps: &regex::Captures| {
+        if caps.get(1).is_none() {
+            return caps[0].to_string();
+        }
+        let table = &caps[1];
         let partition = &caps[2];
         if partition.eq_ignore_ascii_case("BY") {
-            caps[0].to_string()
-        } else {
-            format!("{}${}", &caps[1], partition)
+            return caps[0].to_string();
+        }
+        if let Some(inner) = table.strip_prefix('"').and_then(|t| t.strip_suffix('"')) {
+            return format!("\"{inner}${partition}\"");
+        }
+        match table.rsplit_once('.') {
+            Some((schema, name)) => format!("{schema}.\"{name}${partition}\""),
+            None => format!("\"{table}${partition}\""),
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case("SELECT * FROM books WHERE title = 'a PARTITION b'")]
+    #[case("SELECT rank() OVER (PARTITION BY x) FROM books")]
+    #[case("SELECT * FROM books")]
+    fn rewrite_leaves_sql_untouched(#[case] sql: &str) {
+        assert_eq!(rewrite_partition_syntax(sql), sql);
+    }
+
+    #[rstest]
+    #[case("SELECT * FROM books PARTITION p1", "SELECT * FROM \"books$p1\"")]
+    #[case(
+        "SELECT * FROM public.books-v2 PARTITION p1",
+        "SELECT * FROM public.\"books-v2$p1\""
+    )]
+    #[case(
+        "SELECT * FROM \"logs.2026\" PARTITION p1",
+        "SELECT * FROM \"logs.2026$p1\""
+    )]
+    #[case(
+        "SELECT * FROM logs.2026 PARTITION p1",
+        "SELECT * FROM logs.\"2026$p1\""
+    )]
+    fn rewrite_partition(#[case] sql: &str, #[case] expected: &str) {
+        assert_eq!(rewrite_partition_syntax(sql), expected);
+    }
 }
 
 #[macro_export]

--- a/topk-sql/src/table.rs
+++ b/topk-sql/src/table.rs
@@ -98,6 +98,28 @@ mod tests {
     #[case("PUBLIC.books", Table::Collection("books".into()))]
     #[case("books$part", Table::Partition("books".into(), "part".into()))]
     #[case("public.books$part", Table::Partition("books".into(), "part".into()))]
+    #[case("\"logs-2026.07.29\"", Table::Collection("logs-2026.07.29".into()))]
+    #[case("\"2026-logs\"", Table::Collection("2026-logs".into()))]
+    #[case(
+        "\"logs-2026.07.29\" PARTITION part",
+        Table::Partition("logs-2026.07.29".into(), "part".into())
+    )]
+    #[case(
+        "\"logs-2026.07.29\" PARTITION part-2",
+        Table::Partition("logs-2026.07.29".into(), "part-2".into())
+    )]
+    #[case(
+        "books PARTITION part-2",
+        Table::Partition("books".into(), "part-2".into())
+    )]
+    #[case(
+        "books-v2 PARTITION part",
+        Table::Partition("books-v2".into(), "part".into())
+    )]
+    #[case(
+        "public.books-v2 PARTITION part",
+        Table::Partition("books-v2".into(), "part".into())
+    )]
     fn new_ok(#[case] table: &str, #[case] expected: Table) {
         assert_eq!(Table::new(name(table)).unwrap(), expected);
     }


### PR DESCRIPTION
es:
- `IndexName` → `^[A-Za-z0-9][A-Za-z0-9_.+-]{0,254}$`, was stricter than ES itself

sql:
- partition rewrite no longer mangles quoted names, dashed names, or text in string literals