### PR TITLE
[es] honour _source query params on search

### DIFF
--- a/topk-es/src/api/search.rs
+++ b/topk-es/src/api/search.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
+use async_trait::async_trait;
+use axum::extract::{FromRequest, FromRequestParts, Request};
+
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, OneOrMany};
 use topk_rs::json::Value as JsonValue;
@@ -9,7 +12,8 @@ use topk_rs::query::SortOrder as TopkSortOrder;
 
 use super::aggs::{AggClause, AggResult};
 use super::query::{FieldClause, FieldName, GateQuery, Query};
-use super::source::SourceFilter;
+use super::body::Body;
+use super::source::{SourceFilter, SourceQuery};
 use super::{DocId, IndexName, Shards, Source};
 use crate::vector::ensure_finite;
 use crate::Error;
@@ -49,11 +53,39 @@ pub struct SearchRequest {
     pub aggs: HashMap<String, AggClause>,
 
     #[serde(default, rename = "_source")]
-    pub source: SourceFilter,
+    source: Option<SourceFilter>,
 }
 
 fn default_size() -> u64 {
     10
+}
+
+impl SearchRequest {
+    /// The effective source filter; absent means everything.
+    pub fn source(&self) -> SourceFilter {
+        self.source.clone().unwrap_or_default()
+    }
+}
+
+/// A `_search` body with `_source*` query params already applied.
+///
+/// They outrank the body here, unlike `_mget` where the per-doc `_source` wins.
+pub struct SearchBody(pub SearchRequest);
+
+#[async_trait]
+impl<S: Send + Sync> FromRequest<S> for SearchBody {
+    type Rejection = Error;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        let (mut parts, body) = req.into_parts();
+        let SourceQuery(source) = SourceQuery::from_request_parts(&mut parts, state).await?;
+
+        let req = Request::from_parts(parts, body);
+        let Body(mut search) = Body::<SearchRequest>::from_request(req, state).await?;
+        search.source = source.or(search.source.take());
+
+        Ok(SearchBody(search))
+    }
 }
 
 impl<'de> Deserialize<'de> for SearchRequest {

--- a/topk-es/src/api/source.rs
+++ b/topk-es/src/api/source.rs
@@ -91,10 +91,23 @@ struct SourceQueryParams {
 }
 
 #[async_trait]
-impl<S: Send + Sync> FromRequestParts<S> for SourceFilter {
+impl<S: Send + Sync> FromRequestParts<S> for SourceQueryParams {
     type Rejection = Error;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Query(params) = Query::<Self>::from_request_parts(parts, state)
+            .await
+            .map_err(|e| Error::BadRequest(format!("Invalid query string: {e}")))?;
+        Ok(params)
+    }
+}
+
+impl SourceQueryParams {
+    fn is_empty(&self) -> bool {
+        self.source.is_none() && self.source_includes.is_none() && self.source_excludes.is_none()
+    }
+
+    fn into_filter(self) -> SourceFilter {
         fn split_csv(s: &str) -> Vec<String> {
             s.split(',')
                 .map(str::trim)
@@ -103,22 +116,18 @@ impl<S: Send + Sync> FromRequestParts<S> for SourceFilter {
                 .collect()
         }
 
-        let Query(query) = Query::<SourceQueryParams>::from_request_parts(parts, state)
-            .await
-            .map_err(|e| Error::BadRequest(format!("Invalid query string: {e}")))?;
-
-        let mut includes = query
+        let mut includes = self
             .source_includes
             .as_deref()
             .map(split_csv)
             .unwrap_or_default();
-        let excludes = query
+        let excludes = self
             .source_excludes
             .as_deref()
             .map(split_csv)
             .unwrap_or_default();
 
-        let enabled = match query.source.as_deref() {
+        let enabled = match self.source.as_deref() {
             None | Some("true") => true,
             Some("false") => false,
             Some(csv) => {
@@ -127,7 +136,54 @@ impl<S: Send + Sync> FromRequestParts<S> for SourceFilter {
             }
         };
 
-        Ok(SourceFilter::new(enabled, includes, excludes))
+        SourceFilter::new(enabled, includes, excludes)
+    }
+}
+
+#[async_trait]
+impl<S: Send + Sync> FromRequestParts<S> for SourceFilter {
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        Ok(SourceQueryParams::from_request_parts(parts, state)
+            .await?
+            .into_filter())
+    }
+}
+
+/// The `_source*` query params, or `None` if the request carried none.
+///
+/// `SourceFilter`'s own extractor cannot say "absent" -- with no params it yields the
+/// default, which reads as an explicit "everything".
+#[derive(Debug, Clone)]
+pub struct SourceQuery(pub Option<SourceFilter>);
+
+#[async_trait]
+impl<S: Send + Sync> FromRequestParts<S> for SourceQuery {
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let params = SourceQueryParams::from_request_parts(parts, state).await?;
+        Ok(SourceQuery((!params.is_empty()).then(|| params.into_filter())))
+    }
+}
+
+/// Rejects `_source*` query params, which Elasticsearch does not accept on every
+/// endpoint that takes a search body -- `_msearch` answers 400 for all three.
+pub struct NoSourceQuery;
+
+#[async_trait]
+impl<S: Send + Sync> FromRequestParts<S> for NoSourceQuery {
+    type Rejection = Error;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let path = parts.uri.path().to_string();
+        match SourceQueryParams::from_request_parts(parts, state).await?.is_empty() {
+            true => Ok(Self),
+            false => Err(Error::Unsupported(format!(
+                "request [{path}] contains unrecognized parameter: [_source*]"
+            ))),
+        }
     }
 }
 

--- a/topk-es/src/engine/compile.rs
+++ b/topk-es/src/engine/compile.rs
@@ -156,7 +156,7 @@ fn lower(
     }
     .limit(limit);
 
-    let query = match (req.source.enabled(), req.sort.as_ref()) {
+    let query = match (req.source().enabled(), req.sort.as_ref()) {
         (true, _) => query.fetch(["*"]),
         (false, Some(sort)) => query.fetch(
             sort.iter()

--- a/topk-es/src/engine/rank.rs
+++ b/topk-es/src/engine/rank.rs
@@ -204,15 +204,16 @@ fn to_hits(req: &SearchRequest, candidates: Vec<(f32, Candidate)>) -> Vec<Hit> {
         .as_ref()
         .is_some_and(|s| s.len() == 1 && s[0].is_score() && !s[0].asc);
 
+    let source = req.source();
+
     candidates
         .into_iter()
         .map(|(key, score, candidate)| Hit {
             score: scores.then_some(score),
             sort: key.filter(|_| !default_order).map(SortKey::into_json),
-            source: req
-                .source
+            source: source
                 .enabled()
-                .then(|| decode(&req.source, candidate.fields)),
+                .then(|| decode(&source, candidate.fields)),
             id: candidate.id,
         })
         .collect()

--- a/topk-es/tests/common/mod.rs
+++ b/topk-es/tests/common/mod.rs
@@ -263,6 +263,33 @@ impl TestScope {
         to_json(res).await
     }
 
+    /// `_search` with `_source*` on the query string.
+    pub async fn search_with_source(
+        &self,
+        body: Value,
+        source: Option<&str>,
+        includes: Option<&[&str]>,
+        excludes: Option<&[&str]>,
+    ) -> TestResult<SearchResponse> {
+        let index = [self.name.as_str()];
+        let mut req = self
+            .client
+            .es()
+            .search(SearchParts::Index(&index))
+            .body(body);
+        let source = source.map(|s| [s]);
+        if let Some(source) = source.as_ref() {
+            req = req._source(source);
+        }
+        if let Some(includes) = includes {
+            req = req._source_includes(includes);
+        }
+        if let Some(excludes) = excludes {
+            req = req._source_excludes(excludes);
+        }
+        into_test_result(req.send().await.expect("search")).await.map(SearchResponse)
+    }
+
     pub async fn search(&self, body: Value) -> TestResult<SearchResponse> {
         let dfs = std::env::var("ES_DFS").is_ok() && body.get("knn").is_none();
 

--- a/topk-es/tests/msearch.rs
+++ b/topk-es/tests/msearch.rs
@@ -103,3 +103,32 @@ async fn test_msearch_root_per_header_index(scope: &TwoIndices) {
     );
     assert_eq!(responses[1]["hits"]["hits"][0]["_source"]["v"], "a");
 }
+
+#[test_context(TestScope)]
+#[tokio::test]
+async fn test_rejects_source_params(scope: &TestScope) {
+    scope.create().await;
+
+    // The typed client has no builder for these on _msearch -- Elasticsearch answers 400
+    // for all three -- so they go on by hand.
+    for param in ["_source", "_source_includes", "_source_excludes"] {
+        let res = scope
+            .client
+            .es()
+            .transport()
+            .send::<&str, [(&str, &str); 1]>(
+                elasticsearch::http::Method::Post,
+                &format!("/{}/_msearch", scope.name),
+                elasticsearch::http::headers::HeaderMap::new(),
+                Some(&[(param, "title")]),
+                Some("{}\n{}\n"),
+                None,
+            )
+            .await
+            .expect("msearch");
+
+        assert_eq!(res.status_code(), 400, "{param} should be rejected");
+        let body: serde_json::Value = res.json().await.expect("error body");
+        assert_eq!(body["error"]["type"], "illegal_argument_exception", "{body}");
+    }
+}

--- a/topk-es/tests/search.rs
+++ b/topk-es/tests/search.rs
@@ -1433,3 +1433,70 @@ async fn test_search_source_nested_field_paths(
 
     assert_eq!(body.source("1"), &expected, "{body}");
 }
+
+#[rstest_ctx(BooksContext)]
+#[case::includes(
+    None,
+    Some(&["title", "genre"][..]),
+    None,
+    Some(json!({ "title": "The Hobbit", "genre": "fantasy" }))
+)]
+#[case::source_csv(Some("title"), None, None, Some(json!({ "title": "The Hobbit" })))]
+#[case::source_false(Some("false"), None, None, None)]
+#[case::excludes(
+    None,
+    None,
+    Some(&["embedding", "token_embeddings", "tags"][..]),
+    Some(json!({
+        "title": "The Hobbit",
+        "author": "Tolkien",
+        "published_year": 1937,
+        "rating": 4.3,
+        "genre": "fantasy",
+        "in_print": true,
+    }))
+)]
+async fn test_source_query_params(
+    books: &BooksContext,
+    #[case] source: Option<&str>,
+    #[case] includes: Option<&[&str]>,
+    #[case] excludes: Option<&[&str]>,
+    #[case] expected: Option<Value>,
+) {
+    let body = books
+        .search_with_source(
+            json!({ "query": { "term": { "genre": "fantasy" } }, "size": 10 }),
+            source,
+            includes,
+            excludes,
+        )
+        .await
+        .expect("search should succeed");
+
+    match expected {
+        Some(expected) => assert_eq!(body.source("hobbit"), &expected, "{body}"),
+        None => assert!(body.all_source_omitted(), "{body}"),
+    }
+}
+
+#[rstest_ctx(BooksContext)]
+#[case::query_wins(json!(["genre"]), Some(&["title"][..]), json!({ "title": "The Hobbit" }))]
+#[case::body_only(json!(["genre"]), None, json!({ "genre": "fantasy" }))]
+async fn test_source_precedence(
+    books: &BooksContext,
+    #[case] body_source: Value,
+    #[case] includes: Option<&[&str]>,
+    #[case] expected: Value,
+) {
+    let mut body = json!({ "query": { "term": { "genre": "fantasy" } }, "size": 10 });
+    if !body_source.is_null() {
+        body["_source"] = body_source;
+    }
+
+    let res = books
+        .search_with_source(body, None, includes, None)
+        .await
+        .expect("search should succeed");
+
+    assert_eq!(res.source("hobbit"), &expected, "{res}");
+}


### PR DESCRIPTION
`/_search` ignored `_source`, `_source_includes` and `_source_excludes` on the query string, which is where the official clients put field selection — so every hit came back with its full `_source`, stored embeddings included.
