### PR TITLE
[topk-rs] Quantile and CountDistinct aggregations

### DIFF
--- a/protos/topk/data/v1/expr/aggregate.proto
+++ b/protos/topk/data/v1/expr/aggregate.proto
@@ -24,11 +24,26 @@ message AggregateExpr {
         string field = 1;
     }
 
+    message Quantile {
+        // Numeric field whose approximate quantile should be calculated.
+        string field = 1;
+
+        // Quantile in the inclusive range [0, 1]. Must be finite.
+        double q = 2;
+    }
+
+    message CountDistinct {
+        // Field whose non-null distinct values should be counted approximately.
+        string field = 1;
+    }
+
     oneof op {
         Count count = 1;
         Sum sum = 2;
         Min min = 3;
         Max max = 4;
         Average avg = 5;
+        Quantile quantile = 6;
+        CountDistinct count_distinct = 7;
     }
 }

--- a/topk-rs/src/proto/data/v1/query_ext/expr_ext/aggregate.rs
+++ b/topk-rs/src/proto/data/v1/query_ext/expr_ext/aggregate.rs
@@ -46,4 +46,58 @@ impl AggregateExpr {
             })),
         }
     }
+
+    /// Calculate an approximate quantile of the given numeric field.
+    /// `q` must be finite and in the inclusive range `[0, 1]`.
+    pub fn quantile(field: impl Into<String>, q: f64) -> Self {
+        Self {
+            op: Some(aggregate_expr::Op::Quantile(aggregate_expr::Quantile {
+                field: field.into(),
+                q,
+            })),
+        }
+    }
+
+    /// Count the approximate number of distinct non-null values of the given field.
+    pub fn count_distinct(field: impl Into<String>) -> Self {
+        Self {
+            op: Some(aggregate_expr::Op::CountDistinct(
+                aggregate_expr::CountDistinct {
+                    field: field.into(),
+                },
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quantile_constructs_proto() {
+        let expr = AggregateExpr::quantile("score", 0.99);
+
+        assert_eq!(
+            expr.op,
+            Some(aggregate_expr::Op::Quantile(aggregate_expr::Quantile {
+                field: "score".to_string(),
+                q: 0.99,
+            }))
+        );
+    }
+
+    #[test]
+    fn count_distinct_constructs_proto() {
+        let expr = AggregateExpr::count_distinct("author");
+
+        assert_eq!(
+            expr.op,
+            Some(aggregate_expr::Op::CountDistinct(
+                aggregate_expr::CountDistinct {
+                    field: "author".to_string(),
+                }
+            ))
+        );
+    }
 }

--- a/topk-rs/tests/test_group_by.rs
+++ b/topk-rs/tests/test_group_by.rs
@@ -235,6 +235,75 @@ async fn test_group_by_avg(ctx: &mut ProjectTestContext) {
 
 #[test_context(ProjectTestContext)]
 #[tokio::test]
+async fn test_group_by_quantiles_and_count_distinct(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let result = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            group_by(
+                [("is_old", field("published_year").lt(1940 as u32))],
+                [
+                    ("earliest", AggregateExpr::quantile("published_year", 0.0)),
+                    ("latest", AggregateExpr::quantile("published_year", 1.0)),
+                    ("distinct_ratings", AggregateExpr::count_distinct("rating")),
+                ],
+            ),
+            None,
+            None,
+        )
+        .await
+        .expect("could not query");
+
+    let by_group: HashMap<bool, (f64, f64, u64)> = result
+        .iter()
+        .map(|row| {
+            (
+                row.fields["is_old"].as_bool().unwrap(),
+                (
+                    row.fields["earliest"].as_f64().unwrap(),
+                    row.fields["latest"].as_f64().unwrap(),
+                    row.fields["distinct_ratings"].as_u64().unwrap(),
+                ),
+            )
+        })
+        .collect();
+
+    assert_eq!(by_group[&true], (1813.0, 1937.0, 3));
+    assert_eq!(by_group[&false], (1949.0, 1997.0, 0));
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
+async fn test_group_by_rejects_invalid_quantile(ctx: &mut ProjectTestContext) {
+    let collection = dataset::books::setup(ctx).await;
+
+    let err = ctx
+        .client
+        .collection(&collection.name)
+        .query(
+            group_by(
+                [("is_old", field("published_year").lt(1940 as u32))],
+                [(
+                    "median",
+                    AggregateExpr::quantile("published_year", f64::NAN),
+                )],
+            ),
+            None,
+            None,
+        )
+        .await
+        .expect_err("invalid quantile should fail");
+
+    assert!(
+        matches!(err, Error::InvalidArgument(ref s) if s.contains("finite value in [0, 1]")),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[test_context(ProjectTestContext)]
+#[tokio::test]
 async fn test_group_by_multiple_aggregations(ctx: &mut ProjectTestContext) {
     let collection = dataset::books::setup(ctx).await;
 


### PR DESCRIPTION
Expose `quantile(field, q)` and `count_distinct(field)` aggregations in `topk-rs`.