### PR TITLE
[sdk] ignore empty required lsn

### DIFF
--- a/topk-py/tests/test_collection_update.py
+++ b/topk-py/tests/test_collection_update.py
@@ -60,10 +60,7 @@ def test_update_missing_id(ctx: ProjectContext):
     assert lsn == "1"
 
     # Update non-existent doc
-    new_lsn = ctx.client.collection(collection.name).update(
-        [{"_id": "3", "foo": "bar3"}], False
-    )
-    assert new_lsn == ""
+    ctx.client.collection(collection.name).update([{"_id": "3", "foo": "bar3"}], False)
 
     # Check that no changes were made
     docs = ctx.client.collection(collection.name).get(["1", "2", "3"], lsn=lsn)

--- a/topk-rs/src/client/collection.rs
+++ b/topk-rs/src/client/collection.rs
@@ -112,6 +112,8 @@ impl CollectionClient {
     ) -> Result<HashMap<String, HashMap<String, Value>>, Error> {
         let client = create_client!(QueryServiceClient, self.read, self.config).await?;
         let ids: Vec<String> = ids.into_iter().map(|id| id.into()).collect();
+        // A no-op write returns an empty LSN, which means there is nothing to wait for.
+        let lsn = lsn.filter(|lsn| !lsn.is_empty());
 
         let response = call_with_retry(&self.config.retry_config(), || {
             let mut client = client.clone();
@@ -209,6 +211,8 @@ impl CollectionClient {
         consistency: Option<ConsistencyLevel>,
     ) -> Result<DocumentStream, Error> {
         let client = create_client!(QueryServiceClient, self.read, self.config).await?;
+        // A no-op write returns an empty LSN, which means there is nothing to wait for.
+        let lsn = lsn.filter(|lsn| !lsn.is_empty());
 
         let response = call_with_retry(&self.config.retry_config(), || {
             let mut client = client.clone();

--- a/topk-rs/tests/test_collection_update.rs
+++ b/topk-rs/tests/test_collection_update.rs
@@ -115,7 +115,8 @@ async fn test_update_missing_id(ctx: &mut ProjectTestContext) {
         .await
         .expect("could not update document");
 
-    assert!(new_lsn.is_empty());
+    // Nothing was updated, so the collection is still at the LSN of the upsert.
+    assert_eq!(new_lsn, lsn);
 
     // Check that no changes were made
     let docs = ctx

--- a/topk-rs/tests/test_required_lsn.rs
+++ b/topk-rs/tests/test_required_lsn.rs
@@ -1,4 +1,5 @@
 use test_context::test_context;
+use topk_rs::doc;
 use topk_rs::query::{field, select};
 use topk_rs::Error;
 
@@ -33,4 +34,28 @@ async fn test_invalid_required_lsn(ctx: &mut ProjectTestContext) {
         matches!(err, Error::InvalidArgument(ref s) if s.contains("Invalid required LSN")),
         "query: {err:?}"
     );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_required_lsn_from_noop_update(ctx: &mut ProjectTestContext) {
+    let collection = ctx
+        .client
+        .collections()
+        .create(ctx.wrap("empty"), dataset::books::schema(), None)
+        .await
+        .expect("could not create collection");
+    let collection = ctx.client.collection(&collection.name);
+
+    // Update on a collection that was never written to resolves no documents.
+    let lsn = collection
+        .update(vec![doc!("_id" => "1984", "title" => "1984")], false)
+        .await
+        .expect("update must not fail");
+
+    let docs = collection
+        .get(["1984"], None, Some(lsn), None)
+        .await
+        .expect("get with the lsn returned by update must not fail");
+    assert!(docs.is_empty(), "expected no documents, got {docs:?}");
 }


### PR DESCRIPTION
a no-op write returns an empty lsn — ignore it instead of sending it as a required lsn and getting back `invalid required lsn`