### PR TITLE
[docs] document the Elasticsearch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Start with the [documentation](https://docs.topk.io) for quickstart guides, API 
 - [JavaScript SDK](./topk-js/) - Javascript SDK for TopK API with full Typescript support
 - [Rust SDK](./topk-rs/) - Rust SDK for TopK API
 - [SQL](./topk-sql/) - Connect any PostgreSQL client to TopK
+- [Elasticsearch API](./topk-es/) - Point any Elasticsearch client at TopK
 
 ## CLI
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -195,6 +195,18 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Elasticsearch",
+        "icon": "search",
+        "pages": [
+          {
+            "group": "Elasticsearch",
+            "pages": [
+              "sdk/topk-es/overview"
+            ]
+          }
+        ]
       }
     ]
   },

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -14331,7 +14331,7 @@ PUT /books
       "published_year": { "type": "integer" },
       "rating":         { "type": "float" },
       "in_print":       { "type": "boolean" },
-      "embedding":      { "type": "dense_vector", "dims": 16, "similarity": "cosine" }
+      "embedding":      { "type": "dense_vector", "dims": 4, "similarity": "cosine" }
     }
   }
 }
@@ -14342,9 +14342,9 @@ Index documents:
 ```json
 POST /books/_bulk
 { "index": { "_id": "mockingbird" } }
-{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true }
+{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true, "embedding": [1.0, 0.0, 0.0, 0.0] }
 { "index": { "_id": "gatsby" } }
-{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true }
+{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true, "embedding": [0.9, 0.1, 0.0, 0.0] }
 ```
 
 Search:
@@ -14420,7 +14420,7 @@ The following query clauses are supported inside `query`:
 | `regexp` | Regular expression match. |
 | `range` | `gt`, `gte`, `lt`, `lte` bounds. |
 | `exists` | Field is present and non-null. |
-| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`, `minimum_should_match`. |
+| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`. Accepts `boost`. |
 | `semantic` | **TopK extension.** Managed semantic search — see below. |
 
 #### Search body
