### PR TITLE
[es] serde_json -> sonic-rs

### DIFF
--- a/topk-es/Cargo.toml
+++ b/topk-es/Cargo.toml
@@ -10,14 +10,16 @@ axum = { version = "0.7.9" }
 http = { version = "1.4.0" }
 regex = { version = "1.12" }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0" }
+sonic-rs = { version = "0.5.8" }
 serde_with = { version = "3.12.0" }
 thiserror = { version = "1.0.65" }
 topk-rs = { path = "../topk-rs", features = ["json"] }
 
 [dev-dependencies]
 test-macros = { path = "../utils/test-macros" }
-elasticsearch = { version = "8.15.0-alpha.1", default-features = false, features = ["rustls-tls"] }
+elasticsearch = { version = "8.15.0-alpha.1", default-features = false, features = [
+    "rustls-tls",
+] }
 futures = { version = "0.3.31" }
 rstest = { version = "0.23.0" }
 serde_json = { version = "1.0" }

--- a/topk-es/src/api/body.rs
+++ b/topk-es/src/api/body.rs
@@ -19,7 +19,7 @@ where
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let body = match read_json(req, state).await? {
             Some(body) => body,
-            None => serde_json::from_str("{}")?,
+            None => sonic_rs::from_str("{}")?,
         };
         Ok(Body(body))
     }
@@ -76,11 +76,11 @@ where
     // ES request bodies are always JSON objects. Reject arrays/scalars up front:
     // serde deserializes a struct from a positional sequence, so a bare `[]` would
     // otherwise become an all-defaults request (e.g. `_search` match-all).
-    let json: serde_json::Value = serde_json::from_slice(&bytes)?;
-    if !json.is_object() {
+    if !(bytes.starts_with(b"{") && bytes.ends_with(b"}")) {
         return Err(Error::BadRequest(
             "Request body must be a JSON object".into(),
         ));
     }
-    Ok(Some(serde_json::from_value(json)?))
+
+    Ok(Some(sonic_rs::from_slice(&bytes)?))
 }

--- a/topk-es/src/api/body.rs
+++ b/topk-es/src/api/body.rs
@@ -19,7 +19,7 @@ where
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let body = match read_json(req, state).await? {
             Some(body) => body,
-            None => sonic_rs::from_str("{}")?,
+            None => sonic_rs::from_slice(b"{}")?,
         };
         Ok(Body(body))
     }
