### PR TITLE
[rs] stream body errors

### DIFF
--- a/topk-rs/src/client/ask.rs
+++ b/topk-rs/src/client/ask.rs
@@ -1,5 +1,4 @@
-use futures_util::TryFutureExt;
-use tonic::Streaming;
+use futures_util::{Stream, TryFutureExt, TryStreamExt};
 
 use crate::create_client;
 use crate::proto::v1::ctx::context_service_client::ContextServiceClient;
@@ -20,7 +19,7 @@ impl super::Client {
         mode: Option<Mode>,
         select_fields: Option<Vec<String>>,
         include_content: Option<bool>,
-    ) -> Result<Streaming<AskResult>, Error> {
+    ) -> Result<impl Stream<Item = Result<AskResult, Error>>, Error> {
         let datasets: Vec<_> = datasets.into_iter().map(|s| s.into()).collect();
         if datasets.is_empty() {
             return Err(Error::InvalidArgument(
@@ -46,6 +45,6 @@ impl super::Client {
         })
         .await?;
 
-        Ok(response.into_inner())
+        Ok(response.into_inner().map_err(Error::from))
     }
 }

--- a/topk-rs/src/client/dataset.rs
+++ b/topk-rs/src/client/dataset.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use futures_util::{Stream, TryStreamExt};
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
@@ -12,7 +13,6 @@ use tokio_stream::wrappers::ReceiverStream;
 
 use tokio::sync::OnceCell;
 use tonic::transport::Channel;
-use tonic::Streaming;
 
 use crate::proto::v1::data::Document;
 
@@ -83,7 +83,7 @@ impl DatasetClient {
         &self,
         fields: Option<Vec<String>>,
         filter: Option<LogicalExpr>,
-    ) -> Result<Streaming<ListEntry>, Error> {
+    ) -> Result<impl Stream<Item = Result<ListEntry, Error>>, Error> {
         let client = create_client!(DatasetReadServiceClient, self.read, self.config).await?;
         let fields = fields.unwrap_or_default();
 
@@ -103,7 +103,7 @@ impl DatasetClient {
         })
         .await?;
 
-        Ok(response.into_inner())
+        Ok(response.into_inner().map_err(Error::from))
     }
 
     pub async fn upsert_file(

--- a/topk-rs/src/client/search.rs
+++ b/topk-rs/src/client/search.rs
@@ -1,5 +1,4 @@
-use futures_util::TryFutureExt;
-use tonic::Streaming;
+use futures_util::{Stream, TryFutureExt, TryStreamExt};
 
 use crate::create_client;
 use crate::proto::v1::ctx::context_service_client::ContextServiceClient;
@@ -18,7 +17,7 @@ impl super::Client {
         top_k: u32,
         filter: Option<LogicalExpr>,
         select_fields: impl IntoIterator<Item = impl Into<String>>,
-    ) -> Result<Streaming<SearchResult>, Error> {
+    ) -> Result<impl Stream<Item = Result<SearchResult, Error>>, Error> {
         let datasets: Vec<_> = datasets.into_iter().map(|s| s.into()).collect();
         if datasets.is_empty() {
             return Err(Error::InvalidArgument(
@@ -43,6 +42,6 @@ impl super::Client {
         })
         .await?;
 
-        Ok(response.into_inner())
+        Ok(response.into_inner().map_err(Error::from))
     }
 }

--- a/topk-rs/tests/test_ask.rs
+++ b/topk-rs/tests/test_ask.rs
@@ -1,4 +1,4 @@
-use futures_util::StreamExt;
+use futures_util::{Stream, StreamExt};
 use test_context::test_context;
 
 use topk_rs::proto::v1::{
@@ -64,7 +64,8 @@ async fn test_ask_empty_datasets() {
     let err = Client::new(ClientConfig::new("dummy-key", "us-east-1"))
         .ask("query", Vec::<&str>::new(), None, None, None, Some(true))
         .await
-        .expect_err("should fail with empty datasets");
+        .err()
+        .expect("should fail with empty datasets");
 
     assert!(
         matches!(err, Error::InvalidArgument(ref s) if s == "provide at least one dataset"),
@@ -163,8 +164,9 @@ async fn test_ask_include_content_false_strips_chunks(ctx: &mut ProjectTestConte
 }
 
 async fn collect_answer(
-    mut stream: tonic::Streaming<AskResult>,
+    stream: impl Stream<Item = Result<AskResult, Error>>,
 ) -> topk_rs::proto::v1::ctx::ask_result::Answer {
+    let mut stream = std::pin::pin!(stream);
     while let Some(msg) = stream.next().await {
         if let Some(Message::Answer(answer)) = msg.unwrap().message {
             return answer;

--- a/topk-rs/tests/test_search.rs
+++ b/topk-rs/tests/test_search.rs
@@ -71,7 +71,8 @@ async fn test_search_query_too_long(ctx: &mut ProjectTestContext) {
             Vec::<String>::new(),
         )
         .await
-        .expect_err("should fail with too long query");
+        .err()
+        .expect("should fail with too long query");
 
     assert!(
         matches!(err, Error::InvalidArgument(ref s) if s.contains("maximum length of 512")),
@@ -94,7 +95,8 @@ async fn test_search_invalid_top_k(ctx: &mut ProjectTestContext) {
             .client
             .search("query", [&dataset.name], top_k, None, Vec::<String>::new())
             .await
-            .expect_err("should fail with invalid top_k");
+            .err()
+            .expect("should fail with invalid top_k");
 
         assert!(
             matches!(err, Error::InvalidArgument(ref s) if s.contains("top_k must be between 1 and")),
@@ -108,7 +110,8 @@ async fn test_search_empty_datasets() {
     let err = Client::new(ClientConfig::new("dummy-key", "us-east-1"))
         .search("query", Vec::<&str>::new(), 10, None, Vec::<String>::new())
         .await
-        .expect_err("should fail with empty datasets");
+        .err()
+        .expect("should fail with empty datasets");
 
     assert!(
         matches!(err, Error::InvalidArgument(ref s) if s == "provide at least one dataset"),


### PR DESCRIPTION
we lead raw `Result<_, Status>` errors when a stream breaks, which prevents the retry logic from kicking in (since it keys off of `Error`)