@@ -14447,7 +14447,7 @@ POST /books/_search
 {
   "knn": {
     "field": "embedding",
-    "query_vector": [0.12, 0.87, 0.05, 0.44],
+    "query_vector": [1.0, 0.0, 0.0, 0.0],
     "k": 10,
     "filter": [{ "term": { "in_print": true } }]
   }
@@ -14462,7 +14462,7 @@ reciprocal rank fusion. `rank_constant` defaults to `60`.
 ```json
 POST /books/_search
 {
-  "query": { "match": { "body": "cats" } },
+  "query": { "match": { "title": "mockingbird" } },
   "knn": {
     "field": "embedding",
     "query_vector": [1.0, 0.0, 0.0, 0.0],

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -384,6 +384,20 @@ Currently available public regions:
 | AWS | eu-central-1 | 🇪🇺 Frankfurt | `aws-eu-central-1-monstera` |
 | GCP | us-east4 | 🇺🇸 N. Virginia | `gcp-us-east4-aloe` |
 
+#### Endpoints
+
+Each API is reached at a hostname built from your region name:
+
+| API | Hostname | Example |
+|-----|----------|---------|
+| Collection and Management API | `<region>.api.topk.io` | `aws-us-east-1-elastica.api.topk.io` |
+| [SQL](/sdk/topk-sql/overview) | `<region>.sql.topk.io` | `aws-us-east-1-elastica.sql.topk.io` |
+| [Elasticsearch](/sdk/topk-es/overview) | `<region>.es.topk.io` | `aws-us-east-1-elastica.es.topk.io` |
+
+The SDKs and the CLI build the Collection API hostname for you — pass the region name and
+they handle the rest. The SQL and Elasticsearch endpoints are addressed directly by their
+hostname.
+
 <Info>
   To deploy TopK in your own VPC, please [contact us](https://topk.io/contact).
 </Info>
@@ -14250,6 +14264,372 @@ only affect the wire type.
 | plain column (no cast) | 114 `JSON` |
 | search function (no cast) | 700 `FLOAT4` |
 | `COUNT(*)` (no cast) | 20 `INT8` |
+
+## Elasticsearch
+
+### Elasticsearch API
+
+URL: https://docs.topk.io/sdk/topk-es/overview
+
+TopK exposes an Elasticsearch-compatible HTTP endpoint. Official Elasticsearch clients
+connect to it unchanged — same URLs, same request bodies, same response shapes — so you can
+move an existing application to TopK without rewriting your query layer.
+#### Prerequisites
+
+- **API key** — sign in to [console.topk.io](https://console.topk.io) and generate an API key.
+- **Region** — see [docs.topk.io/regions](https://docs.topk.io/regions) for available regions.
+
+#### Setup
+
+The endpoint is `https://<region>.es.<host>`, where `<host>` is `topk.io`:
+
+```
+https://<region>.es.topk.io
+```
+
+Authenticate with your TopK API key as an Elasticsearch API key. Replace `<region>` with
+your region name and `<api-key>` with your API key — for example
+`https://aws-us-east-1-elastica.es.topk.io`.
+
+```bash
+curl https://<region>.es.topk.io/books/_search \
+  -H "Authorization: ApiKey <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": { "match": { "title": "mockingbird" } } }'
+```
+
+<Tip>
+
+See [available regions](https://docs.topk.io/regions) and get your [API key](https://console.topk.io/api-key).
+
+</Tip>
+
+Any official Elasticsearch client works. For example, in Python:
+
+```python
+from elasticsearch import Elasticsearch
+
+es = Elasticsearch(
+    "https://<region>.es.topk.io",
+    api_key="<api-key>",
+)
+
+es.search(index="books", body={"query": {"match": {"title": "mockingbird"}}})
+```
+
+#### Quick Start
+
+Create an index:
+
+```json
+PUT /books
+{
+  "mappings": {
+    "properties": {
+      "title":          { "type": "text" },
+      "author":         { "type": "keyword" },
+      "published_year": { "type": "integer" },
+      "rating":         { "type": "float" },
+      "in_print":       { "type": "boolean" },
+      "embedding":      { "type": "dense_vector", "dims": 16, "similarity": "cosine" }
+    }
+  }
+}
+```
+
+Index documents:
+
+```json
+POST /books/_bulk
+{ "index": { "_id": "mockingbird" } }
+{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true }
+{ "index": { "_id": "gatsby" } }
+{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true }
+```
+
+Search:
+
+```json
+POST /books/_search
+{
+  "query": {
+    "bool": {
+      "must":   [{ "match": { "title": "mockingbird" } }],
+      "filter": [{ "range": { "published_year": { "gte": 1950 } } }]
+    }
+  },
+  "size": 10
+}
+```
+
+#### Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /` | Cluster info. Returns the `x-elastic-product` header official clients expect. |
+| `PUT /<index>` | Create an index with mappings. |
+| `GET /<index>` | Read an index's mappings and settings. |
+| `HEAD /<index>` | Check whether an index exists. |
+| `DELETE /<index>` | Delete an index. |
+| `GET /<index>/_mapping` | Read the mapping for an index. |
+| `POST /<index>/_search` | Search documents. |
+| `POST /_msearch`, `POST /<index>/_msearch` | Run multiple searches in one request. |
+| `POST /<index>/_count` | Count documents matching a query. |
+| `PUT /<index>/_doc/<id>` | Index a single document. Returns `201`. |
+| `GET /<index>/_doc/<id>` | Get a document by id. |
+| `GET /<index>/_source/<id>` | Get just the `_source` of a document. |
+| `DELETE /<index>/_doc/<id>` | Delete a document by id. |
+| `POST /_mget`, `POST /<index>/_mget` | Get multiple documents by id. |
+| `POST /<index>/_bulk` | Bulk `index`, `create`, `update`, and `delete`. |
+| `GET /<index>/_field_caps` | Field capabilities for an index. |
+| `GET /_resolve/index/<expr>` | Resolve index names. |
+| `POST /<index>/_refresh` | Make pending writes searchable. |
+
+Index names must start with a letter or digit and contain only letters, digits, underscores,
+dashes, and dots, up to 255 characters. Document ids must be non-empty and at most 512 bytes.
+
+##### Making writes visible
+
+Writes become searchable asynchronously. Either call `POST /<index>/_refresh`, or pass the
+`refresh` query parameter on an index, delete, or bulk request to control when the call
+returns:
+
+| Value | Behaviour |
+| --- | --- |
+| `false` (default) | Return immediately. |
+| `true` | Wait for the write to become searchable. |
+| `wait_for` | Wait for the write to become searchable. |
+
+```bash
+curl -X POST "https://<region>.es.topk.io/books/_bulk?refresh=wait_for" ...
+```
+
+#### Query DSL
+
+The following query clauses are supported inside `query`:
+
+| Clause | Notes |
+| --- | --- |
+| `match_all` | Matches every document. Accepts `boost`. |
+| `match` | Full-text match. Accepts `query`, `operator` (`or` / `and`), `boost`. |
+| `multi_match` | Match across several fields. |
+| `term` | Exact term match. |
+| `terms` | Match any of a list of terms. |
+| `ids` | Match documents by `_id`. |
+| `prefix` | Prefix match on a string field. |
+| `regexp` | Regular expression match. |
+| `range` | `gt`, `gte`, `lt`, `lte` bounds. |
+| `exists` | Field is present and non-null. |
+| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`, `minimum_should_match`. |
+| `semantic` | **TopK extension.** Managed semantic search — see below. |
+
+#### Search body
+
+| Field | Description |
+| --- | --- |
+| `query` | Query DSL clause. |
+| `size` | Number of hits to return. Defaults to `10`. |
+| `from` | Offset. `from + size` must be 10,000 or less. |
+| `sort` | Sort by field, or by the `_score` pseudo-field. At most 8 sort fields. |
+| `knn` | Vector search. One clause or an array of clauses. |
+| `rank` | Reciprocal rank fusion across result sets. |
+| `track_scores` | Return scores even when sorting by a field. |
+| `aggs` | Aggregations (alias: `aggregations`). |
+| `_source` | Field filtering. Also accepted as a query parameter, which takes precedence. |
+
+##### Vector search
+
+`knn` takes `field`, `query_vector`, and `k`, plus optional `filter`, `num_candidates`,
+`boost`, and `similarity`.
+
+```json
+POST /books/_search
+{
+  "knn": {
+    "field": "embedding",
+    "query_vector": [0.12, 0.87, 0.05, 0.44],
+    "k": 10,
+    "filter": [{ "term": { "in_print": true } }]
+  }
+}
+```
+
+##### Hybrid search
+
+Pass `knn` and `query` together with a `rank` clause to fuse the two result sets with
+reciprocal rank fusion. `rank_constant` defaults to `60`.
+
+```json
+POST /books/_search
+{
+  "query": { "match": { "body": "cats" } },
+  "knn": {
+    "field": "embedding",
+    "query_vector": [1.0, 0.0, 0.0, 0.0],
+    "k": 10
+  },
+  "rank": { "rrf": { "rank_constant": 60, "rank_window_size": 100 } }
+}
+```
+
+Without a `rank` clause, scores from `query` and `knn` are summed.
+
+##### Semantic search
+
+`semantic` is a TopK extension to the Elasticsearch DSL. Point it at a `semantic_text`
+field and TopK runs embedding and retrieval for you — there is no inference pipeline to
+configure.
+
+```json
+POST /articles/_search
+{
+  "query": { "semantic": { "field": "content", "query": "cats" } },
+  "size": 10
+}
+```
+
+#### Aggregations
+
+| Aggregation | Type |
+| --- | --- |
+| `terms` | Bucket. Accepts `field` and `size`, and supports sub-aggregations. |
+| `sum` | Metric. |
+| `avg` | Metric. |
+| `min` | Metric. |
+| `max` | Metric. |
+| `value_count` | Metric. |
+
+```json
+POST /books/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_author": {
+      "terms": { "field": "author", "size": 10 },
+      "aggs": { "avg_rating": { "avg": { "field": "rating" } } }
+    }
+  }
+}
+```
+
+#### Mapping types
+
+| Type | Aliases | Options |
+| --- | --- | --- |
+| `text` | | `index`, `fields` |
+| `keyword` | | `index`, `fields`, `ignore_above` |
+| `integer` | `long`, `short`, `byte` | `index` |
+| `float` | `double`, `half_float` | `index` |
+| `boolean` | | `index` |
+| `object` | `nested` | `properties` |
+| `dense_vector` | | `dims`, `similarity`, `element_type`, `index` |
+| `rank_vectors` | `matrix` | `dims`, `element_type`, `quantization`, `top_k`, `width` |
+| `semantic_text` | | — |
+
+`dense_vector` accepts `similarity` of `cosine`, `dot_product`, or `l2_norm`, and
+`element_type` of `float` (default), `byte`, or `bit`. For `element_type: "bit"`, `dims`
+must be a multiple of 8 and `similarity` must be `l2_norm` or omitted.
+
+`rank_vectors` maps to TopK multi-vector retrieval. It accepts `element_type` of `float`
+(default) or `byte`, and `quantization` of `scalar`, `binary_1bit`, or `binary_2bit`.
+
+#### Differences from Elasticsearch
+
+Read this section before migrating an existing index.
+
+<Warning>
+
+**`nested` is treated as `object`.** A `nested` mapping is accepted rather than rejected,
+but the field is indexed as a plain object. Queries that rely on nested document
+semantics will return different results instead of an error.
+
+</Warning>
+
+**`hits.total` is a lower bound on hybrid searches.** A search served by a single
+retriever — keyword-only or vector-only — reports `"relation": "eq"` with an exact count. A
+search combining retrievers (for example `query` plus `knn`) reports `"relation": "gte"`,
+and the value is a floor rather than a total. Check `relation` before displaying a count.
+Elasticsearch has the same field with the same meaning but flips to `gte` under different
+conditions, so code that assumed `eq` can start under-reporting after a migration.
+
+**Deleting a missing document succeeds.** `DELETE /<index>/_doc/<id>` returns `200` with
+`"result": "deleted"` whether or not the document existed. Elasticsearch returns `404` with
+`"result": "not_found"`, so code that branches on that will not see the missing case.
+
+**There is no `date` mapping type.** TopK supports timestamps through its other APIs, but
+the Elasticsearch layer has no date mapping. Map date fields as `keyword` (for exact
+matching and terms aggregations) or `integer` (for range queries on epoch values).
+
+**Scores are `null` when sorting by a field.** Matching Elasticsearch behaviour, set
+`track_scores: true` to compute scores anyway. Sorting on the `_score` pseudo-field also
+keeps them.
+
+#### Errors
+
+Handled errors use the Elasticsearch envelope, so client libraries surface them as they
+normally would — `error.type`, `error.reason`, `error.root_cause`, and a top-level `status`.
+
+```json
+{
+  "error": {
+    "root_cause": [{ "type": "index_not_found_exception", "reason": "..." }],
+    "type": "index_not_found_exception",
+    "reason": "..."
+  },
+  "status": 404
+}
+```
+
+| Status | `error.type` | Cause |
+| --- | --- | --- |
+| `400` | `parsing_exception` | The query body could not be parsed. |
+| `400` | `illegal_argument_exception` | A supported field was given an unsupported value. |
+| `400` | `action_request_validation_exception` | The request was structurally invalid — for example an unknown mapping type. |
+| `400` | `invalid_index_name_exception` | Index name violates the naming rules. |
+| `400` | `invalid_document_id_exception` | Document id is empty or over 512 bytes. |
+| `400` | `resource_already_exists_exception` | The index already exists. |
+| `400` | `json_parse_exception` | The body was not valid JSON, or contained an unknown field. |
+| `400` | `no_handler_found_exception` | No handler matches that route. |
+| `404` | `index_not_found_exception` | The index does not exist. |
+| `404` | `not_found` | The document does not exist. |
+| `404` | `resource_not_found_exception` | The document was not found when reading `_source`. |
+| `406` | `media_type_header_exception` | Unsupported `Content-Type` or `Accept`. |
+| `410` | `api_not_available_exception` | A real Elasticsearch API that is not available in serverless mode, such as `/_cluster/health`. |
+| `500` | `internal_server_error` | Unexpected server error. |
+
+Two responses do **not** use this envelope:
+
+- A **request to an unrouted path** returns `400` with a bare
+  `{"error": "no handler found for uri [...] and method [...]"}` — no `type`, `root_cause`,
+  or `status` field.
+- A **`GET` for a missing document** returns `404` with the normal document shape,
+  `{"_index": ..., "_id": ..., "found": false}`, rather than an error.
+
+Pass `ignore_unavailable=true` to turn a missing index into an empty result instead of a
+`404`.
+
+##### Not supported
+
+Nothing here is silently ignored. Unsupported fields in a search body are rejected with
+`400 json_parse_exception`, which lists the fields that are accepted; unrouted endpoints
+return `400` with the bare `no handler found for uri` body:
+
+- Scroll and point-in-time search
+- `_update_by_query` and `_delete_by_query`
+- Highlighting and suggesters
+- `collapse` and `script_fields`
+- `date_histogram` and other bucket aggregations beyond `terms`
+
+#### Limits
+
+| Limit | Value |
+| --- | --- |
+| `from + size` | 10,000 |
+| Sort fields per search | 8 |
+| Index name length | 255 characters |
+| Document id length | 512 bytes |
+
+For collection-level limits, see [docs.topk.io/limits](https://docs.topk.io/limits).
 
 ## Rust SDK
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -4801,7 +4801,437 @@ Let's break down the example above:
 2. Then, the `topk()` function gives 80% weight to content score and 20% weight to document importance.
 3. Sorting by a custom scoring function allows us to boost more critical documents, ensuring that highly relevant but less "important" content doesn't dominate.
 
-## Python SDK Reference
+## CLI
+
+### CLI
+
+URL: https://docs.topk.io/cli
+
+Command-line interface for [TopK](https://topk.io).
+
+#### Installation
+
+```bash
+brew tap topk-io/topk
+brew install topk
+```
+
+#### Quick start
+
+```bash
+topk login
+topk import ./books.parquet --region aws-us-east-1-elastica
+topk import postgres://user:pw@host/db 'public.*' --region aws-us-east-1-elastica
+```
+
+> [!NOTE]
+> `topk import` discovers a schema, shows the plan, and imports on confirmation — see [import](#import).
+
+#### Authentication
+
+To authenticate, run:
+
+```bash
+topk login
+```
+
+Alternatively, you can set `TOPK_API_KEY` environment variable and skip the `topk login` command.
+
+```bash
+export TOPK_API_KEY=<your-api-key>
+```
+
+#### Commands
+
+##### login
+
+To authenticate, run:
+
+```bash
+topk login
+```
+
+Alternatively, you can set `TOPK_API_KEY` environment variable and skip the `topk login` command.
+
+```bash
+export TOPK_API_KEY=<your-api-key>
+```
+
+##### logout
+
+Remove saved credentials:
+
+```bash
+topk logout
+```
+
+##### import
+
+Bulk import into TopK collections. Every run prints the plan as a TOML spec and asks before writing; collections are created right after.
+
+###### Import a database
+
+```bash
+topk import postgres://user:pw@host/db 'public.*'
+topk import mysql://root@host/shop orders
+topk import mongodb://host/shop products
+topk import es+https://user:pw@es.example.com 'products*'
+topk import postgres://host/db orders --filter "created_at > '2024-01-01'"
+```
+
+Objects are exact names, globs, or `<object>=<collection>` renames.
+
+###### Import files
+
+```bash
+topk import ./books.parquet                                   # .csv .tsv .json(l) .arrow .avro
+topk import 's3://bucket/books/*.parquet' --to books          # a glob needs --to
+topk import gs://bucket/books.csv                             # az:// hf:// http(s):// too
+```
+
+A single file names its collection.
+
+###### Copy a TopK collection
+
+```bash
+topk import topk://aws-us-east-1-elastica/books --to books-v2                        # reindex under a new schema
+topk import topk://aws-us-east-1-elastica/books --region aws-eu-central-1-monstera   # copy us → eu
+```
+
+Schema and indexes copy as-is; the copy is additive.
+
+###### Preview and edit the plan
+
+```bash
+topk import postgres://host/db orders --dry-run > spec.toml   # spec on stdout, sample documents on stderr
+vim spec.toml                                                 # drop columns, fix types, add indexes
+topk import "$DB_URL" -f spec.toml --yes                      # run
+```
+
+> [!WARNING]
+> Keep credentials on the command line or in the environment, never in the spec — the spec is meant to go in git.
+
+###### Resume a stopped run
+
+Stop a run — `^C`, a lost connection — and pick it up where it left off:
+
+```bash
+topk import postgres://host/db --resume 01J9...               # run id printed at start
+```
+
+Resume skips finished collections and continues the in-flight one from a checkpoint. Without `--resume`, a re-run re-imports everything — upserts are idempotent.
+
+###### Sources
+
+| source | url | filter | auth |
+| --- | --- | --- | --- |
+| postgres | `postgres://` | SQL `WHERE` | in-URL, `PGPASSWORD` |
+| mysql | `mysql://` | SQL `WHERE` | in-URL, `MYSQL_PWD` |
+| sqlite | `sqlite:<path>` | SQL `WHERE` | — |
+| files | path, glob, `s3://` `r2://` `gs://` `az://` `hf://` `http(s)://` | SQL `WHERE` | credential chain; `hf auth login`; http anonymous |
+| elasticsearch | `es://` `es+https://`, `*.cloud.es.io` | query DSL | in-URL, `ELASTIC_API_KEY` / `ELASTIC_PASSWORD` |
+| mongodb | `mongodb://` | find document | in-URL, `MONGODB_URI` |
+| topk | `topk://[<key>@]<region>/<collection>` | — | URL key, else the run's key |
+
+###### Spec
+
+One TOML table per collection — `from`, `id`, `filter`/`partition`/`limit` as the flags, and a `fields` whitelist (only declared fields import):
+
+```toml
+[books]
+from = "public.books"
+id = "sku"
+
+[books.fields]
+title = { type = "text", index = "semantic" }
+year = { type = "int", from = "published_year" }
+embedding = { type = "f32_vector", dim = 768, index = { vector = { metric = "cosine" } } }
+```
+
+| field key | |
+| --- | --- |
+| `type` | `text` `int` `float` `bool` `bytes` `timestamp` `struct` `*_list` `*_vector` `*_matrix` `*_sparse_vector` |
+| `from` | source column, when the name differs |
+| `required` | fail the document if missing |
+| `truncate` | max chars, text only |
+| `dim` / `cols` | vector dimension / matrix row width |
+| `index` | `"keyword"` `"exact"` `"semantic"` `"ngram"` `{ vector = { metric = "cosine" \| "euclidean" \| "dot_product" \| "hamming" } }` `{ multi_vector = {} }` |
+
+Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); a sparse vector reads numeric keys or parallel `indices`/`values` lists; epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
+
+###### Failures and limits
+
+A document fails when a value does not convert exactly, its id is missing or empty, or it is over 200 KB. A failure stops the run, ready to `--resume`; `--continue-on-error` skips them instead.
+
+- there is no schema migration: an existing collection whose schema differs is rejected
+- an upsert replaces the whole document, so a spec that omits an existing field clears it
+
+#### Global flags
+
+These flags are accepted by every command:
+
+##### `--output`
+
+Options:
+
+* `text` (default)
+* `json`
+
+Output results as NDJSON — one JSON object per line, compatible with `jq`.
+
+##### `--api-key`
+
+API key to use for this invocation. Overrides the `TOPK_API_KEY` environment variable and the key saved via `topk login`.
+
+##### `--region`
+
+Region to connect to (env `TOPK_REGION`); required by `import`. See https://docs.topk.io/regions.
+
+#### Updating the CLI
+
+To update CLI to the latest version, run:
+
+```bash
+brew update
+brew upgrade topk
+```
+
+## Python SDK
+
+### Python SDK
+
+URL: https://docs.topk.io/sdk/topk-py/overview
+
+[![PyPI version](https://img.shields.io/pypi/v/topk-sdk.svg)](https://pypi.org/project/topk-sdk/)
+
+The TopK Python library provides convenient access to the TopK API from any Python 3.9+ application. The library includes type definitions for all request params and response fields, and features both synchronous and asynchronous clients.
+#### Installation
+
+```sh
+pip install topk-sdk
+
+### or
+
+uv add topk-sdk
+```
+
+#### Prerequisites
+
+- **API key** — sign in to [console.topk.io](https://console.topk.io) and generate an API key.
+- **Region** — available regions are listed at [docs.topk.io/regions](https://docs.topk.io/regions).
+
+#### Usage
+
+##### Hybrid Search
+
+```python
+import os
+from topk_sdk import Client
+from topk_sdk.schema import text, keyword_index, semantic_index
+from topk_sdk.query import select, field, fn
+
+client = Client(
+    api_key=os.environ["TOPK_API_KEY"],
+    region="aws-us-east-1-elastica",
+)
+
+### Create a collection
+client.collections().create(
+    "books",
+    schema={
+        "title": text().required().index(keyword_index()),
+        "content": text().index(semantic_index()),
+    },
+)
+
+### Upsert documents
+client.collection("books").upsert([
+    {
+        "_id": "1",
+        "title": "Catcher in the Rye",
+        "content": "IF YOU REALLY WANT TO HEAR about it, the first thing you'll probably want to know is ...",
+        "author": "J.D. Salinger",
+        "rating": 3.8,
+    },
+    {
+        "_id": "2",
+        "title": "1984",
+        "content": "It was a bright cold day in April, and the clocks were striking thirteen. Winston Smith, ...",
+        "author": "George Orwell",
+        "rating": 4.7,
+    },
+])
+
+### Query with hybrid search
+results = client.collection("books").query(
+    select(
+        # Select document fields to return
+        "_id", "title", "author",
+        # Compute semantic similarity of content field with the query
+        similarity_score=fn.semantic_similarity(
+            "content",
+            "What is the meaning of life?",
+        ),
+    )
+    # Filter documents by metadata
+    .filter(field("rating") >= 3.0)
+    # Rank using the computed similarity score and rating
+    .sort(field("rating") * field("similarity_score"), asc=False)
+    # Get top 10 highest ranked documents
+    .limit(10)
+)
+```
+
+##### Vector Search
+
+```python
+import os
+from topk_sdk import Client
+from topk_sdk.schema import text, f32_vector, vector_index
+from topk_sdk.query import select, field, fn
+
+client = Client(
+    api_key=os.environ["TOPK_API_KEY"],
+    region="aws-us-east-1-elastica",
+)
+
+### Create a collection with a vector field (dimension must match your embedding model's output size)
+client.collections().create(
+    "books",
+    schema={
+        "title": text().required(),
+        "embedding": f32_vector(dimension=1536).required().index(vector_index(metric="dot_product")),
+    },
+)
+
+### Upsert documents with embeddings
+client.collection("books").upsert([
+    {"_id": "1", "title": "Catcher in the Rye", "embedding": [0.1, 0.2, ...]},
+    {"_id": "2", "title": "1984",               "embedding": [0.9, 0.8, ...]},
+])
+
+### Query the nearest neighbors to a query vector
+results = client.collection("books").query(
+    select(
+        "_id", "title",
+        distance=fn.vector_distance("embedding", [0.8, 0.9, ...]),
+    )
+    # Return the 10 closest documents (ascending = closest first)
+    .sort(field("distance"), asc=True)
+    .limit(10)
+)
+```
+
+#### Async usage
+
+Simply import `AsyncClient` instead of `Client` and use `async for` / `await` with each API call:
+
+```python
+import os
+import asyncio
+from topk_sdk import AsyncClient
+from topk_sdk.schema import text, keyword_index, semantic_index
+from topk_sdk.query import select, field, fn
+
+client = AsyncClient(
+    api_key=os.environ["TOPK_API_KEY"],
+    region="aws-us-east-1-elastica",
+)
+
+async def main() -> None:
+    # Hybrid search
+    await client.collections().create(
+        "books",
+        schema={
+            "title": text().required().index(keyword_index()),
+            "content": text().index(semantic_index()),
+        },
+    )
+
+    await client.collection("books").upsert([
+        {"_id": "1", "title": "Catcher in the Rye", "content": "...", "rating": 3.8},
+        {"_id": "2", "title": "1984", "content": "...", "rating": 4.7},
+    ])
+
+    results = await client.collection("books").query(
+        select(
+            # Select document fields to return
+            "_id", "title",
+            # Compute semantic similarity of content field with the query
+            similarity_score=fn.semantic_similarity("content", "What is the meaning of life?"),
+        )
+        # Filter documents by metadata
+        .filter(field("rating") >= 3.0)
+        # Rank using the computed similarity score and rating
+        .sort(field("rating") * field("similarity_score"), asc=False)
+        # Get top 10 highest ranked documents
+        .limit(10)
+    )
+
+asyncio.run(main())
+```
+
+#### Handling errors
+
+```python
+from topk_sdk.error import (
+    CollectionNotFoundError,
+    PermissionDeniedError,
+    QuotaExceededError,
+    SlowDownError,
+)
+
+try:
+    client.collections().get("books")
+except CollectionNotFoundError:
+    print("Collection does not exist")
+except PermissionDeniedError:
+    print("Check your API key")
+except QuotaExceededError:
+    print("Usage quota exceeded")
+except SlowDownError:
+    print("Rate limited — the client will retry automatically")
+```
+
+| Error | Description |
+| --- | --- |
+| `CollectionNotFoundError` | Collection does not exist |
+| `PartitionNotFoundError`  | Partition does not exist  |
+| `CollectionAlreadyExistsError` | Collection with this name already exists |
+| `CollectionValidationError` | Invalid collection name or schema |
+| `DocumentValidationError` | Invalid document |
+| `SchemaValidationError` | Invalid schema |
+| `PermissionDeniedError` | Invalid or missing API key |
+| `QuotaExceededError` | Usage quota exceeded |
+| `RequestTooLargeError` | Request payload too large |
+| `SlowDownError` | Rate limited by the server (retried automatically) |
+| `QueryLsnTimeoutError` | Timed out waiting for write consistency |
+
+##### Retries
+
+The client automatically retries on `SlowDownError` and on LSN consistency
+timeouts. Retry behaviour can be configured via `RetryConfig`:
+
+```python
+from topk_sdk import Client, RetryConfig, BackoffConfig
+
+client = Client(
+    api_key=os.environ.get("TOPK_API_KEY"),
+    region="aws-us-east-1-elastica",
+    retry_config=RetryConfig(
+        max_retries=5,        # default: 3
+        timeout=60_000,       # total retry chain timeout in ms, default: 30,000
+        backoff=BackoffConfig(
+            init_backoff=200, # default: 100 ms
+            max_backoff=5_000, # default: 10,000 ms
+        ),
+    ),
+)
+```
+
+#### Requirements
+
+Python 3.9 or higher.
 
 ### topk_sdk
 
@@ -6872,6 +7302,365 @@ Check if the expression matches the provided regexp pattern.
 
 Instances of the `FunctionExpr` class are used to represent function expressions in TopK.
 Usually created using function constructors such as [`fn.vector_distance()`](#vector-distance), [`fn.semantic_similarity()`](#semantic-similarity) or [`fn.bm25_score()`](#bm25-score).
+Comparison and arithmetic operators lift into a [`LogicalExpr`](#logicalexpr), e.g. `fn.bm25_score() > 0.5`.
+
+**Methods**
+
+###### eq()
+
+```python
+eq(self, other: FlexibleExpr) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`FlexibleExpr`](#flexibleexpr) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### ne()
+
+```python
+ne(self, other: FlexibleExpr) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`FlexibleExpr`](#flexibleexpr) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### lt()
+
+```python
+lt(self, other: Ordered) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Ordered`](#ordered) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### lte()
+
+```python
+lte(self, other: Ordered) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Ordered`](#ordered) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### gt()
+
+```python
+gt(self, other: Ordered) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Ordered`](#ordered) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### gte()
+
+```python
+gte(self, other: Ordered) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Ordered`](#ordered) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### add()
+
+```python
+add(self, other: Numeric) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Numeric`](#numeric) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### sub()
+
+```python
+sub(self, other: Numeric) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Numeric`](#numeric) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### mul()
+
+```python
+mul(self, other: Numeric) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Numeric`](#numeric) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### div()
+
+```python
+div(self, other: Numeric) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`Numeric`](#numeric) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### coalesce()
+
+```python
+coalesce(self, other: LogicalExpr | int | float) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`LogicalExpr`](#logicalexpr) &#124; int &#124; float |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### min()
+
+```python
+min(self, other: LogicalExpr | int | float | str) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`LogicalExpr`](#logicalexpr) &#124; int &#124; float &#124; str |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### max()
+
+```python
+max(self, other: LogicalExpr | int | float | str) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `other` | [`LogicalExpr`](#logicalexpr) &#124; int &#124; float &#124; str |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### is\_null()
+
+```python
+is_null(self) -> LogicalExpr
+```
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### is\_not\_null()
+
+```python
+is_not_null(self) -> LogicalExpr
+```
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### abs()
+
+```python
+abs(self) -> LogicalExpr
+```
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### ln()
+
+```python
+ln(self) -> LogicalExpr
+```
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### exp()
+
+```python
+exp(self) -> LogicalExpr
+```
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### sqrt()
+
+```python
+sqrt(self) -> LogicalExpr
+```
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### square()
+
+```python
+square(self) -> LogicalExpr
+```
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### choose()
+
+```python
+choose(self, x: FlexibleExpr, y: FlexibleExpr) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `x` | [`FlexibleExpr`](#flexibleexpr) |
+| `y` | [`FlexibleExpr`](#flexibleexpr) |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
+
+###### boost()
+
+```python
+boost(self, condition: FlexibleExpr, boost: LogicalExpr | int | float) -> LogicalExpr
+```
+
+**Parameters**
+
+| Parameter | Type |
+| --------- | ---- |
+| `condition` | [`FlexibleExpr`](#flexibleexpr) |
+| `boost` | [`LogicalExpr`](#logicalexpr) &#124; int &#124; float |
+
+**Returns**
+
+[`LogicalExpr`](#logicalexpr)
+
+***
 
 ##### AggregateExpr
 
@@ -6907,7 +7696,7 @@ Adds a select stage to the query.
 ###### filter()
 
 ```python
-filter(self, expr: LogicalExpr | TextExpr) -> Query
+filter(self, expr: LogicalExpr | FunctionExpr | TextExpr) -> Query
 ```
 
 Adds a filter stage to the query.
@@ -6916,7 +7705,7 @@ Adds a filter stage to the query.
 
 | Parameter | Type |
 | --------- | ---- |
-| `expr` | [`LogicalExpr`](#logicalexpr) &#124; [`TextExpr`](#textexpr) |
+| `expr` | [`LogicalExpr`](#logicalexpr) &#124; [`FunctionExpr`](#functionexpr) &#124; [`TextExpr`](#textexpr) |
 
 **Returns**
 
@@ -6927,8 +7716,8 @@ Adds a filter stage to the query.
 ###### sort()
 
 ```python
-sort(self, expr: LogicalExpr, asc: bool = True) -> Query
-sort(self, expr: Sequence[tuple[LogicalExpr, Literal['asc', 'desc']]]) -> Query
+sort(self, expr: LogicalExpr | FunctionExpr, asc: bool = True) -> Query
+sort(self, expr: Sequence[tuple[LogicalExpr | FunctionExpr, Literal['asc', 'desc']]]) -> Query
 ```
 
 Adds a sort stage to the query.
@@ -6937,7 +7726,7 @@ Adds a sort stage to the query.
 
 | Parameter | Type |
 | --------- | ---- |
-| `expr` | [`LogicalExpr`](#logicalexpr) &#124; Sequence[tuple[[`LogicalExpr`](#logicalexpr), Literal['asc', 'desc']]] |
+| `expr` | [`LogicalExpr`](#logicalexpr) &#124; [`FunctionExpr`](#functionexpr) &#124; Sequence[tuple[[`LogicalExpr`](#logicalexpr) &#124; [`FunctionExpr`](#functionexpr), Literal['asc', 'desc']]] |
 | `asc` | bool |
 
 **Returns**
@@ -7003,7 +7792,7 @@ Adds a count stage to the query.
 ###### group\_by()
 
 ```python
-group_by(self, keys: dict[str, LogicalExpr], aggs: dict[str, AggregateExpr]) -> Query
+group_by(self, keys: dict[str, LogicalExpr | FunctionExpr], aggs: dict[str, AggregateExpr]) -> Query
 ```
 
 Adds a group-by stage to the query.
@@ -7014,7 +7803,7 @@ Groups documents by one or more key expressions and computes aggregations for ea
 
 | Parameter | Type |
 | --------- | ---- |
-| `keys` | dict[str, [`LogicalExpr`](#logicalexpr)] |
+| `keys` | dict[str, [`LogicalExpr`](#logicalexpr) &#124; [`FunctionExpr`](#functionexpr)] |
 | `aggs` | dict[str, [`AggregateExpr`](#aggregateexpr)] |
 
 **Returns**
@@ -7028,7 +7817,7 @@ Groups documents by one or more key expressions and computes aggregations for ea
 <Warning>**Deprecated** — Use ``.sort(expr, asc).limit(k)`` instead.</Warning>
 
 ```python
-topk(self, expr: LogicalExpr, k: int, asc: bool = False) -> Query
+topk(self, expr: LogicalExpr | FunctionExpr, k: int, asc: bool = False) -> Query
 ```
 
 Adds a top-k stage to the query.
@@ -7037,7 +7826,7 @@ Adds a top-k stage to the query.
 
 | Parameter | Type |
 | --------- | ---- |
-| `expr` | [`LogicalExpr`](#logicalexpr) |
+| `expr` | [`LogicalExpr`](#logicalexpr) &#124; [`FunctionExpr`](#functionexpr) |
 | `k` | int |
 | `asc` | bool |
 
@@ -7389,7 +8178,7 @@ client.collection("books").query(
 ##### filter()
 
 ```python
-filter(expr: LogicalExpr | TextExpr) -> Query
+filter(expr: LogicalExpr | FunctionExpr | TextExpr) -> Query
 ```
 
 Creates a new query with a filter stage.
@@ -7408,7 +8197,7 @@ client.collection("books").query(
 
 | Parameter | Type |
 | --------- | ---- |
-| `expr` | [`LogicalExpr`](#logicalexpr) &#124; [`TextExpr`](#textexpr) |
+| `expr` | [`LogicalExpr`](#logicalexpr) &#124; [`FunctionExpr`](#functionexpr) &#124; [`TextExpr`](#textexpr) |
 
 **Returns**
 
@@ -7419,7 +8208,7 @@ client.collection("books").query(
 ##### group_by()
 
 ```python
-group_by(keys: dict[str, LogicalExpr], aggs: dict[str, AggregateExpr]) -> Query
+group_by(keys: dict[str, LogicalExpr | FunctionExpr], aggs: dict[str, AggregateExpr]) -> Query
 ```
 
 Creates a new query with a group-by stage.
@@ -7442,7 +8231,7 @@ client.collection("books").query(
 
 | Parameter | Type |
 | --------- | ---- |
-| `keys` | dict[str, [`LogicalExpr`](#logicalexpr)] |
+| `keys` | dict[str, [`LogicalExpr`](#logicalexpr) &#124; [`FunctionExpr`](#functionexpr)] |
 | `aggs` | dict[str, [`AggregateExpr`](#aggregateexpr)] |
 
 **Returns**
@@ -8605,7 +9394,172 @@ SchemaFieldSpec = FieldSpec | Mapping[str, 'SchemaFieldSpec']
 
 ***
 
-## JavaScript SDK Reference
+## JavaScript SDK
+
+### JavaScript SDK
+
+URL: https://docs.topk.io/sdk/topk-js/overview
+
+[![npm version](https://img.shields.io/npm/v/topk-js.svg)](https://www.npmjs.com/package/topk-js)
+
+The TopK JavaScript library provides convenient access to the TopK API from Node.js environments with full TypeScript support.
+#### Installation
+
+```sh
+npm install topk-js
+### or
+yarn add topk-js
+### or
+pnpm install topk-js
+```
+
+#### Prerequisites
+
+- **API key** — sign in to [console.topk.io](https://console.topk.io) and generate an API key.
+- **Region** — available regions are listed at [docs.topk.io/regions](https://docs.topk.io/regions).
+
+#### Usage
+
+##### Hybrid Search
+
+```typescript
+import { Client } from "topk-js";
+import { text, keywordIndex, semanticIndex } from "topk-js/schema";
+import { select, field, fn } from "topk-js/query";
+
+const client = new Client({
+  apiKey: process.env.TOPK_API_KEY!,
+  region: "aws-us-east-1-elastica",
+});
+
+// Create a collection
+await client.collections().create("books", {
+  title: text().required().index(keywordIndex()),
+  content: text().index(semanticIndex()),
+});
+
+// Upsert documents
+await client.collection("books").upsert([
+  {
+    _id: "1",
+    title: "Catcher in the Rye",
+    content: "IF YOU REALLY WANT TO HEAR about it, the first thing you'll probably want to know is ...",
+    author: "J.D. Salinger",
+    rating: 3.8,
+  },
+  {
+    _id: "2",
+    title: "1984",
+    content: "It was a bright cold day in April, and the clocks were striking thirteen. Winston Smith, ...",
+    author: "George Orwell",
+    rating: 4.7,
+  },
+]);
+
+// Query with hybrid search
+const results = await client.collection("books").query(
+  select({
+    title: field("title"),
+    author: field("author"),
+    // Compute semantic similarity of content field with the query
+    similarity_score: fn.semanticSimilarity(
+      "content",
+      "What is the meaning of life?",
+    ),
+  })
+  // Filter documents by metadata
+  .filter(field("rating").gte(3.0))
+  // Rank using the computed similarity score and rating
+  .sort(field("rating").mul(field("similarity_score")), false)
+  // Get top 10 highest ranked documents
+  .limit(10)
+);
+```
+
+##### Vector Search
+
+```typescript
+import { Client } from "topk-js";
+import { text, f32Vector, vectorIndex } from "topk-js/schema";
+import { select, field, fn } from "topk-js/query";
+
+const client = new Client({
+  apiKey: process.env.TOPK_API_KEY!,
+  region: "aws-us-east-1-elastica",
+});
+
+// Create a collection with a vector field (dimension must match your embedding model's output size)
+await client.collections().create("books", {
+  title: text().required(),
+  embedding: f32Vector({ dimension: 1536 }).required().index(vectorIndex({ metric: "dot_product" })),
+});
+
+// Upsert documents with embeddings
+await client.collection("books").upsert([
+  { _id: "1", title: "Catcher in the Rye", embedding: [0.1, 0.2, ...] },
+  { _id: "2", title: "1984",               embedding: [0.9, 0.8, ...] },
+]);
+
+// Query the nearest neighbors to a query vector
+const results = await client.collection("books").query(
+  select({
+    title: field("title"),
+    distance: fn.vectorDistance("embedding", [0.8, 0.9, ...]),
+  })
+  // Return the 10 closest documents (ascending = closest first)
+  .sort(field("distance"), true)
+  .limit(10)
+);
+```
+
+#### Handling errors
+
+The SDK throws plain `Error` objects. Check `err.message` to identify the error:
+
+```typescript
+try {
+  await client.collections().get("books");
+} catch (err) {
+  if (err instanceof Error) {
+    if (err.message === "collection not found") console.error("Collection does not exist");
+    else if (err.message === "permission denied") console.error("Check your API key");
+    else console.error("Unexpected error:", err.message);
+  }
+}
+```
+
+| `err.message` | Description |
+| --- | --- |
+| `"collection not found"` | Collection does not exist |
+| `"collection already exists"` | Collection with this name already exists |
+| `"permission denied"` | Invalid or missing API key |
+| starts with `"request too large:"` | Request payload too large |
+
+##### Retries
+
+The client automatically retries on slow-down and LSN consistency
+timeouts. Retry behaviour can be configured via `retryConfig`:
+
+```typescript
+import { Client } from "topk-js";
+
+const client = new Client({
+  apiKey: process.env.TOPK_API_KEY,
+  region: "aws-us-east-1-elastica",
+  retryConfig: {
+    maxRetries: 5,       // default: 3
+    timeout: 60_000,     // total retry chain timeout in ms, default: 30,000
+    backoff: {
+      initBackoff: 200,  // default: 100 ms
+      maxBackoff: 5_000, // default: 10,000 ms
+    },
+  },
+});
+```
+
+#### Requirements
+
+Node.js 18 or higher.
 
 ### topk-js
 
@@ -10034,6 +10988,7 @@ Creates a field reference expression.
 ```ts
 function filter(expr:
   | LogicalExpression
+  | FunctionExpression
   | TextExpression): Query;
 ```
 
@@ -10043,7 +10998,7 @@ Creates a new query with a filter stage.
 
 | Parameter | Type |
 | ------ | ------ |
-| `expr` | \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`TextExpression`](/sdk/topk-js/Namespace.query#textexpression) |
+| `expr` | \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`FunctionExpression`](/sdk/topk-js/Namespace.query#functionexpression) \| [`TextExpression`](/sdk/topk-js/Namespace.query#textexpression) |
 
 **Returns**
 
@@ -10297,6 +11252,368 @@ documents that also match `lord`.
 ##### FunctionExpression
 
 **`Internal`**
+
+**Methods**
+
+###### abs()
+
+```ts
+abs(): LogicalExpression;
+```
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### add()
+
+```ts
+add(other:
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### boost()
+
+```ts
+boost(condition:
+  | boolean
+  | LogicalExpression, boost:
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `condition` | \| `boolean` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+| `boost` | \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### choose()
+
+```ts
+choose(x:
+  | string
+  | number
+  | boolean
+  | LogicalExpression, y:
+  | string
+  | number
+  | boolean
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `x` | \| `string` \| `number` \| `boolean` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+| `y` | \| `string` \| `number` \| `boolean` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### coalesce()
+
+```ts
+coalesce(other:
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### div()
+
+```ts
+div(other:
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### eq()
+
+```ts
+eq(other:
+  | string
+  | number
+  | boolean
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| `boolean` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### exp()
+
+```ts
+exp(): LogicalExpression;
+```
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### gt()
+
+```ts
+gt(other:
+  | string
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### gte()
+
+```ts
+gte(other:
+  | string
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### isNotNull()
+
+```ts
+isNotNull(): LogicalExpression;
+```
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### isNull()
+
+```ts
+isNull(): LogicalExpression;
+```
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### ln()
+
+```ts
+ln(): LogicalExpression;
+```
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### lt()
+
+```ts
+lt(other:
+  | string
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### lte()
+
+```ts
+lte(other:
+  | string
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### max()
+
+```ts
+max(other:
+  | string
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### min()
+
+```ts
+min(other:
+  | string
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### mul()
+
+```ts
+mul(other:
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### ne()
+
+```ts
+ne(other:
+  | string
+  | number
+  | boolean
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `string` \| `number` \| `boolean` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### sqrt()
+
+```ts
+sqrt(): LogicalExpression;
+```
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### square()
+
+```ts
+square(): LogicalExpression;
+```
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
+
+###### sub()
+
+```ts
+sub(other:
+  | number
+  | LogicalExpression): LogicalExpression;
+```
+
+**Parameters**
+
+| Parameter | Type |
+| ------ | ------ |
+| `other` | \| `number` \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+
+**Returns**
+
+[`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)
 
 ***
 
@@ -10979,6 +12296,7 @@ Adds a count stage to the query.
 ```ts
 filter(expr:
   | LogicalExpression
+  | FunctionExpression
   | TextExpression): Query;
 ```
 
@@ -10988,7 +12306,7 @@ Adds a filter stage to the query.
 
 | Parameter | Type |
 | ------ | ------ |
-| `expr` | \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`TextExpression`](/sdk/topk-js/Namespace.query#textexpression) |
+| `expr` | \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`FunctionExpression`](/sdk/topk-js/Namespace.query#functionexpression) \| [`TextExpression`](/sdk/topk-js/Namespace.query#textexpression) |
 
 **Returns**
 
@@ -10997,7 +12315,9 @@ Adds a filter stage to the query.
 ###### groupBy()
 
 ```ts
-groupBy(keys: Record<string, LogicalExpression>, aggs: Record<string, AggregateExpression>): Query;
+groupBy(keys: Record<string,
+  | LogicalExpression
+  | FunctionExpression>, aggs: Record<string, AggregateExpression>): Query;
 ```
 
 Adds a group-by stage to the query.
@@ -11008,7 +12328,7 @@ Groups documents by one or more key expressions and computes aggregations for ea
 
 | Parameter | Type |
 | ------ | ------ |
-| `keys` | `Record`\<`string`, [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression)\> |
+| `keys` | `Record`\<`string`, \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`FunctionExpression`](/sdk/topk-js/Namespace.query#functionexpression)\> |
 | `aggs` | `Record`\<`string`, [`AggregateExpression`](/sdk/topk-js/Namespace.query#aggregateexpression)\> |
 
 **Returns**
@@ -11076,7 +12396,9 @@ Adds a select stage to the query.
 ###### Call Signature
 
 ```ts
-sort(expr: LogicalExpression, asc?: boolean): Query;
+sort(expr:
+  | LogicalExpression
+  | FunctionExpression, asc?: boolean): Query;
 ```
 
 Adds a sort stage to the query.
@@ -11085,7 +12407,7 @@ Adds a sort stage to the query.
 
 | Parameter | Type |
 | ------ | ------ |
-| `expr` | [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+| `expr` | \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`FunctionExpression`](/sdk/topk-js/Namespace.query#functionexpression) |
 | `asc?` | `boolean` |
 
 **Returns**
@@ -11114,7 +12436,9 @@ Adds a sort stage to the query.
 
 ```ts
 topk(
-   expr: LogicalExpression,
+   expr:
+  | LogicalExpression
+  | FunctionExpression,
    k: number,
    asc?: boolean): Query;
 ```
@@ -11125,7 +12449,7 @@ Adds a top-k stage to the query.
 
 | Parameter | Type |
 | ------ | ------ |
-| `expr` | [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) |
+| `expr` | \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`FunctionExpression`](/sdk/topk-js/Namespace.query#functionexpression) |
 | `k` | `number` |
 | `asc?` | `boolean` |
 
@@ -11257,7 +12581,7 @@ An expression to sort by with its sort order.
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="property-expr"></a> `expr` | [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) | The expression to sort by. |
+| <a id="property-expr"></a> `expr` | \| [`LogicalExpression`](/sdk/topk-js/Namespace.query#logicalexpression) \| [`FunctionExpression`](/sdk/topk-js/Namespace.query#functionexpression) | The expression to sort by. |
 | <a id="property-order"></a> `order` | [`SortOrder`](/sdk/topk-js/Namespace.query#sortorder) | Sort order. |
 
 ***
@@ -12926,3 +14250,11 @@ only affect the wire type.
 | plain column (no cast) | 114 `JSON` |
 | search function (no cast) | 700 `FLOAT4` |
 | `COUNT(*)` (no cast) | 20 `INT8` |
+
+## Rust SDK
+
+### Rust SDK
+
+Get started with TopK using Rust SDK.
+
+URL: https://github.com/topk-io/topk/tree/main/topk-rs

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,16 +30,22 @@
 - [Keyword search (BM25)](https://docs.topk.io/guides/keyword-search): Full-text keyword search using the BM25 ranking function for term-frequency-based document retrieval.
 - [True Hybrid search](https://docs.topk.io/guides/true-hybrid-search): Combine vector, multi-vector, keyword search, and metadata filtering in a single query for best-of-all-worlds retrieval.
 
-## Python SDK Reference
+## CLI
 
+- [CLI](https://docs.topk.io/cli): The command-line interface for TopK.
+
+## Python SDK
+
+- [Python SDK](https://docs.topk.io/sdk/topk-py/overview): Get started with TopK using Python SDK.
 - [topk_sdk](https://docs.topk.io/sdk/topk-py)
 - [topk_sdk.data](https://docs.topk.io/sdk/topk-py/data)
 - [topk_sdk.error](https://docs.topk.io/sdk/topk-py/error)
 - [topk_sdk.query](https://docs.topk.io/sdk/topk-py/query)
 - [topk_sdk.schema](https://docs.topk.io/sdk/topk-py/schema)
 
-## JavaScript SDK Reference
+## JavaScript SDK
 
+- [JavaScript SDK](https://docs.topk.io/sdk/topk-js/overview): Get started with TopK using JavaScript SDK.
 - [topk-js](https://docs.topk.io/sdk/topk-js)
 - [topk-js/data](https://docs.topk.io/sdk/topk-js/Namespace.data)
 - [topk-js/query_fn](https://docs.topk.io/sdk/topk-js/Namespace.query_fn)
@@ -50,3 +56,7 @@
 ## SQL
 
 - [Overview](https://docs.topk.io/sdk/topk-sql/overview): Connect any PostgreSQL client to TopK and use SQL to create collections, insert data, and run search.
+
+## Rust SDK
+
+- [Rust SDK](https://github.com/topk-io/topk/tree/main/topk-rs): Get started with TopK using Rust SDK.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -57,6 +57,10 @@
 
 - [Overview](https://docs.topk.io/sdk/topk-sql/overview): Connect any PostgreSQL client to TopK and use SQL to create collections, insert data, and run search.
 
+## Elasticsearch
+
+- [Elasticsearch API](https://docs.topk.io/sdk/topk-es/overview): Point any Elasticsearch client at TopK and keep your existing queries, mappings, and tooling.
+
 ## Rust SDK
 
 - [Rust SDK](https://github.com/topk-io/topk/tree/main/topk-rs): Get started with TopK using Rust SDK.

--- a/docs/regions.mdx
+++ b/docs/regions.mdx
@@ -17,6 +17,20 @@ Currently available public regions:
 | AWS | eu-central-1 | 🇪🇺 Frankfurt | `aws-eu-central-1-monstera` |
 | GCP | us-east4 | 🇺🇸 N. Virginia | `gcp-us-east4-aloe` |
 
+## Endpoints
+
+Each API is reached at a hostname built from your region name:
+
+| API | Hostname | Example |
+|-----|----------|---------|
+| Collection and Management API | `<region>.api.topk.io` | `aws-us-east-1-elastica.api.topk.io` |
+| [SQL](/sdk/topk-sql/overview) | `<region>.sql.topk.io` | `aws-us-east-1-elastica.sql.topk.io` |
+| [Elasticsearch](/sdk/topk-es/overview) | `<region>.es.topk.io` | `aws-us-east-1-elastica.es.topk.io` |
+
+The SDKs and the CLI build the Collection API hostname for you — pass the region name and
+they handle the rest. The SQL and Elasticsearch endpoints are addressed directly by their
+hostname.
+
 <Info>
   To deploy TopK in your own VPC, please [contact us](https://topk.io/contact).
 </Info>

--- a/docs/sdk/topk-es/overview.mdx
+++ b/docs/sdk/topk-es/overview.mdx
@@ -63,7 +63,7 @@ PUT /books
       "published_year": { "type": "integer" },
       "rating":         { "type": "float" },
       "in_print":       { "type": "boolean" },
-      "embedding":      { "type": "dense_vector", "dims": 16, "similarity": "cosine" }
+      "embedding":      { "type": "dense_vector", "dims": 4, "similarity": "cosine" }
     }
   }
 }
@@ -74,9 +74,9 @@ Index documents:
 ```json
 POST /books/_bulk
 { "index": { "_id": "mockingbird" } }
-{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true }
+{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true, "embedding": [1.0, 0.0, 0.0, 0.0] }
 { "index": { "_id": "gatsby" } }
-{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true }
+{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true, "embedding": [0.9, 0.1, 0.0, 0.0] }
 ```
 
 Search:
@@ -152,7 +152,7 @@ The following query clauses are supported inside `query`:
 | `regexp` | Regular expression match. |
 | `range` | `gt`, `gte`, `lt`, `lte` bounds. |
 | `exists` | Field is present and non-null. |
-| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`, `minimum_should_match`. |
+| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`. Accepts `boost`. |
 | `semantic` | **TopK extension.** Managed semantic search — see below. |
 
 ## Search body
@@ -179,7 +179,7 @@ POST /books/_search
 {
   "knn": {
     "field": "embedding",
-    "query_vector": [0.12, 0.87, 0.05, 0.44],
+    "query_vector": [1.0, 0.0, 0.0, 0.0],
     "k": 10,
     "filter": [{ "term": { "in_print": true } }]
   }
@@ -194,7 +194,7 @@ reciprocal rank fusion. `rank_constant` defaults to `60`.
 ```json
 POST /books/_search
 {
-  "query": { "match": { "body": "cats" } },
+  "query": { "match": { "title": "mockingbird" } },
   "knn": {
     "field": "embedding",
     "query_vector": [1.0, 0.0, 0.0, 0.0],

--- a/docs/sdk/topk-es/overview.mdx
+++ b/docs/sdk/topk-es/overview.mdx
@@ -1,0 +1,364 @@
+---
+title: "Elasticsearch API"
+description: "Point any Elasticsearch client at TopK and keep your existing queries, mappings, and tooling."
+---
+
+TopK exposes an Elasticsearch-compatible HTTP endpoint. Official Elasticsearch clients
+connect to it unchanged — same URLs, same request bodies, same response shapes — so you can
+move an existing application to TopK without rewriting your query layer.
+## Prerequisites
+
+- **API key** — sign in to [console.topk.io](https://console.topk.io) and generate an API key.
+- **Region** — see [docs.topk.io/regions](https://docs.topk.io/regions) for available regions.
+
+## Setup
+
+The endpoint is `https://<region>.es.<host>`, where `<host>` is `topk.io`:
+
+```
+https://<region>.es.topk.io
+```
+
+Authenticate with your TopK API key as an Elasticsearch API key. Replace `<region>` with
+your region name and `<api-key>` with your API key — for example
+`https://aws-us-east-1-elastica.es.topk.io`.
+
+```bash
+curl https://<region>.es.topk.io/books/_search \
+  -H "Authorization: ApiKey <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": { "match": { "title": "mockingbird" } } }'
+```
+
+<Tip>
+
+See [available regions](https://docs.topk.io/regions) and get your [API key](https://console.topk.io/api-key).
+
+</Tip>
+
+Any official Elasticsearch client works. For example, in Python:
+
+```python
+from elasticsearch import Elasticsearch
+
+es = Elasticsearch(
+    "https://<region>.es.topk.io",
+    api_key="<api-key>",
+)
+
+es.search(index="books", body={"query": {"match": {"title": "mockingbird"}}})
+```
+
+## Quick Start
+
+Create an index:
+
+```json
+PUT /books
+{
+  "mappings": {
+    "properties": {
+      "title":          { "type": "text" },
+      "author":         { "type": "keyword" },
+      "published_year": { "type": "integer" },
+      "rating":         { "type": "float" },
+      "in_print":       { "type": "boolean" },
+      "embedding":      { "type": "dense_vector", "dims": 16, "similarity": "cosine" }
+    }
+  }
+}
+```
+
+Index documents:
+
+```json
+POST /books/_bulk
+{ "index": { "_id": "mockingbird" } }
+{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true }
+{ "index": { "_id": "gatsby" } }
+{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true }
+```
+
+Search:
+
+```json
+POST /books/_search
+{
+  "query": {
+    "bool": {
+      "must":   [{ "match": { "title": "mockingbird" } }],
+      "filter": [{ "range": { "published_year": { "gte": 1950 } } }]
+    }
+  },
+  "size": 10
+}
+```
+
+## Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /` | Cluster info. Returns the `x-elastic-product` header official clients expect. |
+| `PUT /<index>` | Create an index with mappings. |
+| `GET /<index>` | Read an index's mappings and settings. |
+| `HEAD /<index>` | Check whether an index exists. |
+| `DELETE /<index>` | Delete an index. |
+| `GET /<index>/_mapping` | Read the mapping for an index. |
+| `POST /<index>/_search` | Search documents. |
+| `POST /_msearch`, `POST /<index>/_msearch` | Run multiple searches in one request. |
+| `POST /<index>/_count` | Count documents matching a query. |
+| `PUT /<index>/_doc/<id>` | Index a single document. Returns `201`. |
+| `GET /<index>/_doc/<id>` | Get a document by id. |
+| `GET /<index>/_source/<id>` | Get just the `_source` of a document. |
+| `DELETE /<index>/_doc/<id>` | Delete a document by id. |
+| `POST /_mget`, `POST /<index>/_mget` | Get multiple documents by id. |
+| `POST /<index>/_bulk` | Bulk `index`, `create`, `update`, and `delete`. |
+| `GET /<index>/_field_caps` | Field capabilities for an index. |
+| `GET /_resolve/index/<expr>` | Resolve index names. |
+| `POST /<index>/_refresh` | Make pending writes searchable. |
+
+Index names must start with a letter or digit and contain only letters, digits, underscores,
+dashes, and dots, up to 255 characters. Document ids must be non-empty and at most 512 bytes.
+
+### Making writes visible
+
+Writes become searchable asynchronously. Either call `POST /<index>/_refresh`, or pass the
+`refresh` query parameter on an index, delete, or bulk request to control when the call
+returns:
+
+| Value | Behaviour |
+| --- | --- |
+| `false` (default) | Return immediately. |
+| `true` | Wait for the write to become searchable. |
+| `wait_for` | Wait for the write to become searchable. |
+
+```bash
+curl -X POST "https://<region>.es.topk.io/books/_bulk?refresh=wait_for" ...
+```
+
+## Query DSL
+
+The following query clauses are supported inside `query`:
+
+| Clause | Notes |
+| --- | --- |
+| `match_all` | Matches every document. Accepts `boost`. |
+| `match` | Full-text match. Accepts `query`, `operator` (`or` / `and`), `boost`. |
+| `multi_match` | Match across several fields. |
+| `term` | Exact term match. |
+| `terms` | Match any of a list of terms. |
+| `ids` | Match documents by `_id`. |
+| `prefix` | Prefix match on a string field. |
+| `regexp` | Regular expression match. |
+| `range` | `gt`, `gte`, `lt`, `lte` bounds. |
+| `exists` | Field is present and non-null. |
+| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`, `minimum_should_match`. |
+| `semantic` | **TopK extension.** Managed semantic search — see below. |
+
+## Search body
+
+| Field | Description |
+| --- | --- |
+| `query` | Query DSL clause. |
+| `size` | Number of hits to return. Defaults to `10`. |
+| `from` | Offset. `from + size` must be 10,000 or less. |
+| `sort` | Sort by field, or by the `_score` pseudo-field. At most 8 sort fields. |
+| `knn` | Vector search. One clause or an array of clauses. |
+| `rank` | Reciprocal rank fusion across result sets. |
+| `track_scores` | Return scores even when sorting by a field. |
+| `aggs` | Aggregations (alias: `aggregations`). |
+| `_source` | Field filtering. Also accepted as a query parameter, which takes precedence. |
+
+### Vector search
+
+`knn` takes `field`, `query_vector`, and `k`, plus optional `filter`, `num_candidates`,
+`boost`, and `similarity`.
+
+```json
+POST /books/_search
+{
+  "knn": {
+    "field": "embedding",
+    "query_vector": [0.12, 0.87, 0.05, 0.44],
+    "k": 10,
+    "filter": [{ "term": { "in_print": true } }]
+  }
+}
+```
+
+### Hybrid search
+
+Pass `knn` and `query` together with a `rank` clause to fuse the two result sets with
+reciprocal rank fusion. `rank_constant` defaults to `60`.
+
+```json
+POST /books/_search
+{
+  "query": { "match": { "body": "cats" } },
+  "knn": {
+    "field": "embedding",
+    "query_vector": [1.0, 0.0, 0.0, 0.0],
+    "k": 10
+  },
+  "rank": { "rrf": { "rank_constant": 60, "rank_window_size": 100 } }
+}
+```
+
+Without a `rank` clause, scores from `query` and `knn` are summed.
+
+### Semantic search
+
+`semantic` is a TopK extension to the Elasticsearch DSL. Point it at a `semantic_text`
+field and TopK runs embedding and retrieval for you — there is no inference pipeline to
+configure.
+
+```json
+POST /articles/_search
+{
+  "query": { "semantic": { "field": "content", "query": "cats" } },
+  "size": 10
+}
+```
+
+## Aggregations
+
+| Aggregation | Type |
+| --- | --- |
+| `terms` | Bucket. Accepts `field` and `size`, and supports sub-aggregations. |
+| `sum` | Metric. |
+| `avg` | Metric. |
+| `min` | Metric. |
+| `max` | Metric. |
+| `value_count` | Metric. |
+
+```json
+POST /books/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_author": {
+      "terms": { "field": "author", "size": 10 },
+      "aggs": { "avg_rating": { "avg": { "field": "rating" } } }
+    }
+  }
+}
+```
+
+## Mapping types
+
+| Type | Aliases | Options |
+| --- | --- | --- |
+| `text` | | `index`, `fields` |
+| `keyword` | | `index`, `fields`, `ignore_above` |
+| `integer` | `long`, `short`, `byte` | `index` |
+| `float` | `double`, `half_float` | `index` |
+| `boolean` | | `index` |
+| `object` | `nested` | `properties` |
+| `dense_vector` | | `dims`, `similarity`, `element_type`, `index` |
+| `rank_vectors` | `matrix` | `dims`, `element_type`, `quantization`, `top_k`, `width` |
+| `semantic_text` | | — |
+
+`dense_vector` accepts `similarity` of `cosine`, `dot_product`, or `l2_norm`, and
+`element_type` of `float` (default), `byte`, or `bit`. For `element_type: "bit"`, `dims`
+must be a multiple of 8 and `similarity` must be `l2_norm` or omitted.
+
+`rank_vectors` maps to TopK multi-vector retrieval. It accepts `element_type` of `float`
+(default) or `byte`, and `quantization` of `scalar`, `binary_1bit`, or `binary_2bit`.
+
+## Differences from Elasticsearch
+
+Read this section before migrating an existing index.
+
+<Warning>
+
+**`nested` is treated as `object`.** A `nested` mapping is accepted rather than rejected,
+but the field is indexed as a plain object. Queries that rely on nested document
+semantics will return different results instead of an error.
+
+</Warning>
+
+**`hits.total` is a lower bound on hybrid searches.** A search served by a single
+retriever — keyword-only or vector-only — reports `"relation": "eq"` with an exact count. A
+search combining retrievers (for example `query` plus `knn`) reports `"relation": "gte"`,
+and the value is a floor rather than a total. Check `relation` before displaying a count.
+Elasticsearch has the same field with the same meaning but flips to `gte` under different
+conditions, so code that assumed `eq` can start under-reporting after a migration.
+
+**Deleting a missing document succeeds.** `DELETE /<index>/_doc/<id>` returns `200` with
+`"result": "deleted"` whether or not the document existed. Elasticsearch returns `404` with
+`"result": "not_found"`, so code that branches on that will not see the missing case.
+
+**There is no `date` mapping type.** TopK supports timestamps through its other APIs, but
+the Elasticsearch layer has no date mapping. Map date fields as `keyword` (for exact
+matching and terms aggregations) or `integer` (for range queries on epoch values).
+
+**Scores are `null` when sorting by a field.** Matching Elasticsearch behaviour, set
+`track_scores: true` to compute scores anyway. Sorting on the `_score` pseudo-field also
+keeps them.
+
+## Errors
+
+Handled errors use the Elasticsearch envelope, so client libraries surface them as they
+normally would — `error.type`, `error.reason`, `error.root_cause`, and a top-level `status`.
+
+```json
+{
+  "error": {
+    "root_cause": [{ "type": "index_not_found_exception", "reason": "..." }],
+    "type": "index_not_found_exception",
+    "reason": "..."
+  },
+  "status": 404
+}
+```
+
+| Status | `error.type` | Cause |
+| --- | --- | --- |
+| `400` | `parsing_exception` | The query body could not be parsed. |
+| `400` | `illegal_argument_exception` | A supported field was given an unsupported value. |
+| `400` | `action_request_validation_exception` | The request was structurally invalid — for example an unknown mapping type. |
+| `400` | `invalid_index_name_exception` | Index name violates the naming rules. |
+| `400` | `invalid_document_id_exception` | Document id is empty or over 512 bytes. |
+| `400` | `resource_already_exists_exception` | The index already exists. |
+| `400` | `json_parse_exception` | The body was not valid JSON, or contained an unknown field. |
+| `400` | `no_handler_found_exception` | No handler matches that route. |
+| `404` | `index_not_found_exception` | The index does not exist. |
+| `404` | `not_found` | The document does not exist. |
+| `404` | `resource_not_found_exception` | The document was not found when reading `_source`. |
+| `406` | `media_type_header_exception` | Unsupported `Content-Type` or `Accept`. |
+| `410` | `api_not_available_exception` | A real Elasticsearch API that is not available in serverless mode, such as `/_cluster/health`. |
+| `500` | `internal_server_error` | Unexpected server error. |
+
+Two responses do **not** use this envelope:
+
+- A **request to an unrouted path** returns `400` with a bare
+  `{"error": "no handler found for uri [...] and method [...]"}` — no `type`, `root_cause`,
+  or `status` field.
+- A **`GET` for a missing document** returns `404` with the normal document shape,
+  `{"_index": ..., "_id": ..., "found": false}`, rather than an error.
+
+Pass `ignore_unavailable=true` to turn a missing index into an empty result instead of a
+`404`.
+
+### Not supported
+
+Nothing here is silently ignored. Unsupported fields in a search body are rejected with
+`400 json_parse_exception`, which lists the fields that are accepted; unrouted endpoints
+return `400` with the bare `no handler found for uri` body:
+
+- Scroll and point-in-time search
+- `_update_by_query` and `_delete_by_query`
+- Highlighting and suggesters
+- `collapse` and `script_fields`
+- `date_histogram` and other bucket aggregations beyond `terms`
+
+## Limits
+
+| Limit | Value |
+| --- | --- |
+| `from + size` | 10,000 |
+| Sort fields per search | 8 |
+| Index name length | 255 characters |
+| Document id length | 512 bytes |
+
+For collection-level limits, see [docs.topk.io/limits](https://docs.topk.io/limits).

--- a/topk-es/README.md
+++ b/topk-es/README.md
@@ -62,7 +62,7 @@ PUT /books
       "published_year": { "type": "integer" },
       "rating":         { "type": "float" },
       "in_print":       { "type": "boolean" },
-      "embedding":      { "type": "dense_vector", "dims": 16, "similarity": "cosine" }
+      "embedding":      { "type": "dense_vector", "dims": 4, "similarity": "cosine" }
     }
   }
 }
@@ -73,9 +73,9 @@ Index documents:
 ```json
 POST /books/_bulk
 { "index": { "_id": "mockingbird" } }
-{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true }
+{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true, "embedding": [1.0, 0.0, 0.0, 0.0] }
 { "index": { "_id": "gatsby" } }
-{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true }
+{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true, "embedding": [0.9, 0.1, 0.0, 0.0] }
 ```
 
 Search:
@@ -151,7 +151,7 @@ The following query clauses are supported inside `query`:
 | `regexp` | Regular expression match. |
 | `range` | `gt`, `gte`, `lt`, `lte` bounds. |
 | `exists` | Field is present and non-null. |
-| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`, `minimum_should_match`. |
+| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`. Accepts `boost`. |
 | `semantic` | **TopK extension.** Managed semantic search — see below. |
 
 ## Search body
@@ -178,7 +178,7 @@ POST /books/_search
 {
   "knn": {
     "field": "embedding",
-    "query_vector": [0.12, 0.87, 0.05, 0.44],
+    "query_vector": [1.0, 0.0, 0.0, 0.0],
     "k": 10,
     "filter": [{ "term": { "in_print": true } }]
   }
@@ -193,7 +193,7 @@ reciprocal rank fusion. `rank_constant` defaults to `60`.
 ```json
 POST /books/_search
 {
-  "query": { "match": { "body": "cats" } },
+  "query": { "match": { "title": "mockingbird" } },
   "knn": {
     "field": "embedding",
     "query_vector": [1.0, 0.0, 0.0, 0.0],

--- a/topk-es/README.md
+++ b/topk-es/README.md
@@ -1,0 +1,360 @@
+# topk-es
+
+TopK exposes an Elasticsearch-compatible HTTP endpoint. Official Elasticsearch clients
+connect to it unchanged — same URLs, same request bodies, same response shapes — so you can
+move an existing application to TopK without rewriting your query layer.
+
+## Documentation
+
+The full documentation can be found at [docs.topk.io](https://docs.topk.io).
+
+## Prerequisites
+
+- **API key** — sign in to [console.topk.io](https://console.topk.io) and generate an API key.
+- **Region** — see [docs.topk.io/regions](https://docs.topk.io/regions) for available regions.
+
+## Setup
+
+The endpoint is `https://<region>.es.<host>`, where `<host>` is `topk.io`:
+
+```
+https://<region>.es.topk.io
+```
+
+Authenticate with your TopK API key as an Elasticsearch API key. Replace `<region>` with
+your region name and `<api-key>` with your API key — for example
+`https://aws-us-east-1-elastica.es.topk.io`.
+
+```bash
+curl https://<region>.es.topk.io/books/_search \
+  -H "Authorization: ApiKey <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": { "match": { "title": "mockingbird" } } }'
+```
+
+> [!TIP]
+> See [available regions](https://docs.topk.io/regions) and get your [API key](https://console.topk.io/api-key).
+
+Any official Elasticsearch client works. For example, in Python:
+
+```python
+from elasticsearch import Elasticsearch
+
+es = Elasticsearch(
+    "https://<region>.es.topk.io",
+    api_key="<api-key>",
+)
+
+es.search(index="books", body={"query": {"match": {"title": "mockingbird"}}})
+```
+
+## Quick Start
+
+Create an index:
+
+```json
+PUT /books
+{
+  "mappings": {
+    "properties": {
+      "title":          { "type": "text" },
+      "author":         { "type": "keyword" },
+      "published_year": { "type": "integer" },
+      "rating":         { "type": "float" },
+      "in_print":       { "type": "boolean" },
+      "embedding":      { "type": "dense_vector", "dims": 16, "similarity": "cosine" }
+    }
+  }
+}
+```
+
+Index documents:
+
+```json
+POST /books/_bulk
+{ "index": { "_id": "mockingbird" } }
+{ "title": "To Kill a Mockingbird", "author": "Lee", "published_year": 1960, "rating": 4.3, "in_print": true }
+{ "index": { "_id": "gatsby" } }
+{ "title": "The Great Gatsby", "author": "Fitzgerald", "published_year": 1925, "rating": 3.9, "in_print": true }
+```
+
+Search:
+
+```json
+POST /books/_search
+{
+  "query": {
+    "bool": {
+      "must":   [{ "match": { "title": "mockingbird" } }],
+      "filter": [{ "range": { "published_year": { "gte": 1950 } } }]
+    }
+  },
+  "size": 10
+}
+```
+
+## Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /` | Cluster info. Returns the `x-elastic-product` header official clients expect. |
+| `PUT /<index>` | Create an index with mappings. |
+| `GET /<index>` | Read an index's mappings and settings. |
+| `HEAD /<index>` | Check whether an index exists. |
+| `DELETE /<index>` | Delete an index. |
+| `GET /<index>/_mapping` | Read the mapping for an index. |
+| `POST /<index>/_search` | Search documents. |
+| `POST /_msearch`, `POST /<index>/_msearch` | Run multiple searches in one request. |
+| `POST /<index>/_count` | Count documents matching a query. |
+| `PUT /<index>/_doc/<id>` | Index a single document. Returns `201`. |
+| `GET /<index>/_doc/<id>` | Get a document by id. |
+| `GET /<index>/_source/<id>` | Get just the `_source` of a document. |
+| `DELETE /<index>/_doc/<id>` | Delete a document by id. |
+| `POST /_mget`, `POST /<index>/_mget` | Get multiple documents by id. |
+| `POST /<index>/_bulk` | Bulk `index`, `create`, `update`, and `delete`. |
+| `GET /<index>/_field_caps` | Field capabilities for an index. |
+| `GET /_resolve/index/<expr>` | Resolve index names. |
+| `POST /<index>/_refresh` | Make pending writes searchable. |
+
+Index names must start with a letter or digit and contain only letters, digits, underscores,
+dashes, and dots, up to 255 characters. Document ids must be non-empty and at most 512 bytes.
+
+### Making writes visible
+
+Writes become searchable asynchronously. Either call `POST /<index>/_refresh`, or pass the
+`refresh` query parameter on an index, delete, or bulk request to control when the call
+returns:
+
+| Value | Behaviour |
+| --- | --- |
+| `false` (default) | Return immediately. |
+| `true` | Wait for the write to become searchable. |
+| `wait_for` | Wait for the write to become searchable. |
+
+```bash
+curl -X POST "https://<region>.es.topk.io/books/_bulk?refresh=wait_for" ...
+```
+
+## Query DSL
+
+The following query clauses are supported inside `query`:
+
+| Clause | Notes |
+| --- | --- |
+| `match_all` | Matches every document. Accepts `boost`. |
+| `match` | Full-text match. Accepts `query`, `operator` (`or` / `and`), `boost`. |
+| `multi_match` | Match across several fields. |
+| `term` | Exact term match. |
+| `terms` | Match any of a list of terms. |
+| `ids` | Match documents by `_id`. |
+| `prefix` | Prefix match on a string field. |
+| `regexp` | Regular expression match. |
+| `range` | `gt`, `gte`, `lt`, `lte` bounds. |
+| `exists` | Field is present and non-null. |
+| `bool` | Combine clauses with `must`, `should`, `must_not`, `filter`, `minimum_should_match`. |
+| `semantic` | **TopK extension.** Managed semantic search — see below. |
+
+## Search body
+
+| Field | Description |
+| --- | --- |
+| `query` | Query DSL clause. |
+| `size` | Number of hits to return. Defaults to `10`. |
+| `from` | Offset. `from + size` must be 10,000 or less. |
+| `sort` | Sort by field, or by the `_score` pseudo-field. At most 8 sort fields. |
+| `knn` | Vector search. One clause or an array of clauses. |
+| `rank` | Reciprocal rank fusion across result sets. |
+| `track_scores` | Return scores even when sorting by a field. |
+| `aggs` | Aggregations (alias: `aggregations`). |
+| `_source` | Field filtering. Also accepted as a query parameter, which takes precedence. |
+
+### Vector search
+
+`knn` takes `field`, `query_vector`, and `k`, plus optional `filter`, `num_candidates`,
+`boost`, and `similarity`.
+
+```json
+POST /books/_search
+{
+  "knn": {
+    "field": "embedding",
+    "query_vector": [0.12, 0.87, 0.05, 0.44],
+    "k": 10,
+    "filter": [{ "term": { "in_print": true } }]
+  }
+}
+```
+
+### Hybrid search
+
+Pass `knn` and `query` together with a `rank` clause to fuse the two result sets with
+reciprocal rank fusion. `rank_constant` defaults to `60`.
+
+```json
+POST /books/_search
+{
+  "query": { "match": { "body": "cats" } },
+  "knn": {
+    "field": "embedding",
+    "query_vector": [1.0, 0.0, 0.0, 0.0],
+    "k": 10
+  },
+  "rank": { "rrf": { "rank_constant": 60, "rank_window_size": 100 } }
+}
+```
+
+Without a `rank` clause, scores from `query` and `knn` are summed.
+
+### Semantic search
+
+`semantic` is a TopK extension to the Elasticsearch DSL. Point it at a `semantic_text`
+field and TopK runs embedding and retrieval for you — there is no inference pipeline to
+configure.
+
+```json
+POST /articles/_search
+{
+  "query": { "semantic": { "field": "content", "query": "cats" } },
+  "size": 10
+}
+```
+
+## Aggregations
+
+| Aggregation | Type |
+| --- | --- |
+| `terms` | Bucket. Accepts `field` and `size`, and supports sub-aggregations. |
+| `sum` | Metric. |
+| `avg` | Metric. |
+| `min` | Metric. |
+| `max` | Metric. |
+| `value_count` | Metric. |
+
+```json
+POST /books/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_author": {
+      "terms": { "field": "author", "size": 10 },
+      "aggs": { "avg_rating": { "avg": { "field": "rating" } } }
+    }
+  }
+}
+```
+
+## Mapping types
+
+| Type | Aliases | Options |
+| --- | --- | --- |
+| `text` | | `index`, `fields` |
+| `keyword` | | `index`, `fields`, `ignore_above` |
+| `integer` | `long`, `short`, `byte` | `index` |
+| `float` | `double`, `half_float` | `index` |
+| `boolean` | | `index` |
+| `object` | `nested` | `properties` |
+| `dense_vector` | | `dims`, `similarity`, `element_type`, `index` |
+| `rank_vectors` | `matrix` | `dims`, `element_type`, `quantization`, `top_k`, `width` |
+| `semantic_text` | | — |
+
+`dense_vector` accepts `similarity` of `cosine`, `dot_product`, or `l2_norm`, and
+`element_type` of `float` (default), `byte`, or `bit`. For `element_type: "bit"`, `dims`
+must be a multiple of 8 and `similarity` must be `l2_norm` or omitted.
+
+`rank_vectors` maps to TopK multi-vector retrieval. It accepts `element_type` of `float`
+(default) or `byte`, and `quantization` of `scalar`, `binary_1bit`, or `binary_2bit`.
+
+## Differences from Elasticsearch
+
+Read this section before migrating an existing index.
+
+> [!WARNING]
+> **`nested` is treated as `object`.** A `nested` mapping is accepted rather than rejected,
+> but the field is indexed as a plain object. Queries that rely on nested document
+> semantics will return different results instead of an error.
+
+**`hits.total` is a lower bound on hybrid searches.** A search served by a single
+retriever — keyword-only or vector-only — reports `"relation": "eq"` with an exact count. A
+search combining retrievers (for example `query` plus `knn`) reports `"relation": "gte"`,
+and the value is a floor rather than a total. Check `relation` before displaying a count.
+Elasticsearch has the same field with the same meaning but flips to `gte` under different
+conditions, so code that assumed `eq` can start under-reporting after a migration.
+
+**Deleting a missing document succeeds.** `DELETE /<index>/_doc/<id>` returns `200` with
+`"result": "deleted"` whether or not the document existed. Elasticsearch returns `404` with
+`"result": "not_found"`, so code that branches on that will not see the missing case.
+
+**There is no `date` mapping type.** TopK supports timestamps through its other APIs, but
+the Elasticsearch layer has no date mapping. Map date fields as `keyword` (for exact
+matching and terms aggregations) or `integer` (for range queries on epoch values).
+
+**Scores are `null` when sorting by a field.** Matching Elasticsearch behaviour, set
+`track_scores: true` to compute scores anyway. Sorting on the `_score` pseudo-field also
+keeps them.
+
+## Errors
+
+Handled errors use the Elasticsearch envelope, so client libraries surface them as they
+normally would — `error.type`, `error.reason`, `error.root_cause`, and a top-level `status`.
+
+```json
+{
+  "error": {
+    "root_cause": [{ "type": "index_not_found_exception", "reason": "..." }],
+    "type": "index_not_found_exception",
+    "reason": "..."
+  },
+  "status": 404
+}
+```
+
+| Status | `error.type` | Cause |
+| --- | --- | --- |
+| `400` | `parsing_exception` | The query body could not be parsed. |
+| `400` | `illegal_argument_exception` | A supported field was given an unsupported value. |
+| `400` | `action_request_validation_exception` | The request was structurally invalid — for example an unknown mapping type. |
+| `400` | `invalid_index_name_exception` | Index name violates the naming rules. |
+| `400` | `invalid_document_id_exception` | Document id is empty or over 512 bytes. |
+| `400` | `resource_already_exists_exception` | The index already exists. |
+| `400` | `json_parse_exception` | The body was not valid JSON, or contained an unknown field. |
+| `400` | `no_handler_found_exception` | No handler matches that route. |
+| `404` | `index_not_found_exception` | The index does not exist. |
+| `404` | `not_found` | The document does not exist. |
+| `404` | `resource_not_found_exception` | The document was not found when reading `_source`. |
+| `406` | `media_type_header_exception` | Unsupported `Content-Type` or `Accept`. |
+| `410` | `api_not_available_exception` | A real Elasticsearch API that is not available in serverless mode, such as `/_cluster/health`. |
+| `500` | `internal_server_error` | Unexpected server error. |
+
+Two responses do **not** use this envelope:
+
+- A **request to an unrouted path** returns `400` with a bare
+  `{"error": "no handler found for uri [...] and method [...]"}` — no `type`, `root_cause`,
+  or `status` field.
+- A **`GET` for a missing document** returns `404` with the normal document shape,
+  `{"_index": ..., "_id": ..., "found": false}`, rather than an error.
+
+Pass `ignore_unavailable=true` to turn a missing index into an empty result instead of a
+`404`.
+
+### Not supported
+
+Nothing here is silently ignored. Unsupported fields in a search body are rejected with
+`400 json_parse_exception`, which lists the fields that are accepted; unrouted endpoints
+return `400` with the bare `no handler found for uri` body:
+
+- Scroll and point-in-time search
+- `_update_by_query` and `_delete_by_query`
+- Highlighting and suggesters
+- `collapse` and `script_fields`
+- `date_histogram` and other bucket aggregations beyond `terms`
+
+## Limits
+
+| Limit | Value |
+| --- | --- |
+| `from + size` | 10,000 |
+| Sort fields per search | 8 |
+| Index name length | 255 characters |
+| Document id length | 512 bytes |
+
+For collection-level limits, see [docs.topk.io/limits](https://docs.topk.io/limits).

--- a/utils/generate-docs-llms-txt.ts
+++ b/utils/generate-docs-llms-txt.ts
@@ -92,108 +92,59 @@ async function readPageContent(slug: string): Promise<string> {
 
 // --- Navigation ---
 
-const OVERVIEW_EXCLUDE = new Set(["cli"]);
+// Pages deliberately kept out of llms.txt (console-only, nothing for an agent to call).
 const LLMS_EXCLUDE = new Set(["usage"]);
 
-const API_ENTRIES: Entry[] = [
-  { type: "slug", slug: "cli" },
-  { type: "slug", slug: "sdk/topk-py/overview" },
-  { type: "slug", slug: "sdk/topk-js/overview" },
-  { type: "slug", slug: "sdk/topk-sql/overview" },
+// The Documentation tab's groups are distinct API areas, so each becomes its own
+// section. Every other tab collapses into one section named after the tab.
+const PER_GROUP_TABS = new Set(["Documentation"]);
+
+// Surfaces that have no page in the nav and so can't be discovered by walking tabs.
+const EXTRA_SECTIONS: Section[] = [
   {
-    type: "external",
-    title: "Rust SDK",
-    url: "https://github.com/topk-io/topk/tree/main/topk-rs",
-    description: "Get started with TopK using Rust SDK.",
+    heading: "Rust SDK",
+    entries: [
+      {
+        type: "external",
+        title: "Rust SDK",
+        url: "https://github.com/topk-io/topk/tree/main/topk-rs",
+        description: "Get started with TopK using Rust SDK.",
+      },
+    ],
   },
 ];
 
+/**
+ * Walks every tab in docs.json rather than looking tabs up by name, so a tab added
+ * to the nav reaches llms.txt without a matching change here.
+ */
 function buildSections(): Section[] {
   const sections: Section[] = [];
 
-  // Documentation tab
-  const docTab = docs.navigation.tabs.find((t) => t.tab === "Documentation");
-  if (docTab) {
-    for (const group of normalizeTabPages(docTab.pages)) {
-      const isOverview = group.group === "Overview" || !group.group;
-      const slugs = isOverview
-        ? group.pages.filter((s) => !OVERVIEW_EXCLUDE.has(s))
-        : group.pages.filter((s) => !LLMS_EXCLUDE.has(s));
+  for (const tab of docs.navigation.tabs as Array<{ tab: string; pages: unknown }>) {
+    const groups = normalizeTabPages(tab.pages);
+    const perGroup = PER_GROUP_TABS.has(tab.tab);
+    const collapsed: Entry[] = [];
 
+    for (const group of groups) {
+      const slugs = group.pages.filter((s) => !LLMS_EXCLUDE.has(s));
       if (slugs.length === 0) continue;
 
-      sections.push({
-        heading: isOverview ? "Overview" : group.group!,
-        entries: slugs.map((slug): Entry => ({ type: "slug", slug })),
-      });
+      const entries = slugs.map((slug): Entry => ({ type: "slug", slug }));
 
-      if (group.group === "Core Concepts") {
-        sections.push({ heading: "APIs", entries: API_ENTRIES });
+      if (perGroup) {
+        sections.push({ heading: group.group ?? tab.tab, entries });
+      } else {
+        collapsed.push(...entries);
       }
     }
-  }
 
-  // Guides tab
-  const guidesTab = docs.navigation.tabs.find((t) => t.tab === "Guides");
-  if (guidesTab) {
-    for (const group of normalizeTabPages(guidesTab.pages)) {
-      if (!group.pages.length) continue;
-      sections.push({
-        heading: group.group ?? "Guides",
-        entries: group.pages.map((slug): Entry => ({ type: "slug", slug })),
-      });
+    if (!perGroup && collapsed.length > 0) {
+      sections.push({ heading: tab.tab, entries: collapsed });
     }
   }
 
-  // Python SDK Reference
-  const pyTab = docs.navigation.tabs.find((t) => t.tab === "Python SDK");
-  const pyRef = pyTab && normalizeTabPages(pyTab.pages).find((g) => g.group === "SDK Reference");
-  if (pyRef) {
-    sections.push({
-      heading: "Python SDK Reference",
-      entries: pyRef.pages.map((slug): Entry => ({ type: "slug", slug })),
-    });
-  }
-
-  // JavaScript SDK Reference
-  const jsTab = docs.navigation.tabs.find((t) => t.tab === "JavaScript SDK");
-  const jsRef = jsTab && normalizeTabPages(jsTab.pages).find((g) => g.group === "SDK Reference");
-  if (jsRef) {
-    sections.push({
-      heading: "JavaScript SDK Reference",
-      entries: jsRef.pages.map((slug): Entry => ({ type: "slug", slug })),
-    });
-  }
-
-  // SQL
-  const sqlTab = docs.navigation.tabs.find((t) => t.tab === "SQL");
-  const sqlOverview = sqlTab && normalizeTabPages(sqlTab.pages).find((g) => g.group === "SQL");
-  if (sqlOverview) {
-    sections.push({
-      heading: "SQL",
-      entries: sqlOverview.pages.map((slug): Entry => ({ type: "slug", slug })),
-    });
-  }
-
-  // Database tab
-  const dbTab = docs.navigation.tabs.find((t) => t.tab === "Database");
-  if (dbTab) {
-    const DB_CONCEPT_SLUGS = [
-      "concepts/semantic-search",
-      "concepts/vector-search",
-      "concepts/sparse-vector-search",
-      "concepts/multi-vector-search",
-      "concepts/keyword-search",
-      "concepts/true-hybrid-search",
-    ];
-    sections.push({
-      heading: "Database APIs",
-      entries: [
-        { type: "slug", slug: "database", firstParagraphs: 2 },
-        ...DB_CONCEPT_SLUGS.map((slug): Entry => ({ type: "slug", slug, titlePrefix: "TopK Database - " })),
-      ],
-    });
-  }
+  sections.push(...EXTRA_SECTIONS);
 
   return sections;
 }

--- a/utils/sync-readmes.ts
+++ b/utils/sync-readmes.ts
@@ -38,6 +38,15 @@ const SOURCES: Source[] = [
     },
   },
   {
+    readme: path.join(ROOT, "topk-es", "README.md"),
+    output: path.join(ROOT, "docs", "sdk", "topk-es", "overview.mdx"),
+    frontmatter: {
+      title: "Elasticsearch API",
+      description:
+        "Point any Elasticsearch client at TopK and keep your existing queries, mappings, and tooling.",
+    },
+  },
+  {
     readme: path.join(ROOT, "topk-sql", "README.md"),
     output: path.join(ROOT, "docs", "sdk", "topk-sql", "overview.mdx"),
     frontmatter: {


### PR DESCRIPTION
TopK serves an Elasticsearch-compatible endpoint at <region>.es.topk.io. Any official Elasticsearch client talks to it unchanged, but nothing documented it. Since topk-es is publish = false, the only sign it existed was 4.9k lines of Rust.

Every claim was checked against a live cluster, which corrected several things reading the source alone had got wrong.