@@ -48,39 +48,139 @@ where
     T: DeserializeOwned,
     S: Send + Sync,
 {
-    let media_type = req
-        .headers()
-        .get(CONTENT_TYPE)
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-        .map(str::to_string);
+    // Classified before the body is consumed, but reported after: an empty body
+    // is accepted whatever the header says.
+    let media_type = MediaType::of(&req);
 
     let bytes = Bytes::from_request(req, state)
         .await
         .map_err(|e| Error::BadRequest(format!("Failed to read request body: {e}")))?;
 
-    if bytes.iter().all(u8::is_ascii_whitespace) {
+    let body = bytes.trim_ascii();
+    if body.is_empty() {
         return Ok(None);
     }
 
-    let Some(media_type) = media_type else {
-        return Err(Error::NotAcceptable("Missing Content-Type header".into()));
-    };
-
-    if !media_type.contains("json") {
-        return Err(Error::UnsupportedMediaType(format!(
-            "Content-Type header [{media_type}] is not supported"
-        )));
+    match media_type {
+        MediaType::Json => {}
+        MediaType::Missing => {
+            return Err(Error::NotAcceptable("Missing Content-Type header".into()))
+        }
+        MediaType::Other(media_type) => {
+            return Err(Error::UnsupportedMediaType(format!(
+                "Content-Type header [{media_type}] is not supported"
+            )))
+        }
     }
 
     // ES request bodies are always JSON objects. Reject arrays/scalars up front:
     // serde deserializes a struct from a positional sequence, so a bare `[]` would
     // otherwise become an all-defaults request (e.g. `_search` match-all).
-    if !(bytes.starts_with(b"{") && bytes.ends_with(b"}")) {
+    if !body.starts_with(b"{") {
         return Err(Error::BadRequest(
             "Request body must be a JSON object".into(),
         ));
     }
 
-    Ok(Some(sonic_rs::from_slice(&bytes)?))
+    Ok(Some(sonic_rs::from_slice(body)?))
+}
+
+enum MediaType {
+    Json,
+    Missing,
+    Other(String),
+}
+
+impl MediaType {
+    fn of(req: &Request) -> Self {
+        match req
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .filter(|value| !value.is_empty())
+        {
+            None => MediaType::Missing,
+            Some(media_type) if media_type.contains("json") => MediaType::Json,
+            Some(media_type) => MediaType::Other(media_type.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body as AxumBody;
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Default, Deserialize, PartialEq)]
+    #[serde(deny_unknown_fields)]
+    struct Query {
+        #[serde(default)]
+        size: u64,
+    }
+
+    fn read(content_type: Option<&str>, body: &'static str) -> Result<Option<Query>, Error> {
+        let mut req = Request::builder().method("POST");
+        if let Some(content_type) = content_type {
+            req = req.header(CONTENT_TYPE, content_type);
+        }
+        let req = req.body(AxumBody::from(body)).unwrap();
+
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap()
+            .block_on(read_json(req, &()))
+    }
+
+    #[rstest::rstest]
+    #[case::object(r#"{"size": 5}"#)]
+    #[case::surrounding_whitespace("\n  {\"size\": 5}\n")]
+    fn reads_a_json_object(#[case] body: &'static str) {
+        assert_eq!(
+            read(Some("application/json"), body).unwrap(),
+            Some(Query { size: 5 })
+        );
+    }
+
+    // An empty body means "no body", whatever the headers say.
+    #[rstest::rstest]
+    #[case::empty("")]
+    #[case::whitespace(" \n\t")]
+    fn treats_an_empty_body_as_absent(#[case] body: &'static str) {
+        assert_eq!(read(None, body).unwrap(), None);
+    }
+
+    // A struct deserializes from a positional sequence, so a bare array would
+    // otherwise pass as an all-defaults request.
+    #[rstest::rstest]
+    #[case::array("[]")]
+    #[case::array_of_values("[1, 2]")]
+    #[case::scalar("5")]
+    #[case::string(r#""a""#)]
+    fn rejects_bodies_that_are_not_objects(#[case] body: &'static str) {
+        let result = read(Some("application/json"), body);
+        assert!(matches!(result, Err(Error::BadRequest(_))), "{result:?}");
+    }
+
+    #[test]
+    fn requires_a_content_type() {
+        assert!(matches!(read(None, "{}"), Err(Error::NotAcceptable(_))));
+    }
+
+    #[test]
+    fn rejects_non_json_content_types() {
+        assert!(matches!(
+            read(Some("text/plain"), "{}"),
+            Err(Error::UnsupportedMediaType(_))
+        ));
+    }
+
+    #[test]
+    fn reports_malformed_json() {
+        assert!(matches!(
+            read(Some("application/json"), "{\"size\":"),
+            Err(Error::SerdeJson(_))
+        ));
+    }
 }

--- a/topk-es/src/api/bulk.rs
+++ b/topk-es/src/api/bulk.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
+use serde::de::IgnoredAny;
 use serde::ser::{SerializeMap, Serializer};
 use serde::{Deserialize, Serialize};
 
 use super::ndjson::{NdjsonBody, NdjsonHeader, NdjsonLines};
-use super::{DocBody, DocId, IndexName, WriteBody, WriteDoc, WriteRequest, WriteResult};
+use super::{DocId, IndexName, RawDocBody, WriteBody, WriteDoc, WriteRequest, WriteResult};
 use crate::{Error, ErrorBody};
 
 #[derive(Clone, Copy)]
@@ -64,8 +63,9 @@ impl NdjsonHeader for ActionLine {
 
         match self {
             ActionLine::Index(_) => {
-                let doc: HashMap<String, serde_json::Value> = lines.parse()?;
-                let request = DocBody::try_from(doc)
+                let doc: RawDocBody = lines.parse()?;
+                let request = doc
+                    .into_body()
                     .map(|body| WriteRequest::Upsert(vec![WriteDoc::new(id.clone(), body)]));
                 Ok(BulkEntry {
                     id,
@@ -74,7 +74,7 @@ impl NdjsonHeader for ActionLine {
                 })
             }
             ActionLine::Create(_) => {
-                let _: serde_json::Value = lines.parse()?;
+                let _: IgnoredAny = lines.parse()?;
                 Ok(BulkEntry::unsupported(
                     id,
                     WriteKind::Create,
@@ -100,7 +100,8 @@ impl NdjsonHeader for ActionLine {
                 let doc = src
                     .doc
                     .ok_or_else(|| Error::BadRequest("Update action missing \"doc\"".into()))?;
-                let request = DocBody::try_from(doc)
+                let request = doc
+                    .into_body()
                     .map(|body| WriteRequest::Update(vec![WriteDoc::new(id.clone(), body)]));
                 Ok(BulkEntry {
                     id,
@@ -150,9 +151,10 @@ impl ActionLine {
 #[serde(deny_unknown_fields)]
 struct UpdateSource {
     #[serde(default)]
-    doc: Option<HashMap<String, serde_json::Value>>,
+    doc: Option<RawDocBody>,
+    // Scripted updates are rejected, so the script itself is never read.
     #[serde(default)]
-    script: Option<serde_json::Value>,
+    script: Option<IgnoredAny>,
     #[serde(default)]
     doc_as_upsert: Option<bool>,
 }

--- a/topk-es/src/api/doc.rs
+++ b/topk-es/src/api/doc.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
+use std::fmt;
 
-use serde::{Deserialize, Serialize};
-use topk_rs::json::Value;
-use topk_rs::proto::v1::data::Value as TopkValue;
+use serde::de::{Error as DeError, MapAccess, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use topk_rs::json::{LenientValue, Value};
 
 use super::DocId;
 use super::IndexName;
@@ -23,35 +24,88 @@ pub struct DocItem {
     pub source: Option<Source>,
 }
 
-#[derive(Deserialize)]
-#[serde(try_from = "HashMap<String, serde_json::Value>")]
 pub struct DocBody(HashMap<String, Value>);
 
-impl TryFrom<HashMap<String, serde_json::Value>> for DocBody {
-    type Error = Error;
+impl<'de> Deserialize<'de> for DocBody {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer
+            .deserialize_map(DocBodyVisitor)?
+            .map_err(DeError::custom)
+    }
+}
 
-    fn try_from(doc: HashMap<String, serde_json::Value>) -> Result<Self, Self::Error> {
-        let mut fields = HashMap::with_capacity(doc.len());
-        for (key, value) in doc {
-            if key == "_id" {
-                return Err(Error::BadRequest(
+/// A document body whose field errors are captured instead of raised, so a bulk
+/// request can reject the offending item and keep reading the ones around it.
+/// Malformed JSON still fails the deserializer.
+pub struct RawDocBody(Result<DocBody, Error>);
+
+impl RawDocBody {
+    pub fn into_body(self) -> Result<DocBody, Error> {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for RawDocBody {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_map(DocBodyVisitor).map(Self)
+    }
+}
+
+struct DocBodyVisitor;
+
+impl<'de> Visitor<'de> for DocBodyVisitor {
+    type Value = Result<DocBody, Error>;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a document body")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+        let mut fields = HashMap::with_capacity(map.size_hint().unwrap_or(0));
+        let mut rejected = None;
+
+        // Entries keep being read after one is rejected: the body must be
+        // consumed whole for the caller to report the failure as its own.
+        while let Some(name) = map.next_key::<String>()? {
+            let value = map.next_value::<LenientValue>()?.into_result();
+            if rejected.is_some() {
+                continue;
+            }
+
+            if name == "_id" {
+                rejected = Some(Error::BadRequest(
                     "\"_id\" is a metadata field and cannot be set inside the document body".into(),
                 ));
+                continue;
             }
-            let value = TopkValue::try_from(value)
-                .map(Value::from)
-                .map_err(|e| Error::BadRequest(e.to_string()))?;
-            fields.insert(key, value);
+
+            match value {
+                Ok(value) => {
+                    fields.insert(name, Value::from(value));
+                }
+                Err(e) => rejected = Some(Error::BadRequest(e.to_string())),
+            }
         }
-        Ok(Self(fields))
+
+        Ok(match rejected {
+            Some(e) => Err(e),
+            None => Ok(DocBody(fields)),
+        })
     }
 }
 
 impl DocBody {
     pub fn into_fields(self, id: &DocId) -> HashMap<String, Value> {
         let mut doc = self.0;
-        doc.insert("_id".to_string(), id.to_string().into());
+        doc.insert("_id".to_string(), id.as_str().into());
         doc
+    }
+}
+
+impl DocBody {
+    #[cfg(test)]
+    fn fields(&self) -> &HashMap<String, Value> {
+        &self.0
     }
 }
 
@@ -67,5 +121,66 @@ impl WriteDoc {
 
     pub fn into_fields(self) -> HashMap<String, Value> {
         self.body.into_fields(&self.id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use topk_rs::proto::v1::data::Value as TopkValue;
+
+    use super::*;
+
+    #[test]
+    fn reads_fields_into_topk_values() {
+        let doc: DocBody =
+            sonic_rs::from_str(r#"{"title": "a", "n": [1, 2], "meta": {"x": 1.5}}"#).unwrap();
+        let fields = doc.fields();
+
+        assert_eq!(fields["title"].0, TopkValue::string("a"));
+        assert_eq!(fields["n"].0, TopkValue::list(vec![1_i64, 2]));
+        assert_eq!(
+            fields["meta"].0,
+            TopkValue::r#struct([("x", TopkValue::f64(1.5))])
+        );
+    }
+
+    #[test]
+    fn adds_the_id_field() {
+        let doc: DocBody = sonic_rs::from_str(r#"{"title": "a"}"#).unwrap();
+        let id = DocId::try_from("1".to_string()).unwrap();
+
+        assert_eq!(doc.into_fields(&id)["_id"].0, TopkValue::string("1"));
+    }
+
+    #[test]
+    fn rejects_id_in_the_body() {
+        assert!(sonic_rs::from_str::<DocBody>(r#"{"_id": "spoofed"}"#).is_err());
+    }
+
+    #[test]
+    fn rejects_values_topk_cannot_hold() {
+        assert!(sonic_rs::from_str::<DocBody>(r#"{"items": [{"a": 1}]}"#).is_err());
+    }
+
+    // Bulk reports a bad document as one failed item, so the body has to parse.
+    #[rstest::rstest]
+    #[case::id_in_body(r#"{"_id": "spoofed", "title": "a"}"#)]
+    #[case::unrepresentable_value(r#"{"items": [{"a": 1}], "title": "a"}"#)]
+    fn raw_body_captures_field_errors(#[case] body: &str) {
+        let doc: RawDocBody = sonic_rs::from_str(body).expect("the line itself is valid JSON");
+        assert!(doc.into_body().is_err());
+    }
+
+    #[test]
+    fn raw_body_still_fails_on_malformed_json() {
+        assert!(sonic_rs::from_str::<RawDocBody>(r#"{"title":"#).is_err());
+    }
+
+    #[rstest::rstest]
+    #[case::array("[1, 2]")]
+    #[case::scalar("5")]
+    fn a_document_body_must_be_an_object(#[case] body: &str) {
+        assert!(sonic_rs::from_str::<DocBody>(body).is_err());
+        assert!(sonic_rs::from_str::<RawDocBody>(body).is_err());
     }
 }

--- a/topk-es/src/api/index.rs
+++ b/topk-es/src/api/index.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::Serialize;
 
 use super::mapping::MappingProperties;
@@ -56,9 +54,13 @@ pub struct IndexSettingsBody {
     pub index: IndexSettingsInnerBody,
 }
 
+// Aliases are not supported, so the response always carries an empty object.
+#[derive(Serialize)]
+pub struct Aliases {}
+
 #[derive(Serialize)]
 pub struct GetIndexBody {
-    pub aliases: HashMap<String, serde_json::Value>,
+    pub aliases: Aliases,
     pub mappings: MappingBody,
     pub settings: IndexSettingsBody,
 }
@@ -66,7 +68,7 @@ pub struct GetIndexBody {
 impl GetIndexBody {
     pub fn new(index: String, properties: MappingProperties) -> Self {
         Self {
-            aliases: HashMap::new(),
+            aliases: Aliases {},
             mappings: MappingBody { properties },
             settings: IndexSettingsBody {
                 index: IndexSettingsInnerBody {

--- a/topk-es/src/api/mapping.rs
+++ b/topk-es/src/api/mapping.rs
@@ -44,7 +44,7 @@ impl TryFrom<HashMap<String, serde_json::Value>> for MappingProperties {
                     }
                 }
 
-                serde_json::from_value(value)
+                sonic_rs::from_value(value)
                     .map(|mapping| (name, mapping))
                     .map_err(|e| Error::BadRequest(e.to_string()))
             })

--- a/topk-es/src/api/mapping.rs
+++ b/topk-es/src/api/mapping.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
+use serde::de::IgnoredAny;
 use serde::{Deserialize, Serialize};
+use sonic_rs::{JsonValueMutTrait, Value as JsonValue};
 
 use topk_rs::proto::v1::control::{
     field_index, field_type, field_type_matrix::MatrixValueType, FieldIndex, FieldSpec,
@@ -12,9 +14,10 @@ use crate::Error;
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct IndexMapping {
+    // Accepted for compatibility, never read.
     #[serde(default)]
     #[allow(dead_code)]
-    settings: Option<serde_json::Value>,
+    settings: Option<IgnoredAny>,
 
     #[serde(default)]
     mappings: Option<Mappings>,
@@ -27,24 +30,27 @@ struct Mappings {
     properties: Option<MappingProperties>,
 }
 
+// Mappings are read once per index create/get, so the intermediate document
+// here costs nothing measurable — and `FieldMapping` is an internally tagged
+// enum, whose tag has to be patched in before serde can pick a variant.
 #[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq)]
-#[serde(try_from = "HashMap<String, serde_json::Value>")]
+#[serde(try_from = "HashMap<String, JsonValue>")]
 pub struct MappingProperties(pub HashMap<String, FieldMapping>);
 
-impl TryFrom<HashMap<String, serde_json::Value>> for MappingProperties {
+impl TryFrom<HashMap<String, JsonValue>> for MappingProperties {
     type Error = Error;
 
-    fn try_from(raw: HashMap<String, serde_json::Value>) -> Result<Self, Self::Error> {
+    fn try_from(raw: HashMap<String, JsonValue>) -> Result<Self, Self::Error> {
         raw.into_iter()
             .map(|(name, mut value)| {
                 // ES infers `type: object` from a bare `properties` block.
                 if let Some(object) = value.as_object_mut() {
-                    if !object.contains_key("type") && object.contains_key("properties") {
-                        object.insert("type".to_string(), "object".into());
+                    if !object.contains_key(&"type") && object.contains_key(&"properties") {
+                        object.insert(&"type", "object");
                     }
                 }
 
-                sonic_rs::from_value(value)
+                sonic_rs::from_value(&value)
                     .map(|mapping| (name, mapping))
                     .map_err(|e| Error::BadRequest(e.to_string()))
             })
@@ -168,7 +174,7 @@ pub enum FieldMapping {
 
         #[allow(dead_code)]
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        chunking_settings: Option<serde_json::Value>,
+        chunking_settings: Option<JsonValue>,
     },
 }
 

--- a/topk-es/src/api/ndjson.rs
+++ b/topk-es/src/api/ndjson.rs
@@ -1,7 +1,8 @@
 use std::marker::PhantomData;
-use std::str::Lines;
+use std::slice::Split;
 
 use async_trait::async_trait;
+use axum::body::Bytes;
 use axum::extract::{FromRequest, FromRequestParts, Request};
 use serde::de::DeserializeOwned;
 
@@ -44,20 +45,20 @@ impl<H: NdjsonHeader> NdjsonBody<H> {
         self.entries
     }
 
-    fn parse(body: String, path: Option<IndexName>) -> Result<Self, Error> {
-        if !body.ends_with('\n') {
+    fn parse(body: &[u8], path: Option<IndexName>) -> Result<Self, Error> {
+        if !body.ends_with(b"\n") {
             return Err(Error::BadRequest(
                 "NDJSON request must be terminated by a newline [\\n]".into(),
             ));
         }
 
         let mut lines = NdjsonLines {
-            lines: body.lines(),
+            lines: body.split(is_newline),
         };
 
         let mut entries = Vec::new();
         while let Some(first) = lines.next() {
-            let header: H = sonic_rs::from_str(first)?;
+            let header: H = sonic_rs::from_slice(first)?;
             let line_index = header.index();
             let payload = header.parse_payload(&mut lines)?;
             let index = line_index
@@ -86,20 +87,27 @@ where
         let path = Option::<IndexName>::from_request_parts(&mut parts, state)
             .await
             .expect("Option<IndexName> extraction is infallible");
-        let body = String::from_request(Request::from_parts(parts, body), state)
+        let body = Bytes::from_request(Request::from_parts(parts, body), state)
             .await
             .map_err(|e| Error::BadRequest(format!("Failed to read NDJSON body: {e}")))?;
-        Self::parse(body, path)
+        Self::parse(&body, path)
     }
 }
 
+fn is_newline(byte: &u8) -> bool {
+    *byte == b'\n'
+}
+
 pub struct NdjsonLines<'a> {
-    lines: Lines<'a>,
+    lines: Split<'a, u8, fn(&u8) -> bool>,
 }
 
 impl<'a> NdjsonLines<'a> {
-    fn next(&mut self) -> Option<&'a str> {
-        self.lines.by_ref().find(|line| !line.trim().is_empty())
+    fn next(&mut self) -> Option<&'a [u8]> {
+        self.lines
+            .by_ref()
+            .map(|line| line.trim_ascii())
+            .find(|line| !line.is_empty())
     }
 
     pub(crate) fn parse<T: DeserializeOwned>(&mut self) -> Result<T, Error> {
@@ -107,6 +115,68 @@ impl<'a> NdjsonLines<'a> {
             .next()
             .ok_or_else(|| Error::BadRequest("Unexpected end of NDJSON body".into()))?;
 
-        Ok(sonic_rs::from_str(line)?)
+        Ok(sonic_rs::from_slice(line)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct Header {
+        #[serde(default)]
+        index: Option<IndexName>,
+    }
+
+    impl NdjsonJsonHeader for Header {
+        type Payload = Vec<i64>;
+
+        fn index(&self) -> Option<IndexName> {
+            self.index.clone()
+        }
+    }
+
+    fn parse(body: &str, path: Option<&str>) -> Result<Vec<(IndexName, Vec<i64>)>, Error> {
+        let path = path.map(|index| IndexName::try_from(index.to_string()).unwrap());
+        NdjsonBody::<Header>::parse(body.as_bytes(), path).map(NdjsonBody::into_entries)
+    }
+
+    #[test]
+    fn pairs_each_header_with_its_payload() {
+        let entries = parse("{\"index\":\"a\"}\n[1,2]\n{\"index\":\"b\"}\n[3]\n", None).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0.as_str(), "a");
+        assert_eq!(entries[0].1, vec![1, 2]);
+        assert_eq!(entries[1].0.as_str(), "b");
+        assert_eq!(entries[1].1, vec![3]);
+    }
+
+    #[test]
+    fn skips_blank_lines_and_carriage_returns() {
+        let entries = parse("{}\r\n[1]\r\n\r\n{}\n\n[2]\n", Some("idx")).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0.as_str(), "idx");
+        assert_eq!(entries[0].1, vec![1]);
+        assert_eq!(entries[1].1, vec![2]);
+    }
+
+    #[test]
+    fn requires_a_trailing_newline() {
+        assert!(parse("{}\n[1]", Some("idx")).is_err());
+    }
+
+    #[test]
+    fn requires_an_index() {
+        assert!(parse("{}\n[1]\n", None).is_err());
+    }
+
+    #[test]
+    fn requires_a_payload_for_every_header() {
+        assert!(parse("{}\n", Some("idx")).is_err());
     }
 }

--- a/topk-es/src/api/ndjson.rs
+++ b/topk-es/src/api/ndjson.rs
@@ -57,7 +57,7 @@ impl<H: NdjsonHeader> NdjsonBody<H> {
 
         let mut entries = Vec::new();
         while let Some(first) = lines.next() {
-            let header: H = serde_json::from_str(first)?;
+            let header: H = sonic_rs::from_str(first)?;
             let line_index = header.index();
             let payload = header.parse_payload(&mut lines)?;
             let index = line_index
@@ -107,6 +107,6 @@ impl<'a> NdjsonLines<'a> {
             .next()
             .ok_or_else(|| Error::BadRequest("Unexpected end of NDJSON body".into()))?;
 
-        Ok(serde_json::from_str(line)?)
+        Ok(sonic_rs::from_str(line)?)
     }
 }

--- a/topk-es/src/api/path.rs
+++ b/topk-es/src/api/path.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use axum::extract::{FromRequestParts, Path};
 use http::request::Parts;
 use regex::Regex;
-use serde::de::Error as DeError;
+use serde::de::{Error as DeError, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::Error;
@@ -80,16 +80,43 @@ pub struct DocId(String);
 // ES coerces numeric ids to their string form, so accept a string or a number.
 impl<'de> Deserialize<'de> for DocId {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let id = match serde_json::Value::deserialize(deserializer)? {
-            serde_json::Value::String(s) => s,
-            serde_json::Value::Number(n) => n.to_string(),
-            other => {
-                return Err(DeError::custom(format!(
-                    "document id must be a string or number, got {other}"
-                )))
-            }
-        };
+        deserializer.deserialize_any(DocIdVisitor)
+    }
+}
+
+struct DocIdVisitor;
+
+impl DocIdVisitor {
+    fn build<E: DeError>(id: String) -> Result<DocId, E> {
         DocId::try_from(id).map_err(DeError::custom)
+    }
+}
+
+impl Visitor<'_> for DocIdVisitor {
+    type Value = DocId;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a document id as a string or number")
+    }
+
+    fn visit_str<E: DeError>(self, id: &str) -> Result<DocId, E> {
+        Self::build(id.to_string())
+    }
+
+    fn visit_string<E: DeError>(self, id: String) -> Result<DocId, E> {
+        Self::build(id)
+    }
+
+    fn visit_i64<E: DeError>(self, id: i64) -> Result<DocId, E> {
+        Self::build(id.to_string())
+    }
+
+    fn visit_u64<E: DeError>(self, id: u64) -> Result<DocId, E> {
+        Self::build(id.to_string())
+    }
+
+    fn visit_f64<E: DeError>(self, id: f64) -> Result<DocId, E> {
+        Self::build(id.to_string())
     }
 }
 
@@ -114,6 +141,10 @@ impl DocId {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
 }
 
 impl fmt::Display for DocId {
@@ -127,6 +158,38 @@ impl Deref for DocId {
 
     fn deref(&self) -> &str {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::string(r#""abc""#, "abc")]
+    #[case::integer("42", "42")]
+    #[case::negative_integer("-42", "-42")]
+    #[case::float("1.5", "1.5")]
+    fn doc_id_accepts_strings_and_numbers(#[case] body: &str, #[case] expected: &str) {
+        let id: DocId = sonic_rs::from_str(body).unwrap();
+        assert_eq!(id.as_str(), expected);
+    }
+
+    #[rstest]
+    #[case::empty(r#""""#)]
+    #[case::bool("true")]
+    #[case::null("null")]
+    #[case::array("[1]")]
+    fn doc_id_rejected(#[case] body: &str) {
+        assert!(sonic_rs::from_str::<DocId>(body).is_err());
+    }
+
+    #[test]
+    fn doc_id_rejects_ids_over_512_bytes() {
+        let id = "a".repeat(513);
+        assert!(sonic_rs::from_str::<DocId>(&format!("\"{id}\"")).is_err());
     }
 }
 

--- a/topk-es/src/api/query.rs
+++ b/topk-es/src/api/query.rs
@@ -1,8 +1,11 @@
-use std::collections::HashMap;
+use std::fmt;
+use std::marker::PhantomData;
 
+use serde::de::{Error as DeError, IgnoredAny, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 use serde_with::{serde_as, OneOrMany};
 use topk_rs::json::Value;
+use topk_rs::proto::v1::data::{value, Value as TopkValue};
 
 use super::DocId;
 use crate::value::ValueExt;
@@ -100,26 +103,37 @@ pub struct SemanticQuery {
     pub boost: Option<f32>,
 }
 
-#[derive(Deserialize)]
-#[serde(try_from = "HashMap<String, V>")]
+/// A `{"field": value}` clause. Read straight off the map — a single-entry
+/// `HashMap` never gets built.
 pub struct FieldClause<V> {
     pub field: FieldName,
     pub value: V,
 }
 
-impl<V> TryFrom<HashMap<String, V>> for FieldClause<V> {
-    type Error = Error;
+impl<'de, V: Deserialize<'de>> Deserialize<'de> for FieldClause<V> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_map(FieldClauseVisitor(PhantomData))
+    }
+}
 
-    fn try_from(map: HashMap<String, V>) -> Result<Self, Self::Error> {
-        let mut iter = map.into_iter();
-        let (field, value) = iter.next().ok_or_else(|| {
-            Error::InvalidQuery("Expected a single \"field\": value clause".into())
-        })?;
-        if iter.next().is_some() {
-            return Err(Error::InvalidQuery(
-                "Expected exactly one field in clause".into(),
-            ));
+struct FieldClauseVisitor<V>(PhantomData<V>);
+
+impl<'de, V: Deserialize<'de>> Visitor<'de> for FieldClauseVisitor<V> {
+    type Value = FieldClause<V>;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a single \"field\": value clause")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<FieldClause<V>, A::Error> {
+        let Some((field, value)) = map.next_entry::<String, V>()? else {
+            return Err(DeError::custom("Expected a single \"field\": value clause"));
+        };
+
+        if map.next_key::<IgnoredAny>()?.is_some() {
+            return Err(DeError::custom("Expected exactly one field in clause"));
         }
+
         Ok(FieldClause {
             field: FieldName::new(field),
             value,
@@ -213,49 +227,64 @@ pub enum TermValue {
 }
 
 impl TermValue {
-    pub fn value(&self) -> topk_rs::proto::v1::data::Value {
+    pub fn into_parts(self) -> (TopkValue, Option<f32>) {
         match self {
-            TermValue::Full { value, .. } => value.0.clone(),
-            TermValue::Bare(value) => value.0.clone(),
+            TermValue::Full { value, boost } => (value.into_inner(), boost),
+            TermValue::Bare(value) => (value.into_inner(), None),
         }
     }
 }
 
-#[derive(Deserialize)]
-#[serde(try_from = "TermsQueryWire")]
 pub struct TermsQuery {
     pub field: FieldName,
-    pub values: topk_rs::proto::v1::data::Value,
+    pub values: TopkValue,
     pub boost: Option<f32>,
 }
 
-#[derive(Deserialize)]
-struct TermsQueryWire {
-    #[serde(default)]
-    boost: Option<f32>,
-
-    #[serde(flatten)]
-    fields: HashMap<String, Vec<serde_json::Value>>,
+impl<'de> Deserialize<'de> for TermsQuery {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_map(TermsQueryVisitor)
+    }
 }
 
-impl TryFrom<TermsQueryWire> for TermsQuery {
-    type Error = Error;
+struct TermsQueryVisitor;
 
-    fn try_from(wire: TermsQueryWire) -> Result<Self, Self::Error> {
-        let mut fields = wire.fields.into_iter();
-        let (field, values) = fields
-            .next()
-            .ok_or_else(|| Error::InvalidQuery("Terms query missing a field".into()))?;
-        if fields.next().is_some() {
-            return Err(Error::InvalidQuery(
-                "Terms query must have exactly one field".into(),
-            ));
+impl<'de> Visitor<'de> for TermsQueryVisitor {
+    type Value = TermsQuery;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a \"field\": [values] clause with an optional \"boost\"")
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<TermsQuery, A::Error> {
+        let mut terms: Option<(FieldName, TopkValue)> = None;
+        let mut boost = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "boost" {
+                boost = Some(map.next_value()?);
+                continue;
+            }
+
+            if terms.is_some() {
+                return Err(DeError::custom("Terms query must have exactly one field"));
+            }
+
+            let values = map.next_value::<Value>()?.into_inner();
+            if !matches!(values.value, Some(value::Value::List(_))) {
+                return Err(DeError::custom("Terms query values must be an array"));
+            }
+
+            terms = Some((FieldName::new(key), values));
         }
+
+        let (field, values) =
+            terms.ok_or_else(|| DeError::custom("Terms query missing a field"))?;
+
         Ok(TermsQuery {
-            field: FieldName::new(field),
-            values: topk_rs::proto::v1::data::Value::try_from(values)
-                .map_err(|e| Error::InvalidQuery(e.to_string()))?,
-            boost: wire.boost,
+            field,
+            values,
+            boost,
         })
     }
 }
@@ -331,11 +360,11 @@ pub struct StringValueFull {
     value: String,
 }
 
-impl From<&StringValue> for String {
-    fn from(value: &StringValue) -> Self {
-        match value {
-            StringValue::Bare(s) => s.clone(),
-            StringValue::Full(full) => full.value.clone(),
+impl StringValue {
+    pub fn into_string(self) -> String {
+        match self {
+            StringValue::Bare(s) => s,
+            StringValue::Full(full) => full.value,
         }
     }
 }
@@ -363,13 +392,11 @@ impl RegexpValue {
             RegexpValue::Full(full) => full.case_insensitive.unwrap_or(false),
         }
     }
-}
 
-impl From<&RegexpValue> for String {
-    fn from(value: &RegexpValue) -> Self {
-        match value {
-            RegexpValue::Bare(s) => s.clone(),
-            RegexpValue::Full(full) => full.value.clone(),
+    pub fn into_string(self) -> String {
+        match self {
+            RegexpValue::Bare(s) => s,
+            RegexpValue::Full(full) => full.value,
         }
     }
 }
@@ -391,5 +418,84 @@ impl FieldName {
 impl From<FieldName> for String {
     fn from(name: FieldName) -> Self {
         name.as_str().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn field_clause_reads_the_single_entry() {
+        let clause: FieldClause<StringValue> = sonic_rs::from_str(r#"{"title": "a"}"#).unwrap();
+
+        assert_eq!(clause.field.as_str(), "title");
+        assert_eq!(clause.value.into_string(), "a");
+    }
+
+    #[rstest]
+    #[case::empty("{}")]
+    #[case::two_fields(r#"{"title": "a", "genre": "b"}"#)]
+    fn field_clause_requires_exactly_one_entry(#[case] body: &str) {
+        assert!(sonic_rs::from_str::<FieldClause<StringValue>>(body).is_err());
+    }
+
+    #[test]
+    fn terms_query_reads_field_values_and_boost() {
+        let query: TermsQuery =
+            sonic_rs::from_str(r#"{"genre": ["a", "b"], "boost": 2.0}"#).unwrap();
+
+        assert_eq!(query.field.as_str(), "genre");
+        assert_eq!(query.values, TopkValue::list(vec!["a", "b"]));
+        assert_eq!(query.boost, Some(2.0));
+    }
+
+    #[rstest]
+    #[case::no_field(r#"{"boost": 2.0}"#)]
+    #[case::two_fields(r#"{"a": [1], "b": [2]}"#)]
+    #[case::scalar_value(r#"{"a": "b"}"#)]
+    fn terms_query_rejected(#[case] body: &str) {
+        assert!(sonic_rs::from_str::<TermsQuery>(body).is_err());
+    }
+
+    #[test]
+    fn term_value_carries_its_boost() {
+        let bare: TermValue = sonic_rs::from_str("1").unwrap();
+        assert_eq!(bare.into_parts(), (TopkValue::i64(1), None));
+
+        let full: TermValue = sonic_rs::from_str(r#"{"value": "a", "boost": 3.0}"#).unwrap();
+        assert_eq!(full.into_parts(), (TopkValue::string("a"), Some(3.0)));
+    }
+
+    // A sparse vector is an object, and `term` must still read it as a value
+    // rather than as the `{value, boost}` form.
+    #[test]
+    fn term_value_accepts_an_object_value() {
+        let bare: TermValue = sonic_rs::from_str(r#"{"0": 1.5}"#).unwrap();
+
+        assert_eq!(
+            bare.into_parts(),
+            (TopkValue::f32_sparse_vector(vec![0], vec![1.5]), None)
+        );
+    }
+
+    #[rstest]
+    #[case::list(r#"{"gte": [1, 2]}"#)]
+    #[case::object(r#"{"lt": {"a": 1}}"#)]
+    fn range_bounds_reject_non_scalars(#[case] body: &str) {
+        assert!(sonic_rs::from_str::<RangeBounds>(body).is_err());
+    }
+
+    #[test]
+    fn range_bounds_read_scalars() {
+        let bounds: RangeBounds = sonic_rs::from_str(r#"{"gte": 1, "lt": "b"}"#).unwrap();
+
+        assert_eq!(bounds.gte.map(|v| v.into_inner()), Some(TopkValue::i64(1)));
+        assert_eq!(
+            bounds.lt.map(|v| v.into_inner()),
+            Some(TopkValue::string("b"))
+        );
     }
 }

--- a/topk-es/src/api/search.rs
+++ b/topk-es/src/api/search.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::ser::SerializeMap;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{serde_as, OneOrMany};
 use topk_rs::json::Value as JsonValue;
-use topk_rs::proto::v1::data::Value as TopkValue;
+use topk_rs::proto::v1::data::{list, value, Value as TopkValue};
 use topk_rs::query::SortOrder as TopkSortOrder;
 
 use super::aggs::{AggClause, AggResult};
@@ -134,8 +135,7 @@ pub struct RrfClause {
 
 // Query vectors are parsed like document values (whole numbers stay integers)
 // so the engine can coerce them to the target field's element type.
-#[derive(Clone, Deserialize)]
-#[serde(try_from = "QueryVectorWire")]
+#[derive(Clone)]
 pub enum QueryVector {
     Flat(TopkValue),
     Matrix(TopkValue),
@@ -149,36 +149,25 @@ impl QueryVector {
     }
 }
 
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum QueryVectorWire {
-    Flat(Vec<sonic_rs::Number>),
-    Matrix(Vec<Vec<sonic_rs::Number>>),
-}
+impl<'de> Deserialize<'de> for QueryVector {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = JsonValue::deserialize(deserializer)?.into_inner();
 
-impl TryFrom<QueryVectorWire> for QueryVector {
-    type Error = Error;
+        let vector =
+            match &value.value {
+                // A matrix is always numeric; a list has to be checked.
+                Some(value::Value::List(list))
+                    if !matches!(list.values, Some(list::Values::String(_))) =>
+                {
+                    QueryVector::Flat(value)
+                }
+                Some(value::Value::Matrix(_)) => QueryVector::Matrix(value),
+                _ => return Err(serde::de::Error::custom(
+                    "[knn] query_vector must be an array of numbers, or an array of such arrays",
+                )),
+            };
 
-    fn try_from(wire: QueryVectorWire) -> Result<Self, Self::Error> {
-        let values = |numbers: Vec<serde_json::Number>| {
-            numbers
-                .into_iter()
-                .map(serde_json::Value::Number)
-                .collect::<Vec<_>>()
-        };
-
-        let vector = match wire {
-            QueryVectorWire::Flat(numbers) => {
-                TopkValue::try_from(values(numbers)).map(QueryVector::Flat)
-            }
-            QueryVectorWire::Matrix(rows) => {
-                TopkValue::try_from(rows.into_iter().map(values).collect::<Vec<_>>())
-                    .map(QueryVector::Matrix)
-            }
-        }
-        .map_err(|e| Error::InvalidQuery(e.to_string()))?;
-
-        ensure_finite(vector.value())?;
+        ensure_finite(vector.value()).map_err(serde::de::Error::custom)?;
 
         Ok(vector)
     }
@@ -389,32 +378,59 @@ impl SearchResponse {
                     },
                 },
                 max_score,
-                hits: hits
-                    .into_iter()
-                    .map(|hit| IndexedHit {
-                        index: index.clone(),
-                        hit,
-                    })
-                    .collect(),
+                index: index.clone(),
+                hits,
             },
             aggregations,
         }
     }
 }
 
-#[derive(Serialize)]
+// Every hit reports the same `_index`, so it is held once and written into each
+// hit on the way out rather than cloned per hit.
 pub struct HitsWrapper {
     pub total: Total,
     pub max_score: Option<f32>,
-    pub hits: Vec<IndexedHit>,
+    pub index: IndexName,
+    pub hits: Vec<Hit>,
+}
+
+impl Serialize for HitsWrapper {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(3))?;
+        map.serialize_entry("total", &self.total)?;
+        map.serialize_entry("max_score", &self.max_score)?;
+        map.serialize_entry(
+            "hits",
+            &IndexedHits {
+                index: &self.index,
+                hits: &self.hits,
+            },
+        )?;
+        map.end()
+    }
+}
+
+struct IndexedHits<'a> {
+    index: &'a IndexName,
+    hits: &'a [Hit],
+}
+
+impl Serialize for IndexedHits<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_seq(self.hits.iter().map(|hit| IndexedHit {
+            index: self.index,
+            hit,
+        }))
+    }
 }
 
 #[derive(Serialize)]
-pub struct IndexedHit {
+struct IndexedHit<'a> {
     #[serde(rename = "_index")]
-    pub index: IndexName,
+    index: &'a IndexName,
     #[serde(flatten)]
-    pub hit: Hit,
+    hit: &'a Hit,
 }
 
 #[derive(Serialize)]
@@ -433,4 +449,113 @@ pub struct Hit {
     pub sort: Option<Vec<JsonValue>>,
     #[serde(rename = "_source", skip_serializing_if = "Option::is_none")]
     pub source: Option<Source>,
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    // Whole numbers stay integers so the engine can narrow them to the target
+    // field's element type.
+    #[rstest]
+    #[case::floats("[1.0, 0.0]", TopkValue::list(vec![1.0_f32, 0.0]))]
+    #[case::ints("[127, 0]", TopkValue::list(vec![127_i64, 0]))]
+    #[case::signed_ints("[-1, 1]", TopkValue::list(vec![-1_i64, 1]))]
+    fn flat_query_vector(#[case] body: &str, #[case] expected: TopkValue) {
+        let vector: QueryVector = sonic_rs::from_str(body).unwrap();
+
+        assert!(matches!(vector, QueryVector::Flat(_)));
+        assert_eq!(vector.value(), &expected);
+    }
+
+    #[test]
+    fn matrix_query_vector() {
+        let vector: QueryVector = sonic_rs::from_str("[[1.0, 0.0], [0.5, 0.5]]").unwrap();
+
+        assert!(matches!(vector, QueryVector::Matrix(_)));
+        assert_eq!(
+            vector.value(),
+            &TopkValue::matrix(2, vec![1.0_f32, 0.0, 0.5, 0.5])
+        );
+    }
+
+    #[rstest]
+    #[case::scalar("1.0")]
+    #[case::strings(r#"["a"]"#)]
+    #[case::object(r#"{"0": 1.0}"#)]
+    #[case::ragged("[[1.0], [1.0, 2.0]]")]
+    // A number past f32's range lands as infinity, which ES rejects.
+    #[case::overflow("[1e39, 0.0]")]
+    fn query_vector_rejected(#[case] body: &str) {
+        assert!(sonic_rs::from_str::<QueryVector>(body).is_err());
+    }
+
+    // A whole request, to keep the derive-heavy corners — externally tagged
+    // query clauses, `OneOrMany`, flattened agg types — honest.
+    #[rstest]
+    #[case::single(
+        r#"{
+            "query": {"bool": {"must": {"match": {"title": "a"}}, "filter": {"term": {"genre": "b"}}}},
+            "knn": {"field": "embedding", "query_vector": [1.0, 0.0], "k": 2},
+            "sort": {"year": "desc"}
+        }"#
+    )]
+    #[case::many(
+        r#"{
+            "query": {"bool": {"must": [{"match": {"title": "a"}}], "filter": [{"term": {"genre": "b"}}]}},
+            "knn": [{"field": "embedding", "query_vector": [1.0, 0.0], "k": 2}],
+            "sort": [{"year": "desc"}]
+        }"#
+    )]
+    fn accepts_one_or_many(#[case] body: &str) {
+        let req: SearchRequest = sonic_rs::from_str(body).unwrap();
+
+        assert_eq!(req.knn.as_ref().map(Vec::len), Some(1));
+        assert_eq!(req.sort.as_deref().map(<[SortField]>::len), Some(1));
+        assert!(matches!(req.query, Some(Query::Bool(_))));
+        assert_eq!(req.size, 10, "size defaults to 10");
+    }
+
+    #[test]
+    fn reads_aggs_and_source_filters() {
+        let req: SearchRequest = sonic_rs::from_str(
+            r#"{
+                "size": 5,
+                "from": 1,
+                "track_scores": true,
+                "aggs": {
+                    "by_genre": {"terms": {"field": "genre", "size": 3}},
+                    "total": {"sum": {"field": "year"}}
+                },
+                "_source": {"includes": ["title"]}
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!((req.size, req.from), (5, 1));
+        assert!(req.track_scores);
+        assert_eq!(req.aggs.len(), 2);
+        assert!(req.source.enabled());
+        assert!(req.source.keep("title") && !req.source.keep("genre"));
+    }
+
+    #[test]
+    fn empty_sort_is_no_sort() {
+        let req: SearchRequest = sonic_rs::from_str(r#"{"sort": []}"#).unwrap();
+        assert!(req.sort.is_none());
+    }
+
+    #[rstest]
+    #[case::window_too_large(r#"{"from": 9999, "size": 10}"#)]
+    #[case::unknown_field(r#"{"nope": 1}"#)]
+    #[case::knn_without_k(r#"{"knn": {"field": "e", "query_vector": [1.0]}}"#)]
+    #[case::zero_k(r#"{"knn": {"field": "e", "query_vector": [1.0], "k": 0}}"#)]
+    #[case::too_few_candidates(
+        r#"{"knn": {"field": "e", "query_vector": [1.0], "k": 2, "num_candidates": 1}}"#
+    )]
+    fn search_request_rejected(#[case] body: &str) {
+        assert!(sonic_rs::from_str::<SearchRequest>(body).is_err());
+    }
 }

--- a/topk-es/src/api/search.rs
+++ b/topk-es/src/api/search.rs
@@ -152,8 +152,8 @@ impl QueryVector {
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum QueryVectorWire {
-    Flat(Vec<serde_json::Number>),
-    Matrix(Vec<Vec<serde_json::Number>>),
+    Flat(Vec<sonic_rs::Number>),
+    Matrix(Vec<Vec<sonic_rs::Number>>),
 }
 
 impl TryFrom<QueryVectorWire> for QueryVector {

--- a/topk-es/src/api/source.rs
+++ b/topk-es/src/api/source.rs
@@ -134,13 +134,27 @@ impl<S: Send + Sync> FromRequestParts<S> for SourceFilter {
 #[cfg(test)]
 mod tests {
     use super::SourceFilter;
-    use serde_json::json;
 
     #[test]
     fn string_include_filters_to_one_field() {
-        let filter: SourceFilter = serde_json::from_value(json!("title")).unwrap();
+        let filter: SourceFilter = sonic_rs::from_str(r#""title""#).unwrap();
         assert!(filter.keep("title"));
         assert!(!filter.keep("genre"));
+    }
+
+    #[test]
+    fn object_form_reads_includes_and_excludes() {
+        let filter: SourceFilter =
+            sonic_rs::from_str(r#"{"includes": ["meta"], "excludes": ["meta.author"]}"#).unwrap();
+        assert!(filter.keep("meta.year"));
+        assert!(!filter.keep("meta.author"));
+        assert!(!filter.keep("title"));
+    }
+
+    #[test]
+    fn bool_form_disables_source() {
+        let filter: SourceFilter = sonic_rs::from_str("false").unwrap();
+        assert!(!filter.enabled());
     }
 
     #[test]

--- a/topk-es/src/engine/compile.rs
+++ b/topk-es/src/engine/compile.rs
@@ -7,8 +7,8 @@ use super::rank::Ranking;
 use super::score::{ann_score, AnnQuery, AnnTerm, CompiledQuery, Score};
 use super::{agg, RANK_BM25, RANK_SCORE};
 use crate::api::{
-    AggClause, AggType, FieldName, GateQuery, KnnRequest, MatchAllQuery, MatchOperator, MatchValue,
-    Query, SearchRequest, SortField, SortTarget, TermValue,
+    AggClause, AggType, DocId, FieldName, GateQuery, KnnRequest, MatchAllQuery, MatchOperator,
+    MatchValue, Query, SearchRequest, SortField, SortTarget,
 };
 use crate::value::ValueExt;
 
@@ -119,7 +119,7 @@ fn lower(
     if has_bm25 {
         query = query.select([(RANK_BM25, fns::bm25_score(None, None))]);
     }
-    let (query, ann_term) = ann_score(query, schema, &score.anns)?;
+    let (query, ann_term) = ann_score(query, schema, score.anns)?;
 
     let total = [has_bm25.then(|| field(RANK_BM25)), ann_term, score.expr]
         .into_iter()
@@ -258,12 +258,8 @@ fn compile_clause(schema: &Schema, query: Query) -> Result<CompiledQuery, Error>
             }
         }
         Query::Term(clause) => {
-            let boost = match &clause.value {
-                TermValue::Full { boost, .. } => *boost,
-                TermValue::Bare(_) => None,
-            };
             let field_name = clause.field.as_str().to_string();
-            let value = clause.value.value();
+            let (value, boost) = clause.value.into_parts();
             if !value.is_scalar() {
                 return Err(Error::InvalidQuery(format!(
                     "[term] query does not support a non-scalar value for field [{field_name}]"
@@ -299,18 +295,21 @@ fn compile_clause(schema: &Schema, query: Query) -> Result<CompiledQuery, Error>
         Query::Terms(q) => Ok(constant(field(q.field).in_(q.values), q.boost)),
         Query::Ids(q) => Ok(constant(
             field("_id").in_(Value::list(
-                q.values.iter().map(|id| id.as_str()).collect::<Vec<_>>(),
+                q.values
+                    .into_iter()
+                    .map(DocId::into_string)
+                    .collect::<Vec<String>>(),
             )),
             q.boost,
         )),
         Query::Prefix(c) => Ok(constant(
-            field(c.field).starts_with(String::from(&c.value)),
+            field(c.field).starts_with(c.value.into_string()),
             None,
         )),
         Query::Regexp(c) => {
             let flags = c.value.case_insensitive().then(|| "i");
             Ok(constant(
-                field(c.field).regexp_match(String::from(&c.value), flags),
+                field(c.field).regexp_match(c.value.into_string(), flags),
                 None,
             ))
         }

--- a/topk-es/src/engine/doc.rs
+++ b/topk-es/src/engine/doc.rs
@@ -82,19 +82,22 @@ pub fn encode(schema: &Schema, doc: WriteDoc) -> Result<Document, Error> {
             let value = value.into_inner();
             let spec = schema.get(name.as_str());
 
+            // A value the field's type cannot take passes through untouched; the
+            // server rejects it with a message about the schema.
             let value = match spec.and_then(|spec| spec.data_type.as_ref()?.data_type.as_ref()) {
-                Some(field_type::DataType::F32Vector(_)) => value.to_f32_list().unwrap_or(value),
-                Some(field_type::DataType::I8Vector(_)) => value.to_i8_list().unwrap_or(value),
+                Some(field_type::DataType::F32Vector(_)) => value.into_f32_list(),
+                Some(field_type::DataType::I8Vector(_)) => value.into_i8_list(),
                 Some(field_type::DataType::U8Vector(_) | field_type::DataType::BinaryVector(_)) => {
-                    value.to_unsigned_bytes().unwrap_or(value)
+                    value.into_unsigned_bytes()
                 }
                 Some(field_type::DataType::Matrix(m))
                     if matches!(m.value_type(), MatrixValueType::U8) =>
                 {
-                    value.to_u8_matrix().unwrap_or(value)
+                    value.into_u8_matrix()
                 }
-                _ => value,
-            };
+                _ => Ok(value),
+            }
+            .unwrap_or_else(|value| value);
 
             if let Some(IndexKind::Vector(metric)) = spec.map(IndexKind::from) {
                 vector::ensure_magnitude(&name, metric, &value)?;

--- a/topk-es/src/engine/rank.rs
+++ b/topk-es/src/engine/rank.rs
@@ -134,7 +134,9 @@ fn combine(
     req: &SearchRequest,
     results: Vec<Vec<Document>>,
 ) -> Result<Vec<(f32, Candidate)>, Error> {
-    let mut by_id: HashMap<DocId, Candidate> = HashMap::new();
+    // Fields are keyed by id and rejoined at the end, so an id is only ever
+    // copied for the ranking pass — not stored a third time per retriever hit.
+    let mut by_id: HashMap<DocId, HashMap<String, Value>> = HashMap::new();
 
     let mut groups: Vec<Vec<(DocId, f32)>> = Vec::with_capacity(results.len());
     for docs in results {
@@ -151,10 +153,7 @@ fn combine(
                 .and_then(|v| v.as_f32())
                 .unwrap_or(0.0);
             members.push((id.clone(), score));
-            by_id.entry(id.clone()).or_insert(Candidate {
-                id,
-                fields: doc.fields,
-            });
+            by_id.entry(id).or_insert(doc.fields);
         }
         groups.push(members);
     }
@@ -163,7 +162,10 @@ fn combine(
 
     Ok(totals
         .into_iter()
-        .filter_map(|(id, score)| by_id.remove(&id).map(|candidate| (score, candidate)))
+        .filter_map(|(id, score)| {
+            let fields = by_id.remove(&id)?;
+            Some((score, Candidate { id, fields }))
+        })
         .collect())
 }
 

--- a/topk-es/src/engine/score.rs
+++ b/topk-es/src/engine/score.rs
@@ -137,10 +137,10 @@ impl Fold {
 pub fn ann_score(
     mut query: TopkQuery,
     schema: &Schema,
-    anns: &[AnnTerm],
+    anns: Vec<AnnTerm>,
 ) -> Result<(TopkQuery, Option<LogicalExpr>), Error> {
     let mut total: Option<LogicalExpr> = None;
-    for (index, ann) in anns.iter().enumerate() {
+    for (index, ann) in anns.into_iter().enumerate() {
         let spec = schema.get(&ann.field).ok_or_else(|| {
             Error::InvalidQuery(format!(
                 "\"{}\" is not in the collection's schema",
@@ -148,7 +148,8 @@ pub fn ann_score(
             ))
         })?;
 
-        let (spec, scorer) = match &ann.query {
+        let semantic = matches!(ann.query, AnnQuery::Semantic(_));
+        let (spec, scorer) = match ann.query {
             AnnQuery::Semantic(text) => {
                 let spec = match IndexKind::from(spec) {
                     IndexKind::Semantic => {
@@ -168,16 +169,16 @@ pub fn ann_score(
                 num_candidates,
             } => (
                 spec,
-                knn_distance(&ann.field, vector, *num_candidates, spec)?,
+                knn_distance(&ann.field, vector, num_candidates, spec)?,
             ),
         };
 
-        let fold = Fold::of(IndexKind::from(spec)).ok_or_else(|| match &ann.query {
-            AnnQuery::Semantic(_) => Error::InvalidQuery(format!(
+        let fold = Fold::of(IndexKind::from(spec)).ok_or_else(|| match semantic {
+            true => Error::InvalidQuery(format!(
                 "Field [{}] does not support semantic queries",
                 ann.field
             )),
-            AnnQuery::Vector { .. } => not_knn_searchable(&ann.field),
+            false => not_knn_searchable(&ann.field),
         })?;
 
         let rank_ann = format!("{RANK_ANN}_{index}");
@@ -210,7 +211,7 @@ fn not_knn_searchable(field: &str) -> Error {
 
 fn knn_distance(
     field_name: &str,
-    query_vector: &QueryVector,
+    query_vector: QueryVector,
     num_candidates: Option<u64>,
     spec: &FieldSpec,
 ) -> Result<FunctionExpr, Error> {
@@ -238,18 +239,19 @@ fn knn_distance(
     }
 }
 
-fn query_value(field_name: &str, spec: &FieldSpec, value: &Value) -> Result<Value, Error> {
+fn query_value(field_name: &str, spec: &FieldSpec, value: Value) -> Result<Value, Error> {
     match spec.data_type.as_ref().and_then(|t| t.data_type.as_ref()) {
-        Some(field_type::DataType::I8Vector(_)) => value.to_i8_list(),
+        Some(field_type::DataType::I8Vector(_)) => value.into_i8_list(),
         Some(field_type::DataType::U8Vector(_) | field_type::DataType::BinaryVector(_)) => {
-            value.to_unsigned_bytes()
+            value.into_unsigned_bytes()
         }
         Some(field_type::DataType::Matrix(m)) if matches!(m.value_type(), MatrixValueType::U8) => {
-            value.to_u8_matrix()
+            value.into_u8_matrix()
         }
-        _ => value.to_f32_list().or_else(|| Some(value.clone())),
+        // A float field takes the query vector as it stands.
+        _ => Ok(value.into_f32_list().unwrap_or_else(|value| value)),
     }
-    .ok_or_else(|| {
+    .map_err(|_| {
         Error::InvalidQuery(format!(
             "\"query_vector\" is not compatible with the type of field \"{field_name}\""
         ))

--- a/topk-es/src/error.rs
+++ b/topk-es/src/error.rs
@@ -47,8 +47,8 @@ pub enum Error {
     SerdeJson(String),
 }
 
-impl From<serde_json::Error> for Error {
-    fn from(e: serde_json::Error) -> Self {
+impl From<sonic_rs::Error> for Error {
+    fn from(e: sonic_rs::Error) -> Self {
         Error::SerdeJson(e.to_string())
     }
 }

--- a/topk-es/src/error.rs
+++ b/topk-es/src/error.rs
@@ -1,9 +1,10 @@
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
 use serde::Serialize;
 use thiserror::Error as ThisError;
 use topk_rs::Error as TopkError;
+
+use crate::json::Json;
 
 #[derive(Debug, Clone, ThisError)]
 pub enum Error {

--- a/topk-es/src/json.rs
+++ b/topk-es/src/json.rs
@@ -1,0 +1,96 @@
+use axum::response::{IntoResponse, Response};
+use http::header::{HeaderValue, CONTENT_TYPE};
+use http::StatusCode;
+use serde::Serialize;
+
+const CONTENT_TYPE_JSON: HeaderValue = HeaderValue::from_static("application/json");
+
+/// A JSON response body, serialized with `sonic_rs` — the counterpart to the
+/// `sonic_rs`-backed request extractors, and a drop-in for `axum::Json` on the
+/// response side.
+pub struct Json<T>(pub T);
+
+impl<T: Serialize> IntoResponse for Json<T> {
+    fn into_response(self) -> Response {
+        match sonic_rs::to_vec(&self.0) {
+            Ok(body) => ([(CONTENT_TYPE, CONTENT_TYPE_JSON)], body).into_response(),
+            // Serialization only fails on values JSON cannot express (a NaN
+            // score, say). The fallback is written by hand because rendering the
+            // error as JSON is exactly what just failed.
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(CONTENT_TYPE, CONTENT_TYPE_JSON)],
+                format!(
+                    r#"{{"error":{{"type":"internal_server_error","reason":{}}},"status":500}}"#,
+                    escape(&e.to_string())
+                ),
+            )
+                .into_response(),
+        }
+    }
+}
+
+fn escape(reason: &str) -> String {
+    sonic_rs::to_string(reason).unwrap_or_else(|_| "\"Internal error\"".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use topk_rs::proto::v1::data::Value as TopkValue;
+
+    use crate::api::{DocId, Hit, IndexName, SearchResponse, Source};
+    use crate::Error;
+
+    use super::*;
+
+    fn index() -> IndexName {
+        IndexName::try_from("books".to_string()).unwrap()
+    }
+
+    fn hit(id: &str, score: f32) -> Hit {
+        Hit {
+            id: DocId::try_from(id.to_string()).unwrap(),
+            score: Some(score),
+            sort: None,
+            source: Some(Source(
+                TopkValue::r#struct([("title", TopkValue::string("a"))]).into(),
+            )),
+        }
+    }
+
+    // `_index` is written per hit even though it is stored once, and `Hit`'s
+    // fields are flattened alongside it.
+    #[test]
+    fn search_response_carries_the_index_on_every_hit() {
+        let response =
+            SearchResponse::new(&index(), vec![hit("1", 1.5), hit("2", 0.5)], None, &[2]);
+
+        assert_eq!(
+            sonic_rs::to_string(&response).unwrap(),
+            r#"{"took":1,"timed_out":false,"_shards":{"total":1,"successful":1,"failed":0},"hits":{"total":{"value":2,"relation":"eq"},"max_score":1.5,"hits":[{"_index":"books","_id":"1","_score":1.5,"_source":{"title":"a"}},{"_index":"books","_id":"2","_score":0.5,"_source":{"title":"a"}}]}}"#
+        );
+    }
+
+    #[test]
+    fn empty_response_reports_a_null_max_score() {
+        let response = SearchResponse::new(&index(), vec![], None, &[]);
+        let body = sonic_rs::to_string(&response).unwrap();
+
+        assert!(body.contains(r#""max_score":null"#), "{body}");
+        assert!(body.contains(r#""hits":[]"#), "{body}");
+    }
+
+    #[test]
+    fn error_responses_serialize() {
+        let response = Error::IndexNotFound("no such index [books]".into()).into_response();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("application/json")
+        );
+    }
+}

--- a/topk-es/src/lib.rs
+++ b/topk-es/src/lib.rs
@@ -1,6 +1,9 @@
 mod error;
 pub use error::{Error, ErrorBody};
 
+mod json;
+pub use json::Json;
+
 pub mod api;
 pub mod engine;
 pub mod value;

--- a/topk-es/src/value.rs
+++ b/topk-es/src/value.rs
@@ -37,13 +37,17 @@ impl PartialEq for OrdValue {
 
 impl Eq for OrdValue {}
 
+// Coercions a value undergoes on its way to (or from) a typed collection field.
+// Each one consumes the value and hands it back untouched — `Err(value)` — when
+// it does not apply, so a caller that can live without the coercion pays no
+// clone, and one that cannot has its rejection.
 pub trait ValueExt: Sized {
     fn number(&self) -> Option<f64>;
     fn is_scalar(&self) -> bool;
-    fn to_f32_list(&self) -> Option<Self>;
-    fn to_i8_list(&self) -> Option<Self>;
-    fn to_unsigned_bytes(&self) -> Option<Self>;
-    fn to_u8_matrix(&self) -> Option<Self>;
+    fn into_f32_list(self) -> Result<Self, Self>;
+    fn into_i8_list(self) -> Result<Self, Self>;
+    fn into_unsigned_bytes(self) -> Result<Self, Self>;
+    fn into_u8_matrix(self) -> Result<Self, Self>;
     fn into_signed_bytes(self) -> Self;
 }
 
@@ -65,53 +69,49 @@ impl ValueExt for Value {
     }
 
     fn number(&self) -> Option<f64> {
-        self.as_f64()
-            .or_else(|| self.as_f32().map(f64::from))
-            .or_else(|| self.as_i64().map(|v| v as f64))
-            .or_else(|| self.as_i32().map(f64::from))
-            .or_else(|| self.as_u64().map(|v| v as f64))
-            .or_else(|| self.as_u32().map(f64::from))
-    }
-
-    fn to_f32_list(&self) -> Option<Self> {
-        if self.as_f32_list().is_some() {
-            return Some(self.clone());
+        match &self.value {
+            Some(value::Value::F64(v)) => Some(*v),
+            Some(value::Value::F32(v)) => Some(f64::from(*v)),
+            Some(value::Value::I64(v)) => Some(*v as f64),
+            Some(value::Value::I32(v)) => Some(f64::from(*v)),
+            Some(value::Value::U64(v)) => Some(*v as f64),
+            Some(value::Value::U32(v)) => Some(f64::from(*v)),
+            _ => None,
         }
-        let ints = self.as_i64_list()?;
-        Some(Value::list(
-            ints.iter().map(|&n| n as f32).collect::<Vec<_>>(),
-        ))
     }
 
-    fn to_i8_list(&self) -> Option<Self> {
-        let ints = self.as_i64_list()?;
-        ints.iter()
-            .all(|n| (-128..=127).contains(n))
-            .then(|| Value::list(ints.iter().map(|&n| n as i8).collect::<Vec<i8>>()))
+    fn into_f32_list(self) -> Result<Self, Self> {
+        if self.as_f32_list().is_some() {
+            return Ok(self);
+        }
+
+        match int_list(&self, |n| n as f32) {
+            Some(values) => Ok(Value::list(values)),
+            None => Err(self),
+        }
+    }
+
+    fn into_i8_list(self) -> Result<Self, Self> {
+        match byte_list(&self, |n| n as i8) {
+            Some(values) => Ok(Value::list(values)),
+            None => Err(self),
+        }
     }
 
     // Signed bytes wrapped into their unsigned storage form; inverse of
     // `into_signed_bytes`.
-    fn to_unsigned_bytes(&self) -> Option<Self> {
-        let ints = self.as_i64_list()?;
-        ints.iter()
-            .all(|n| (-128..=127).contains(n))
-            .then(|| Value::list(ints.iter().map(|&n| n as u8).collect::<Vec<u8>>()))
+    fn into_unsigned_bytes(self) -> Result<Self, Self> {
+        match byte_list(&self, |n| n as u8) {
+            Some(values) => Ok(Value::list(values)),
+            None => Err(self),
+        }
     }
 
-    fn to_u8_matrix(&self) -> Option<Self> {
-        let (_, num_cols, values) = self.as_f32_matrix()?;
-        if !values
-            .iter()
-            .all(|v| v.is_finite() && v.fract() == 0.0 && (0.0..=255.0).contains(v))
-        {
-            return None;
+    fn into_u8_matrix(self) -> Result<Self, Self> {
+        match u8_matrix(&self) {
+            Some((num_cols, values)) => Ok(Value::matrix(num_cols, values)),
+            None => Err(self),
         }
-
-        Some(Value::matrix(
-            num_cols,
-            values.iter().map(|&v| v as u8).collect::<Vec<u8>>(),
-        ))
     }
 
     // Reinterpret a u8 list as the signed bytes it was encoded from.
@@ -129,4 +129,26 @@ impl ValueExt for Value {
             _ => self,
         }
     }
+}
+
+// The helpers below hand back owned values so the borrow of `value` ends with
+// the call, leaving the caller free to move it into the `None` arm.
+fn int_list<T>(value: &Value, cast: impl Fn(i64) -> T) -> Option<Vec<T>> {
+    Some(value.as_i64_list()?.iter().map(|&n| cast(n)).collect())
+}
+
+fn byte_list<T>(value: &Value, cast: impl Fn(i64) -> T) -> Option<Vec<T>> {
+    let ints = value.as_i64_list()?;
+    ints.iter()
+        .all(|n| (-128..=127).contains(n))
+        .then(|| ints.iter().map(|&n| cast(n)).collect())
+}
+
+fn u8_matrix(value: &Value) -> Option<(u32, Vec<u8>)> {
+    let (_, num_cols, values) = value.as_f32_matrix()?;
+
+    values
+        .iter()
+        .all(|v| v.is_finite() && v.fract() == 0.0 && (0.0..=255.0).contains(v))
+        .then(|| (num_cols, values.iter().map(|&v| v as u8).collect()))
 }

--- a/topk-rs/src/json.rs
+++ b/topk-rs/src/json.rs
@@ -1,30 +1,21 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::ops::Deref;
 
-use serde::de::Error as DeError;
-use serde::ser::Error as SerError;
+use serde::de::{Error as DeError, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::ser::{Error as SerError, SerializeMap, SerializeSeq};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::proto::v1::data::{list, matrix, sparse_vector, value, vector, Value as TopkValue};
 
-macro_rules! array_of {
-    ($values:expr, $mapper:expr) => {
-        $values
-            .into_iter()
-            .map($mapper)
-            .collect::<Result<Vec<_>, crate::Error>>()
-    };
-    ($values:expr, $variant:path, $error:expr) => {
-        $values
-            .into_iter()
-            .map(|value| match value {
-                $variant(inner) => Ok(inner),
-                _ => Err(crate::Error::InvalidArgument($error.into())),
-            })
-            .collect::<Result<Vec<_>, crate::Error>>()
-    };
-}
+// A JSON array maps onto a homogeneous TopK list or matrix, so these rejections
+// are shared by every path that walks one.
+const MIXED_ARRAY: &str = "JSON arrays must contain only numbers or strings";
+const INVALID_ARRAY: &str = "JSON arrays must contain only numbers, strings, or numeric arrays";
+const NUMBER_RANGE: &str = "JSON number is outside TopK's supported numeric range";
 
+/// A [`TopkValue`] that serializes to, and deserializes from, JSON directly —
+/// no intermediate JSON document is built in either direction.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Value(pub TopkValue);
 
@@ -48,317 +39,701 @@ impl Deref for Value {
     }
 }
 
-impl Serialize for Value {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serde_json::Value::try_from(self.0.clone())
-            .map_err(SerError::custom)?
-            .serialize(serializer)
-    }
-}
-
 impl<'de> Deserialize<'de> for Value {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self(
-            TopkValue::try_from(serde_json::Value::deserialize(deserializer)?)
-                .map_err(DeError::custom)?,
-        ))
+        deserializer
+            .deserialize_any(ValueVisitor)?
+            .map(Self)
+            .map_err(DeError::custom)
     }
 }
 
-impl TryFrom<serde_json::Value> for TopkValue {
-    type Error = crate::Error;
+/// A [`Value`] whose *shape* errors — a mixed array, a numeric struct field
+/// name, ... — are captured instead of raised, so a caller that reports errors
+/// per value (a bulk write, say) can keep reading the surrounding document.
+/// Malformed JSON still fails the deserializer.
+pub struct LenientValue(Parsed);
 
-    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-        match value {
-            serde_json::Value::Null => Ok(TopkValue::null()),
-            serde_json::Value::Bool(value) => Ok(TopkValue::bool(value)),
-            serde_json::Value::String(value) => Ok(TopkValue::string(value)),
-            serde_json::Value::Number(value) => Ok(TopkValue::try_from(value)?),
-            serde_json::Value::Object(value) => Ok(TopkValue::try_from(value)?),
-            serde_json::Value::Array(value) => Ok(TopkValue::try_from(value)?),
+impl LenientValue {
+    pub fn into_result(self) -> Result<TopkValue, crate::Error> {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for LenientValue {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(ValueVisitor).map(Self)
+    }
+}
+
+// Deserialization
+//
+// Every visitor below yields `Parsed`: JSON that parsed cleanly but does not
+// describe a TopK value comes back as `Err`, keeping the two failure kinds —
+// malformed JSON and unrepresentable value — apart.
+type Parsed = Result<TopkValue, crate::Error>;
+
+fn invalid(reason: &str) -> crate::Error {
+    crate::Error::InvalidArgument(reason.into())
+}
+
+struct ValueVisitor;
+
+impl<'de> Visitor<'de> for ValueVisitor {
+    type Value = Parsed;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a JSON value")
+    }
+
+    fn visit_unit<E: DeError>(self) -> Result<Parsed, E> {
+        Ok(Ok(TopkValue::null()))
+    }
+
+    fn visit_none<E: DeError>(self) -> Result<Parsed, E> {
+        Ok(Ok(TopkValue::null()))
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Parsed, D::Error> {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_newtype_struct<D: Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<Parsed, D::Error> {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_bool<E: DeError>(self, value: bool) -> Result<Parsed, E> {
+        Ok(Ok(TopkValue::bool(value)))
+    }
+
+    fn visit_i64<E: DeError>(self, value: i64) -> Result<Parsed, E> {
+        Ok(Ok(TopkValue::i64(value)))
+    }
+
+    fn visit_u64<E: DeError>(self, value: u64) -> Result<Parsed, E> {
+        Ok(Ok(from_u64(value)))
+    }
+
+    fn visit_i128<E: DeError>(self, _: i128) -> Result<Parsed, E> {
+        Ok(Err(invalid(NUMBER_RANGE)))
+    }
+
+    fn visit_u128<E: DeError>(self, _: u128) -> Result<Parsed, E> {
+        Ok(Err(invalid(NUMBER_RANGE)))
+    }
+
+    fn visit_f64<E: DeError>(self, value: f64) -> Result<Parsed, E> {
+        Ok(Ok(TopkValue::f64(value)))
+    }
+
+    fn visit_str<E: DeError>(self, value: &str) -> Result<Parsed, E> {
+        Ok(Ok(TopkValue::string(value)))
+    }
+
+    fn visit_string<E: DeError>(self, value: String) -> Result<Parsed, E> {
+        Ok(Ok(TopkValue::string(value)))
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Parsed, A::Error> {
+        let mut items = Items::Empty;
+
+        while let Some(item) = seq.next_element::<Item>()? {
+            items = match items.push(item) {
+                Ok(items) => items,
+                Err(e) => {
+                    while seq.next_element::<IgnoredAny>()?.is_some() {}
+                    return Ok(Err(e));
+                }
+            };
         }
+
+        Ok(items.finish())
     }
-}
 
-impl TryFrom<serde_json::Number> for TopkValue {
-    type Error = crate::Error;
-
-    fn try_from(value: serde_json::Number) -> Result<Self, Self::Error> {
-        if let Some(value) = value.as_i64() {
-            Ok(TopkValue::i64(value))
-        } else if let Some(value) = value.as_u64() {
-            Ok(TopkValue::u64(value))
-        } else {
-            let value = value.as_f64().ok_or_else(|| {
-                crate::Error::InvalidArgument(
-                    "JSON number is outside TopK's supported numeric range".into(),
-                )
-            })?;
-
-            Ok(TopkValue::f64(value))
-        }
-    }
-}
-
-impl TryFrom<Vec<serde_json::Value>> for TopkValue {
-    type Error = crate::Error;
-
-    fn try_from(values: Vec<serde_json::Value>) -> Result<Self, Self::Error> {
-        let Some(first) = values.first() else {
-            return Ok(TopkValue::list(Vec::<f32>::new()));
+    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Parsed, A::Error> {
+        let Some(key) = map.next_key::<Key>()? else {
+            return Ok(Ok(TopkValue::r#struct(HashMap::<String, TopkValue>::new())));
         };
 
-        // Integer arrays keep their integer width so callers that narrow against a
-        // collection schema (e.g. topk-es `engine::value`) can still see the original
-        // values. Anything else falls back to f32, matching the JS/Python SDKs.
-        if first.is_number() {
-            if let Some(ints) = collect_ints(&values, serde_json::Value::as_i64) {
-                return Ok(TopkValue::list(ints));
-            }
+        // An object whose every key is a `u32` index and every value a number is
+        // a sparse vector; anything else is a struct.
+        match key {
+            Key::Index(index) => {
+                let mut indices = Vec::with_capacity(map.size_hint().unwrap_or(0) + 1);
+                let mut values = Vec::with_capacity(indices.capacity());
 
-            if let Some(ints) = collect_ints(&values, serde_json::Value::as_u64) {
-                return Ok(TopkValue::list(ints));
-            }
+                let mut key = Some(index);
+                while let Some(index) = key {
+                    let Some(value) = map.next_value::<Number>()?.0 else {
+                        return drain(map).map(|()| {
+                            Err(invalid(
+                                "JSON objects with numeric keys are sparse vectors \
+                                 and must have numeric values",
+                            ))
+                        });
+                    };
+                    indices.push(index);
+                    values.push(value);
 
-            return array_of!(values, number_to_f32).map(TopkValue::list);
-        }
-
-        if first.is_string() {
-            return Ok(TopkValue::list(array_of!(
-                values,
-                serde_json::Value::String,
-                "JSON arrays must contain only numbers or strings"
-            )?));
-        }
-
-        if first.is_array() {
-            return TopkValue::try_from(array_of!(
-                values,
-                serde_json::Value::Array,
-                "JSON arrays must contain only numbers, strings, or numeric arrays"
-            )?);
-        }
-
-        Err(crate::Error::InvalidArgument(
-            "JSON arrays must contain only numbers, strings, or numeric arrays".into(),
-        ))
-    }
-}
-
-impl TryFrom<Vec<Vec<serde_json::Value>>> for TopkValue {
-    type Error = crate::Error;
-
-    fn try_from(rows: Vec<Vec<serde_json::Value>>) -> Result<Self, Self::Error> {
-        let num_cols = rows
-            .first()
-            .map(Vec::len)
-            .filter(|num_cols| *num_cols > 0)
-            .ok_or_else(|| {
-                crate::Error::InvalidArgument("JSON matrices must have at least one column".into())
-            })?;
-
-        for row in &rows {
-            if row.len() != num_cols {
-                return Err(crate::Error::InvalidArgument(
-                    "JSON matrix rows must have the same length".into(),
-                ));
-            }
-        }
-
-        if rows.len() * num_cols >= u32::MAX as usize {
-            return Err(crate::Error::InvalidArgument(
-                "JSON matrix has too many values".into(),
-            ));
-        }
-
-        rows.into_iter()
-            .flatten()
-            .map(number_to_f32)
-            .collect::<Result<Vec<_>, _>>()
-            .map(|values| TopkValue::matrix(num_cols as u32, values))
-    }
-}
-
-impl TryFrom<serde_json::Map<String, serde_json::Value>> for TopkValue {
-    type Error = crate::Error;
-
-    fn try_from(object: serde_json::Map<String, serde_json::Value>) -> Result<Self, Self::Error> {
-        let is_sparse_vector = !object.is_empty()
-            && object
-                .iter()
-                .all(|(key, value)| key.parse::<u32>().is_ok() && value.is_number());
-
-        if is_sparse_vector {
-            let mut indices = Vec::with_capacity(object.len());
-            let mut values = Vec::with_capacity(object.len());
-            for (key, value) in object {
-                indices.push(key.parse::<u32>().expect("keys are valid u32 indices"));
-                values.push(number_to_f32(value)?);
-            }
-            return Ok(TopkValue::f32_sparse_vector(indices, values));
-        }
-
-        object
-            .into_iter()
-            .map(|(key, value)| {
-                if key.parse::<u32>().is_ok() {
-                    return Err(crate::Error::InvalidArgument(
-                        "Struct field names must not be numeric indices".into(),
-                    ));
+                    key = match map.next_key::<Key>()? {
+                        Some(Key::Index(index)) => Some(index),
+                        Some(Key::Name(_)) => {
+                            return drain_entry(map).map(|()| {
+                                Err(invalid(
+                                    "JSON objects must not mix numeric indices with field names",
+                                ))
+                            })
+                        }
+                        None => None,
+                    };
                 }
 
-                Ok((key, TopkValue::try_from(value)?))
-            })
-            .collect::<Result<HashMap<_, _>, _>>()
-            .map(TopkValue::r#struct)
+                Ok(Ok(TopkValue::f32_sparse_vector(indices, values)))
+            }
+            Key::Name(name) => {
+                let mut fields = HashMap::with_capacity(map.size_hint().unwrap_or(0) + 1);
+
+                let mut key = Some(name);
+                while let Some(name) = key {
+                    match map.next_value::<LenientValue>()?.0 {
+                        Ok(value) => fields.insert(name, value),
+                        Err(e) => return drain(map).map(|()| Err(e)),
+                    };
+
+                    key = match map.next_key::<Key>()? {
+                        Some(Key::Name(name)) => Some(name),
+                        Some(Key::Index(_)) => {
+                            return drain_entry(map).map(|()| {
+                                Err(invalid("Struct field names must not be numeric indices"))
+                            })
+                        }
+                        None => None,
+                    };
+                }
+
+                Ok(Ok(TopkValue::r#struct(fields)))
+            }
+        }
     }
 }
 
-impl TryFrom<TopkValue> for serde_json::Value {
-    type Error = crate::Error;
+fn from_u64(value: u64) -> TopkValue {
+    match i64::try_from(value) {
+        Ok(value) => TopkValue::i64(value),
+        Err(_) => TopkValue::u64(value),
+    }
+}
 
-    fn try_from(value: TopkValue) -> Result<Self, Self::Error> {
-        match value.value {
-            None | Some(value::Value::Null(_)) => Ok(Self::Null),
-            Some(value::Value::Bool(v)) => Ok(Self::Bool(v)),
-            Some(value::Value::String(v)) => Ok(Self::String(v)),
-            Some(value::Value::U32(v)) => Ok(Self::from(v)),
-            Some(value::Value::U64(v)) => Ok(Self::from(v)),
-            Some(value::Value::I32(v)) => Ok(Self::from(v)),
-            Some(value::Value::I64(v)) => Ok(Self::from(v)),
-            Some(value::Value::F32(v)) => number(v),
-            Some(value::Value::F64(v)) => number(v),
-            Some(value::Value::Binary(v)) => {
-                Ok(Self::Array(v.into_iter().map(Self::from).collect()))
-            }
-            #[allow(deprecated)]
-            Some(value::Value::Vector(v)) => match v.vector {
-                Some(vector::Vector::Float(v)) => array_of!(v.values, number).map(Self::Array),
-                Some(vector::Vector::Byte(v)) => {
-                    Ok(Self::Array(v.values.into_iter().map(Self::from).collect()))
-                }
-                None => Ok(Self::Null),
+// A visitor must consume its whole map even once it has given up, or the
+// format's parser is left standing mid-object.
+fn drain<'de, A: MapAccess<'de>>(mut map: A) -> Result<(), A::Error> {
+    while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+    Ok(())
+}
+
+// Same, for a key whose value has not been read yet.
+fn drain_entry<'de, A: MapAccess<'de>>(mut map: A) -> Result<(), A::Error> {
+    map.next_value::<IgnoredAny>()?;
+    drain(map)
+}
+
+/// The element type a JSON array has settled on. Numbers accumulate into the
+/// narrowest integer width that holds every value seen so far and widen — never
+/// narrow — as the array is read, so callers that later match against a
+/// collection schema (e.g. topk-es `engine::doc`) still see the original values.
+enum Items {
+    Empty,
+    I64(Vec<i64>),
+    U64(Vec<u64>),
+    F32(Vec<f32>),
+    Str(Vec<String>),
+    Matrix { num_cols: usize, values: Vec<f32> },
+}
+
+impl Items {
+    fn push(self, item: Item) -> Result<Self, crate::Error> {
+        Ok(match (self, item) {
+            (_, Item::Invalid(reason)) => return Err(invalid(reason)),
+
+            // The first element fixes the array's kind.
+            (Items::Empty, Item::I64(v)) => Items::I64(vec![v]),
+            (Items::Empty, Item::U64(v)) => Items::U64(vec![v]),
+            (Items::Empty, Item::F64(v)) => Items::F32(vec![v as f32]),
+            (Items::Empty, Item::Str(v)) => Items::Str(vec![v]),
+            (Items::Empty, Item::Row(row)) => match row.is_empty() {
+                true => return Err(invalid("JSON matrices must have at least one column")),
+                false => Items::Matrix {
+                    num_cols: row.len(),
+                    values: row,
+                },
             },
-            Some(value::Value::Struct(v)) => v
-                .fields
-                .into_iter()
-                .map(|(key, value)| Ok((key, serde_json::Value::try_from(value)?)))
-                .collect::<Result<serde_json::Map<_, _>, _>>()
-                .map(Self::Object),
-            Some(value::Value::List(v)) => {
-                let values = match v.values {
-                    Some(list::Values::U32(v)) => v.values.into_iter().map(Self::from).collect(),
-                    Some(list::Values::U64(v)) => v.values.into_iter().map(Self::from).collect(),
-                    Some(list::Values::I32(v)) => v.values.into_iter().map(Self::from).collect(),
-                    Some(list::Values::I64(v)) => v.values.into_iter().map(Self::from).collect(),
-                    Some(list::Values::F8(v)) => {
-                        array_of!(v.as_ref().iter().map(|n| f32::from(*n)), number)?
-                    }
-                    Some(list::Values::F16(v)) => {
-                        array_of!(v.as_ref().iter().map(|n| f32::from(*n)), number)?
-                    }
-                    Some(list::Values::F32(v)) => array_of!(v.values, number)?,
-                    Some(list::Values::F64(v)) => array_of!(v.values, number)?,
-                    Some(list::Values::String(v)) => v.values.into_iter().map(Self::from).collect(),
-                    Some(list::Values::U8(v)) => v.values.into_iter().map(Self::from).collect(),
-                    Some(list::Values::I8(v)) => {
-                        v.as_ref().iter().copied().map(Self::from).collect()
-                    }
-                    None => Vec::new(),
-                };
 
-                Ok(Self::Array(values))
+            (Items::I64(mut values), Item::I64(v)) => {
+                values.push(v);
+                Items::I64(values)
             }
+            (Items::I64(values), Item::U64(v)) => match values.iter().all(|v| *v >= 0) {
+                true => {
+                    let mut values: Vec<u64> = values.iter().map(|v| *v as u64).collect();
+                    values.push(v);
+                    Items::U64(values)
+                }
+                // No integer width holds both a negative value and one past
+                // `i64::MAX`, so the array becomes floating point.
+                false => Items::F32(widen(values, v as f32)),
+            },
+            (Items::I64(values), Item::F64(v)) => Items::F32(widen(values, v as f32)),
+
+            (Items::U64(mut values), Item::U64(v)) => {
+                values.push(v);
+                Items::U64(values)
+            }
+            (Items::U64(values), Item::I64(v)) => match u64::try_from(v) {
+                Ok(v) => {
+                    let mut values = values;
+                    values.push(v);
+                    Items::U64(values)
+                }
+                Err(_) => Items::F32(widen(values, v as f32)),
+            },
+            (Items::U64(values), Item::F64(v)) => Items::F32(widen(values, v as f32)),
+
+            (Items::F32(mut values), Item::I64(v)) => {
+                values.push(v as f32);
+                Items::F32(values)
+            }
+            (Items::F32(mut values), Item::U64(v)) => {
+                values.push(v as f32);
+                Items::F32(values)
+            }
+            (Items::F32(mut values), Item::F64(v)) => {
+                values.push(v as f32);
+                Items::F32(values)
+            }
+
+            (Items::Str(mut values), Item::Str(v)) => {
+                values.push(v);
+                Items::Str(values)
+            }
+
+            (
+                Items::Matrix {
+                    num_cols,
+                    mut values,
+                },
+                Item::Row(row),
+            ) => {
+                if row.len() != num_cols {
+                    return Err(invalid("JSON matrix rows must have the same length"));
+                }
+                values.extend_from_slice(&row);
+                Items::Matrix { num_cols, values }
+            }
+
+            (Items::Matrix { .. }, _) => return Err(invalid(INVALID_ARRAY)),
+            _ => return Err(invalid(MIXED_ARRAY)),
+        })
+    }
+
+    fn finish(self) -> Parsed {
+        Ok(match self {
+            // An empty array has no element type; f32 matches the JS/Python SDKs.
+            Items::Empty => TopkValue::list(Vec::<f32>::new()),
+            Items::I64(values) => TopkValue::list(values),
+            Items::U64(values) => TopkValue::list(values),
+            Items::F32(values) => TopkValue::list(values),
+            Items::Str(values) => TopkValue::list(values),
+            Items::Matrix { num_cols, values } => {
+                if values.len() >= u32::MAX as usize {
+                    return Err(invalid("JSON matrix has too many values"));
+                }
+                TopkValue::matrix(num_cols as u32, values)
+            }
+        })
+    }
+}
+
+fn widen<T: Copy + IntoF32>(values: Vec<T>, extra: f32) -> Vec<f32> {
+    let mut widened = Vec::with_capacity(values.len() + 1);
+    widened.extend(values.iter().map(|v| v.into_f32()));
+    widened.push(extra);
+    widened
+}
+
+// `as` casts, not `Into`: `i64`/`u64` lose precision on the way to `f32`.
+trait IntoF32 {
+    fn into_f32(self) -> f32;
+}
+
+impl IntoF32 for i64 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
+impl IntoF32 for u64 {
+    fn into_f32(self) -> f32 {
+        self as f32
+    }
+}
+
+/// One element of a JSON array, read without materializing a JSON value.
+enum Item {
+    I64(i64),
+    U64(u64),
+    F64(f64),
+    Str(String),
+    Row(Vec<f32>),
+    Invalid(&'static str),
+}
+
+impl<'de> Deserialize<'de> for Item {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(ItemVisitor)
+    }
+}
+
+struct ItemVisitor;
+
+impl<'de> Visitor<'de> for ItemVisitor {
+    type Value = Item;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a number, a string, or an array of numbers")
+    }
+
+    fn visit_bool<E: DeError>(self, _: bool) -> Result<Item, E> {
+        Ok(Item::Invalid(INVALID_ARRAY))
+    }
+
+    fn visit_unit<E: DeError>(self) -> Result<Item, E> {
+        Ok(Item::Invalid(INVALID_ARRAY))
+    }
+
+    fn visit_none<E: DeError>(self) -> Result<Item, E> {
+        Ok(Item::Invalid(INVALID_ARRAY))
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Item, D::Error> {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_newtype_struct<D: Deserializer<'de>>(self, deserializer: D) -> Result<Item, D::Error> {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_i64<E: DeError>(self, value: i64) -> Result<Item, E> {
+        Ok(Item::I64(value))
+    }
+
+    fn visit_u64<E: DeError>(self, value: u64) -> Result<Item, E> {
+        Ok(match i64::try_from(value) {
+            Ok(value) => Item::I64(value),
+            Err(_) => Item::U64(value),
+        })
+    }
+
+    fn visit_i128<E: DeError>(self, _: i128) -> Result<Item, E> {
+        Ok(Item::Invalid(NUMBER_RANGE))
+    }
+
+    fn visit_u128<E: DeError>(self, _: u128) -> Result<Item, E> {
+        Ok(Item::Invalid(NUMBER_RANGE))
+    }
+
+    fn visit_f64<E: DeError>(self, value: f64) -> Result<Item, E> {
+        Ok(Item::F64(value))
+    }
+
+    fn visit_str<E: DeError>(self, value: &str) -> Result<Item, E> {
+        Ok(Item::Str(value.to_string()))
+    }
+
+    fn visit_string<E: DeError>(self, value: String) -> Result<Item, E> {
+        Ok(Item::Str(value))
+    }
+
+    // A nested array is a matrix row, and matrices are numeric.
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Item, A::Error> {
+        let mut row = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+        let mut invalid = false;
+
+        while let Some(number) = seq.next_element::<Number>()? {
+            match number.0 {
+                Some(value) => row.push(value),
+                None => invalid = true,
+            }
+        }
+
+        Ok(match invalid {
+            true => Item::Invalid(MIXED_ARRAY),
+            false => Item::Row(row),
+        })
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Item, A::Error> {
+        drain(map).map(|()| Item::Invalid(INVALID_ARRAY))
+    }
+}
+
+/// A JSON number narrowed to `f32`, or `None` for anything that is not a
+/// number. Values beyond `f32`'s range become infinity, matching the JS/Python
+/// SDKs.
+struct Number(Option<f32>);
+
+impl<'de> Deserialize<'de> for Number {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(NumberVisitor)
+    }
+}
+
+struct NumberVisitor;
+
+impl<'de> Visitor<'de> for NumberVisitor {
+    type Value = Number;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("a number")
+    }
+
+    fn visit_i64<E: DeError>(self, value: i64) -> Result<Number, E> {
+        Ok(Number(Some(value as f32)))
+    }
+
+    fn visit_u64<E: DeError>(self, value: u64) -> Result<Number, E> {
+        Ok(Number(Some(value as f32)))
+    }
+
+    fn visit_f64<E: DeError>(self, value: f64) -> Result<Number, E> {
+        Ok(Number(Some(value as f32)))
+    }
+
+    fn visit_bool<E: DeError>(self, _: bool) -> Result<Number, E> {
+        Ok(Number(None))
+    }
+
+    fn visit_unit<E: DeError>(self) -> Result<Number, E> {
+        Ok(Number(None))
+    }
+
+    fn visit_none<E: DeError>(self) -> Result<Number, E> {
+        Ok(Number(None))
+    }
+
+    fn visit_some<D: Deserializer<'de>>(self, deserializer: D) -> Result<Number, D::Error> {
+        deserializer.deserialize_any(self)
+    }
+
+    fn visit_str<E: DeError>(self, _: &str) -> Result<Number, E> {
+        Ok(Number(None))
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Number, A::Error> {
+        while seq.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(Number(None))
+    }
+
+    fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Number, A::Error> {
+        drain(map).map(|()| Number(None))
+    }
+}
+
+/// An object key, classified as a sparse-vector index or a struct field name
+/// while it is read — indices never reach the heap.
+enum Key {
+    Index(u32),
+    Name(String),
+}
+
+impl<'de> Deserialize<'de> for Key {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_any(KeyVisitor)
+    }
+}
+
+struct KeyVisitor;
+
+impl Visitor<'_> for KeyVisitor {
+    type Value = Key;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("an object key")
+    }
+
+    fn visit_str<E: DeError>(self, value: &str) -> Result<Key, E> {
+        Ok(match value.parse::<u32>() {
+            Ok(index) => Key::Index(index),
+            Err(_) => Key::Name(value.to_string()),
+        })
+    }
+
+    fn visit_string<E: DeError>(self, value: String) -> Result<Key, E> {
+        Ok(match value.parse::<u32>() {
+            Ok(index) => Key::Index(index),
+            Err(_) => Key::Name(value),
+        })
+    }
+}
+
+// Serialization
+
+impl Serialize for Value {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        ValueRef(&self.0).serialize(serializer)
+    }
+}
+
+/// Serializes a borrowed [`TopkValue`] as JSON, without cloning it into an
+/// intermediate JSON document.
+pub struct ValueRef<'a>(pub &'a TopkValue);
+
+impl Serialize for ValueRef<'_> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match &self.0.value {
+            None | Some(value::Value::Null(_)) => s.serialize_unit(),
+            Some(value::Value::Bool(v)) => s.serialize_bool(*v),
+            Some(value::Value::String(v)) => s.serialize_str(v),
+            Some(value::Value::U32(v)) => s.serialize_u32(*v),
+            Some(value::Value::U64(v)) => s.serialize_u64(*v),
+            Some(value::Value::I32(v)) => s.serialize_i32(*v),
+            Some(value::Value::I64(v)) => s.serialize_i64(*v),
+            Some(value::Value::F32(v)) => s.serialize_f32(finite(*v)?),
+            Some(value::Value::F64(v)) => s.serialize_f64(finite(*v)?),
+            Some(value::Value::Binary(v)) => s.collect_seq(v.iter()),
+            #[allow(deprecated)]
+            Some(value::Value::Vector(v)) => match &v.vector {
+                Some(vector::Vector::Float(v)) => Floats(&v.values).serialize(s),
+                Some(vector::Vector::Byte(v)) => s.collect_seq(&v.values),
+                None => s.serialize_unit(),
+            },
+            Some(value::Value::Struct(v)) => {
+                s.collect_map(v.fields.iter().map(|(key, value)| (key, ValueRef(value))))
+            }
+            Some(value::Value::List(v)) => match &v.values {
+                Some(list::Values::U8(v)) => s.collect_seq(&v.values),
+                Some(list::Values::I8(v)) => s.collect_seq(v.as_ref()),
+                Some(list::Values::U32(v)) => s.collect_seq(&v.values),
+                Some(list::Values::U64(v)) => s.collect_seq(&v.values),
+                Some(list::Values::I32(v)) => s.collect_seq(&v.values),
+                Some(list::Values::I64(v)) => s.collect_seq(&v.values),
+                Some(list::Values::F8(v)) => Floats(v.as_ref()).serialize(s),
+                Some(list::Values::F16(v)) => Floats(v.as_ref()).serialize(s),
+                Some(list::Values::F32(v)) => Floats(&v.values).serialize(s),
+                Some(list::Values::F64(v)) => Doubles(&v.values).serialize(s),
+                Some(list::Values::String(v)) => s.collect_seq(&v.values),
+                None => s.collect_seq(std::iter::empty::<f32>()),
+            },
             Some(value::Value::SparseVector(v)) => {
-                let mut object = serde_json::Map::new();
-                match v.values {
+                let mut map = s.serialize_map(Some(v.indices.len()))?;
+                match &v.values {
                     Some(sparse_vector::Values::F32(values)) => {
-                        for (index, value) in v.indices.into_iter().zip(values.values) {
-                            object.insert(index.to_string(), number(value)?);
+                        for (index, value) in v.indices.iter().zip(&values.values) {
+                            map.serialize_entry(&Index(*index), &finite(*value)?)?;
                         }
                     }
                     Some(sparse_vector::Values::F16(values)) => {
-                        for (index, value) in v.indices.into_iter().zip(values.as_ref()) {
-                            object.insert(index.to_string(), number(f32::from(*value))?);
+                        for (index, value) in v.indices.iter().zip(values.as_ref()) {
+                            map.serialize_entry(&Index(*index), &finite(f32::from(*value))?)?;
                         }
                     }
                     Some(sparse_vector::Values::F8(values)) => {
-                        for (index, value) in v.indices.into_iter().zip(values.as_ref()) {
-                            object.insert(index.to_string(), number(f32::from(*value))?);
+                        for (index, value) in v.indices.iter().zip(values.as_ref()) {
+                            map.serialize_entry(&Index(*index), &finite(f32::from(*value))?)?;
                         }
                     }
                     Some(sparse_vector::Values::U8(values)) => {
-                        for (index, value) in v.indices.into_iter().zip(values.values) {
-                            object.insert(index.to_string(), Self::from(value));
+                        for (index, value) in v.indices.iter().zip(&values.values) {
+                            map.serialize_entry(&Index(*index), value)?;
                         }
                     }
                     Some(sparse_vector::Values::I8(values)) => {
-                        for (index, value) in v.indices.into_iter().zip(values.as_ref()) {
-                            object.insert(index.to_string(), Self::from(*value));
+                        for (index, value) in v.indices.iter().zip(values.as_ref()) {
+                            map.serialize_entry(&Index(*index), value)?;
                         }
                     }
                     None => {}
                 }
-                Ok(Self::Object(object))
+                map.end()
             }
             Some(value::Value::Matrix(v)) => {
                 let num_cols = v.num_cols as usize;
-                if num_cols == 0 {
-                    return Ok(Self::Array(Vec::new()));
+                match &v.values {
+                    None => s.collect_seq(std::iter::empty::<f32>()),
+                    Some(_) if num_cols == 0 => s.collect_seq(std::iter::empty::<f32>()),
+                    Some(matrix::Values::F32(m)) => {
+                        s.collect_seq(m.values.chunks(num_cols).map(Floats))
+                    }
+                    Some(matrix::Values::F16(m)) => {
+                        s.collect_seq(m.as_ref().chunks(num_cols).map(Floats))
+                    }
+                    Some(matrix::Values::F8(m)) => {
+                        s.collect_seq(m.as_ref().chunks(num_cols).map(Floats))
+                    }
+                    Some(matrix::Values::U8(m)) => s.collect_seq(m.values.chunks(num_cols)),
+                    Some(matrix::Values::I8(m)) => s.collect_seq(m.as_ref().chunks(num_cols)),
                 }
-
-                let rows = match v.values {
-                    Some(matrix::Values::F32(values)) => array_of!(
-                        values.values.chunks(num_cols),
-                        |row| array_of!(row.iter().copied(), number).map(Self::Array)
-                    )?,
-                    Some(matrix::Values::F16(values)) => array_of!(
-                        values.as_ref().chunks(num_cols),
-                        |row| array_of!(row.iter().map(|n| f32::from(*n)), number).map(Self::Array)
-                    )?,
-                    Some(matrix::Values::F8(values)) => array_of!(
-                        values.as_ref().chunks(num_cols),
-                        |row| array_of!(row.iter().map(|n| f32::from(*n)), number).map(Self::Array)
-                    )?,
-                    Some(matrix::Values::U8(values)) => values
-                        .values
-                        .chunks(num_cols)
-                        .map(|row| Self::Array(row.iter().copied().map(Self::from).collect()))
-                        .collect(),
-                    Some(matrix::Values::I8(values)) => values
-                        .as_ref()
-                        .chunks(num_cols)
-                        .map(|row| Self::Array(row.iter().copied().map(Self::from).collect()))
-                        .collect(),
-                    None => Vec::new(),
-                };
-
-                Ok(Self::Array(rows))
             }
         }
     }
 }
 
-// `extract` never matches float-backed numbers, so whole-valued floats like
-// `[1.0, 2.0]` stay f32 rather than collapsing into the integer path.
-fn collect_ints<T>(
-    values: &[serde_json::Value],
-    extract: fn(&serde_json::Value) -> Option<T>,
-) -> Option<Vec<T>> {
-    values.iter().map(extract).collect()
+// JSON has no way to spell NaN or an infinity, and silently writing `null`
+// would hide the value.
+fn finite<T: Into<f64> + Copy, E: SerError>(value: T) -> Result<T, E> {
+    match value.into().is_finite() {
+        true => Ok(value),
+        false => Err(SerError::custom("non-finite floating-point value")),
+    }
 }
 
-fn number_to_f32(value: serde_json::Value) -> Result<f32, crate::Error> {
-    // Values beyond f32's range become infinity when downcast, matching the JS/Python SDKs.
-    Ok(value.as_f64().ok_or_else(|| {
-        crate::Error::InvalidArgument("JSON arrays must contain only numbers or strings".into())
-    })? as f32)
+/// A slice of anything that widens to `f32`, serialized as a JSON array.
+struct Floats<'a, T>(&'a [T]);
+
+impl<T: Copy + Into<f32>> Serialize for Floats<'_, T> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        let mut seq = s.serialize_seq(Some(self.0.len()))?;
+        for value in self.0 {
+            seq.serialize_element(&finite::<f32, S::Error>((*value).into())?)?;
+        }
+        seq.end()
+    }
 }
 
-fn number(value: impl Into<f64>) -> Result<serde_json::Value, crate::Error> {
-    serde_json::Number::from_f64(value.into())
-        .map(serde_json::Value::Number)
-        .ok_or_else(|| crate::Error::InvalidArgument("non-finite floating-point value".into()))
+struct Doubles<'a>(&'a [f64]);
+
+impl Serialize for Doubles<'_> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        let mut seq = s.serialize_seq(Some(self.0.len()))?;
+        for value in self.0 {
+            seq.serialize_element(&finite::<f64, S::Error>(*value)?)?;
+        }
+        seq.end()
+    }
+}
+
+/// A sparse-vector index as an object key, formatted in place rather than
+/// through a `String`.
+struct Index(u32);
+
+impl Serialize for Index {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        let mut buf = [0u8; 10];
+        let mut end = buf.len();
+        let mut rest = self.0;
+        loop {
+            end -= 1;
+            buf[end] = b'0' + (rest % 10) as u8;
+            rest /= 10;
+            if rest == 0 {
+                break;
+            }
+        }
+
+        s.serialize_str(std::str::from_utf8(&buf[end..]).expect("decimal digits are ASCII"))
+    }
 }
 
 #[cfg(test)]
@@ -380,8 +755,15 @@ mod tests {
             .collect()
     }
 
+    fn from_json_value(input: serde_json::Value) -> Result<TopkValue, serde_json::Error> {
+        serde_json::from_value::<Value>(input).map(Value::into_inner)
+    }
+
     #[rstest]
     // scalars
+    #[case::null(json!(null), TopkValue::null())]
+    #[case::bool(json!(true), TopkValue::bool(true))]
+    #[case::string(json!("a"), TopkValue::string("a"))]
     #[case::i64(json!(42), TopkValue::i64(42))]
     #[case::i64_negative(json!(-5), TopkValue::i64(-5))]
     #[case::u64(
@@ -395,9 +777,23 @@ mod tests {
     #[case::byte_value_list(json!([255, 128, 1, 0]), TopkValue::list(vec![255_i64, 128, 1, 0]))]
     #[case::whole_float_list(json!([1.0, 2.0]), TopkValue::list(vec![1.0_f32, 2.0]))]
     #[case::mixed_list(json!([1, 2.5]), TopkValue::list(vec![1.0_f32, 2.5]))]
+    #[case::float_then_int_list(json!([2.5, 1]), TopkValue::list(vec![2.5_f32, 1.0]))]
     #[case::u64_overflow_list(
         json!([1, i64::MAX as u64 + 1]),
         TopkValue::list(vec![1_u64, i64::MAX as u64 + 1])
+    )]
+    #[case::u64_overflow_then_int_list(
+        json!([i64::MAX as u64 + 1, 1]),
+        TopkValue::list(vec![i64::MAX as u64 + 1, 1_u64])
+    )]
+    // A negative and a value past `i64::MAX` share no integer width.
+    #[case::u64_overflow_with_negative_list(
+        json!([-1, i64::MAX as u64 + 1]),
+        TopkValue::list(vec![-1.0_f32, (i64::MAX as u64 + 1) as f32])
+    )]
+    #[case::u64_overflow_then_negative_list(
+        json!([i64::MAX as u64 + 1, -1]),
+        TopkValue::list(vec![(i64::MAX as u64 + 1) as f32, -1.0])
     )]
     #[case::empty_list(json!([]), TopkValue::list(Vec::<f32>::new()))]
     #[case::string_list(json!(["a", "b"]), TopkValue::list(vec!["a", "b"]))]
@@ -431,22 +827,53 @@ mod tests {
         )])
     )]
     fn from_json(#[case] input: serde_json::Value, #[case] expected: TopkValue) {
-        assert_eq!(TopkValue::try_from(input).unwrap(), expected);
+        assert_eq!(from_json_value(input.clone()).unwrap(), expected);
+
+        // The same shapes off the wire, through a streaming parser.
+        assert_eq!(
+            serde_json::from_str::<Value>(&input.to_string())
+                .unwrap()
+                .into_inner(),
+            expected
+        );
     }
 
     #[rstest]
     #[case::mixed_number_string(json!([1, "a"]))]
+    #[case::mixed_string_number(json!(["a", 1]))]
     #[case::bool_array(json!([true, false]))]
     #[case::null_array(json!([null]))]
     #[case::object_array(json!([{}]))]
+    #[case::nested_object_array(json!([[{}]]))]
     #[case::ragged_matrix(json!([[1], [2, 3]]))]
     #[case::zero_column_matrix(json!([[]]))]
     #[case::non_numeric_matrix(json!([[1], ["a"]]))]
     #[case::mixed_matrix_scalar(json!([[1], 2]))]
+    #[case::mixed_scalar_matrix(json!([1, [2]]))]
     #[case::mixed_keys_object(json!({"0": 1.5, "name": 2}))]
+    #[case::mixed_keys_object_reversed(json!({"name": 2, "0": 1.5}))]
     #[case::numeric_key_non_number_value(json!({"0": "a"}))]
+    #[case::nested_invalid_value(json!({"a": {"b": [1, "c"]}}))]
     fn from_json_invalid(#[case] input: serde_json::Value) {
-        assert!(TopkValue::try_from(input).is_err());
+        assert!(from_json_value(input.clone()).is_err());
+        assert!(serde_json::from_str::<Value>(&input.to_string()).is_err());
+    }
+
+    // Shape errors are reported to the caller, not to the deserializer, so the
+    // rest of the document still parses.
+    #[rstest]
+    #[case::mixed_array(json!({"ok": 1, "bad": [1, "a"], "also_ok": 2}))]
+    #[case::numeric_field_name(json!({"ok": 1, "bad": {"0": "a"}}))]
+    fn lenient_captures_shape_errors(#[case] input: serde_json::Value) {
+        let value: HashMap<String, LenientValue> = serde_json::from_value(input).unwrap();
+
+        assert!(value["ok"].0.is_ok());
+        assert!(value["bad"].0.is_err());
+    }
+
+    #[test]
+    fn lenient_still_fails_on_malformed_json() {
+        assert!(serde_json::from_str::<LenientValue>("{\"a\":").is_err());
     }
 
     #[rstest]
@@ -494,6 +921,10 @@ mod tests {
         TopkValue::i8_sparse_vector(vec![0, 2], vec![-1, 3]),
         json!({"0": -1, "2": 3})
     )]
+    #[case::wide_sparse_index(
+        TopkValue::f32_sparse_vector(vec![4294967295], vec![1.5]),
+        json!({"4294967295": 1.5})
+    )]
     // matrices
     #[case::f32_matrix(
         TopkValue::matrix(2, vec![1.5_f32, 2.5, 3.5, 4.5]),
@@ -525,14 +956,16 @@ mod tests {
         json!({})
     )]
     fn to_json(#[case] input: TopkValue, #[case] expected: serde_json::Value) {
-        assert_eq!(serde_json::Value::try_from(input).unwrap(), expected);
+        assert_eq!(serde_json::to_value(Value(input)).unwrap(), expected);
     }
 
     #[rstest]
     #[case::nan_f32(TopkValue::f32(f32::NAN))]
     #[case::inf_f64(TopkValue::f64(f64::INFINITY))]
+    #[case::nan_in_list(TopkValue::list(vec![1.0_f32, f32::NAN]))]
+    #[case::inf_in_matrix(TopkValue::matrix(1, vec![f32::INFINITY]))]
+    #[case::nan_in_sparse_vector(TopkValue::f32_sparse_vector(vec![0], vec![f32::NAN]))]
     fn non_finite(#[case] input: TopkValue) {
-        assert!(serde_json::Value::try_from(input.clone()).is_err());
         assert!(serde_json::to_value(Value(input)).is_err());
     }
 
@@ -546,11 +979,6 @@ mod tests {
     fn serde_roundtrip(#[case] input: TopkValue, #[case] expected: serde_json::Value) {
         let serialized = serde_json::to_value(Value(input.clone())).unwrap();
         assert_eq!(serialized, expected);
-        assert_eq!(
-            serde_json::from_value::<Value>(serialized)
-                .unwrap()
-                .into_inner(),
-            input
-        );
+        assert_eq!(from_json_value(serialized).unwrap(), input);
     }
 }


### PR DESCRIPTION
- Switch from `serde_json` to `sonic-rs` to reduce JSON serde overhead.
- Implement custom visitor/serializer/deserializer for wrapper types
- Reduce temporary allocations when converting from json value -> topk proto value