### PR TITLE
[import] alternative sparse vector syntax

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -154,7 +154,7 @@ embedding = { type = "f32_vector", dim = 768, index = { vector = { metric = "cos
 | `dim` / `cols` | vector dimension / matrix row width |
 | `index` | `"keyword"` `"exact"` `"semantic"` `"ngram"` `{ vector = { metric = "cosine" \| "euclidean" \| "dot_product" \| "hamming" } }` `{ multi_vector = {} }` |
 
-Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
+Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); a sparse vector reads a map of numeric keys or a struct of parallel `indices` and `values` lists; epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
 
 #### Failures and limits
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -154,7 +154,7 @@ embedding = { type = "f32_vector", dim = 768, index = { vector = { metric = "cos
 | `dim` / `cols` | vector dimension / matrix row width |
 | `index` | `"keyword"` `"exact"` `"semantic"` `"ngram"` `{ vector = { metric = "cosine" \| "euclidean" \| "dot_product" \| "hamming" } }` `{ multi_vector = {} }` |
 
-Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); a sparse vector reads a map of numeric keys or a struct of parallel `indices` and `values` lists; epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
+Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); a sparse vector reads numeric keys or parallel `indices`/`values` lists; epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
 
 #### Failures and limits
 

--- a/topk-cli/README.md
+++ b/topk-cli/README.md
@@ -150,7 +150,7 @@ embedding = { type = "f32_vector", dim = 768, index = { vector = { metric = "cos
 | `dim` / `cols` | vector dimension / matrix row width |
 | `index` | `"keyword"` `"exact"` `"semantic"` `"ngram"` `{ vector = { metric = "cosine" \| "euclidean" \| "dot_product" \| "hamming" } }` `{ multi_vector = {} }` |
 
-Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); a sparse vector reads a map of numeric keys or a struct of parallel `indices` and `values` lists; epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
+Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); a sparse vector reads numeric keys or parallel `indices`/`values` lists; epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
 
 #### Failures and limits
 

--- a/topk-cli/README.md
+++ b/topk-cli/README.md
@@ -150,7 +150,7 @@ embedding = { type = "f32_vector", dim = 768, index = { vector = { metric = "cos
 | `dim` / `cols` | vector dimension / matrix row width |
 | `index` | `"keyword"` `"exact"` `"semantic"` `"ngram"` `{ vector = { metric = "cosine" \| "euclidean" \| "dot_product" \| "hamming" } }` `{ multi_vector = {} }` |
 
-Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
+Discovery takes the source's types; declaring a different `type` converts. Embeddings that arrive as float lists, text (`"[1,2,3]"`) or packed bytes become vectors by declaring `f32_vector` and `dim` (`f32_matrix` and `cols` for multi-vectors); a sparse vector reads a map of numeric keys or a struct of parallel `indices` and `values` lists; epoch numbers or date text become `timestamp`. Conversions are exact or the document fails; a narrower declaration (`truncate` included) is how loss is accepted.
 
 #### Failures and limits
 

--- a/topk-cli/src/import/coerce.rs
+++ b/topk-cli/src/import/coerce.rs
@@ -302,11 +302,7 @@ fn sparse_pairs(value: &Value, ty: Type) -> Result<(Vec<u32>, Vec<f64>), Error> 
                     }
                     let mut pairs = Vec::with_capacity(indices.len());
                     for (index, value) in indices.into_iter().zip(values) {
-                        let index = u32::try_from(index).map_err(|_| {
-                            Error::InvalidArgument(format!(
-                                "sparse index {index} does not fit in a u32"
-                            ))
-                        })?;
+                        let index = u32::try_from(index).map_err(|_| Error::CannotCoerce(ty))?;
                         pairs.push((index, value));
                     }
                     pairs

--- a/topk-cli/src/import/coerce.rs
+++ b/topk-cli/src/import/coerce.rs
@@ -274,8 +274,8 @@ fn matrix_floats(value: &Value, cols: u32, ty: Type) -> Result<Vec<f64>, Error> 
     Ok(nums)
 }
 
-/// (indices, values) sorted by index, from topk's sparse form or a struct of
-/// numeric keys.
+/// (indices, values) sorted by index, from topk's sparse form, a struct of
+/// parallel `indices` and `values` lists, or a struct of numeric keys.
 fn sparse_pairs(value: &Value, ty: Type) -> Result<(Vec<u32>, Vec<f64>), Error> {
     let mut pairs: Vec<(u32, f64)> = match value.value.as_ref() {
         Some(Inner::SparseVector(sparse)) => match sparse.values.as_ref() {
@@ -289,16 +289,41 @@ fn sparse_pairs(value: &Value, ty: Type) -> Result<(Vec<u32>, Vec<f64>), Error> 
         },
         _ => {
             let entries = value.as_struct().ok_or(Error::CannotCoerce(ty))?;
-            let mut pairs = Vec::with_capacity(entries.len());
-            for (key, entry) in entries {
-                // duckdb unifies jsonl schemas by filling absent keys with null.
-                if entry.as_null().is_some() {
-                    continue;
+            match (entries.get("indices"), entries.get("values")) {
+                (Some(indices), Some(values)) => {
+                    let indices = ints(indices).ok_or(Error::CannotCoerce(ty))?;
+                    let values = floats(values).ok_or(Error::CannotCoerce(ty))?;
+                    if indices.len() != values.len() {
+                        return Err(Error::InvalidArgument(format!(
+                            "sparse vector has {} indices and {} values",
+                            indices.len(),
+                            values.len()
+                        )));
+                    }
+                    let mut pairs = Vec::with_capacity(indices.len());
+                    for (index, value) in indices.into_iter().zip(values) {
+                        let index = u32::try_from(index).map_err(|_| {
+                            Error::InvalidArgument(format!(
+                                "sparse index {index} does not fit in a u32"
+                            ))
+                        })?;
+                        pairs.push((index, value));
+                    }
+                    pairs
                 }
-                let index: u32 = key.trim().parse().map_err(|_| Error::CannotCoerce(ty))?;
-                pairs.push((index, float(entry).ok_or(Error::CannotCoerce(ty))?));
+                _ => {
+                    let mut pairs = Vec::with_capacity(entries.len());
+                    for (key, entry) in entries {
+                        // duckdb unifies jsonl schemas by filling absent keys with null.
+                        if entry.as_null().is_some() {
+                            continue;
+                        }
+                        let index: u32 = key.trim().parse().map_err(|_| Error::CannotCoerce(ty))?;
+                        pairs.push((index, float(entry).ok_or(Error::CannotCoerce(ty))?));
+                    }
+                    pairs
+                }
             }
-            pairs
         }
     };
     pairs.sort_by_key(|(index, _)| *index);

--- a/topk-cli/src/import/preview.rs
+++ b/topk-cli/src/import/preview.rs
@@ -50,10 +50,19 @@ pub fn elide(value: &serde_json::Value) -> String {
             format!("{head:?}…")
         }
         serde_json::Value::Object(entries) => {
-            let pairs: Vec<String> = entries
-                .iter()
-                .map(|(key, value)| format!("{key:?}: {}", elide(value)))
-                .collect();
+            let pair =
+                |(key, value): (&String, &serde_json::Value)| format!("{key:?}: {}", elide(value));
+            if entries.len() > PREVIEW_ELEMENTS {
+                let head: Vec<String> = entries.iter().take(2).map(pair).collect();
+                let tail: Vec<String> = entries.iter().skip(entries.len() - 2).map(pair).collect();
+                return format!(
+                    "{{{}, … {} pairs, {}}}",
+                    head.join(", "),
+                    entries.len(),
+                    tail.join(", ")
+                );
+            }
+            let pairs: Vec<String> = entries.iter().map(pair).collect();
             format!("{{{}}}", pairs.join(", "))
         }
         other => other.to_string(),

--- a/topk-cli/src/import/source/codec/arrow.rs
+++ b/topk-cli/src/import/source/codec/arrow.rs
@@ -1,10 +1,10 @@
 use duckdb::arrow::array::{self, Array, ArrayRef, AsArray};
-use duckdb::arrow::datatypes::{DataType, Float64Type, Int64Type, TimeUnit, UInt64Type};
+use duckdb::arrow::datatypes::{DataType, Fields, Float64Type, Int64Type, TimeUnit, UInt64Type};
 use topk_rs::proto::v1::data::Value;
 
 use crate::import::decode::floats;
 use crate::import::error::Error;
-use crate::import::spec::Type;
+use crate::import::spec::{Element, Type};
 
 pub fn ty(input: &DataType) -> Type {
     match input {
@@ -35,6 +35,7 @@ pub fn ty(input: &DataType) -> Type {
                 _ => Type::TextList,
             }
         }
+        DataType::Struct(fields) if is_sparse_struct(fields) => Type::Sparse(Element::F32),
         DataType::Struct(_) => Type::Struct,
         // value() renders these to RFC 3339 / a bare date, which the Timestamp
         // coercion reads back to epoch millis.
@@ -118,9 +119,7 @@ pub fn value(array: &ArrayRef, row: usize) -> Result<Value, Error> {
                 }
             }
         }
-        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
-            return list(&elements_at(array, row))
-        }
+        ty if is_list(ty) => return list(&elements_at(array, row)),
         DataType::Struct(fields) => {
             let columns = array.as_any().downcast_ref::<array::StructArray>().unwrap();
             let mut out = Vec::with_capacity(fields.len());
@@ -164,9 +163,7 @@ fn list(elements: &ArrayRef) -> Result<Value, Error> {
     }
     let dtype = elements.data_type();
     Ok(match dtype {
-        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _) => {
-            return matrix(elements)
-        }
+        ty if is_list(ty) => return matrix(elements),
         // A u64 past i64::MAX has no wider integer to read as.
         DataType::UInt64 => Value::list(cast(elements, &DataType::UInt64)?.as_primitive::<UInt64Type>().values().to_vec()),
         // `ty` picks the family; the elements are then read as its widest member.
@@ -252,4 +249,21 @@ fn matrix(rows: &ArrayRef) -> Result<Value, Error> {
         ));
     }
     Ok(Value::matrix(cols as u32, values))
+}
+
+fn is_list(ty: &DataType) -> bool {
+    matches!(
+        ty,
+        DataType::List(_) | DataType::LargeList(_) | DataType::FixedSizeList(_, _)
+    )
+}
+
+/// The shape a sparse vector arrives in: parallel `indices` and `values` lists.
+fn is_sparse_struct(fields: &Fields) -> bool {
+    let named = |name: &str| {
+        fields
+            .iter()
+            .any(|f| f.name() == name && is_list(f.data_type()))
+    };
+    fields.len() == 2 && named("indices") && named("values")
 }

--- a/topk-cli/tests/import/coerce.rs
+++ b/topk-cli/tests/import/coerce.rs
@@ -135,6 +135,9 @@ fn fields_share_columns_and_the_id() {
 #[case::sparse_f32_from_struct(r#"{ type = "f32_sparse_vector" }"#, Value::r#struct([("2", Value::f64(0.25))]), Value::sparse_vector(vec![2], vec![0.25]))]
 #[case::sparse_u8_from_ints(r#"{ type = "u8_sparse_vector" }"#, Value::r#struct([("7", Value::i64(3))]), Value::sparse_vector(vec![7], vec![3u8]))]
 #[case::sparse_skips_null_entries(r#"{ type = "f32_sparse_vector" }"#, Value::r#struct([("0", Value::f64(1.0)), ("3", Value::null()), ("7", Value::f64(0.5))]), Value::sparse_vector(vec![0, 7], vec![1.0, 0.5]))]
+#[case::sparse_f32_from_parallel_lists(r#"{ type = "f32_sparse_vector" }"#, Value::r#struct([("indices", Value::list(vec![3_i64, 1])), ("values", Value::list(vec![1.5_f64, 0.5]))]), Value::sparse_vector(vec![1, 3], vec![0.5, 1.5]))]
+#[case::sparse_u8_from_parallel_lists(r#"{ type = "u8_sparse_vector" }"#, Value::r#struct([("indices", Value::list(vec![7_i64])), ("values", Value::list(vec![3_i64]))]), Value::sparse_vector(vec![7], vec![3u8]))]
+#[case::sparse_from_empty_parallel_lists(r#"{ type = "f32_sparse_vector" }"#, Value::r#struct([("indices", Value::list(Vec::<i64>::new())), ("values", Value::list(Vec::<f64>::new()))]), Value::sparse_vector(Vec::<u32>::new(), Vec::<f32>::new()))]
 fn coerces(#[case] field: &str, #[case] input: Value, #[case] expected: Value) {
     assert_eq!(coerced(field, input), expected);
 }
@@ -233,6 +236,16 @@ fn nulls(
     "cannot coerce to f32_sparse_vector"
 )]
 #[case::sparse_from_a_list(r#"{ type = "f32_sparse_vector" }"#, Value::list(vec![1.0_f32]), "cannot coerce to f32_sparse_vector")]
+#[case::sparse_from_ragged_parallel_lists(
+    r#"{ type = "f32_sparse_vector" }"#,
+    Value::r#struct([("indices", Value::list(vec![1_i64, 2])), ("values", Value::list(vec![0.5_f64]))]),
+    "sparse vector has 2 indices and 1 values"
+)]
+#[case::sparse_from_a_negative_index(
+    r#"{ type = "f32_sparse_vector" }"#,
+    Value::r#struct([("indices", Value::list(vec![-1_i64])), ("values", Value::list(vec![0.5_f64]))]),
+    "sparse index -1 does not fit in a u32"
+)]
 #[case::vector_too_short(r#"{ type = "f32_vector", dim = 3 }"#, Value::list(vec![1.0_f32, 2.0]), "vector has 2 values, declared dim=3")]
 #[case::vector_too_long(r#"{ type = "f32_vector", dim = 3 }"#, Value::list(vec![1.0_f32, 2.0, 3.0, 4.0]), "vector has 4 values, declared dim=3")]
 #[case::vector_from_a_json_string(

--- a/topk-cli/tests/import/coerce.rs
+++ b/topk-cli/tests/import/coerce.rs
@@ -244,7 +244,7 @@ fn nulls(
 #[case::sparse_from_a_negative_index(
     r#"{ type = "f32_sparse_vector" }"#,
     Value::r#struct([("indices", Value::list(vec![-1_i64])), ("values", Value::list(vec![0.5_f64]))]),
-    "sparse index -1 does not fit in a u32"
+    "cannot coerce to f32_sparse_vector"
 )]
 #[case::vector_too_short(r#"{ type = "f32_vector", dim = 3 }"#, Value::list(vec![1.0_f32, 2.0]), "vector has 2 values, declared dim=3")]
 #[case::vector_too_long(r#"{ type = "f32_vector", dim = 3 }"#, Value::list(vec![1.0_f32, 2.0, 3.0, 4.0]), "vector has 4 values, declared dim=3")]

--- a/topk-cli/tests/import/discover.rs
+++ b/topk-cli/tests/import/discover.rs
@@ -253,3 +253,17 @@ async fn all_objects_skipped_says_so(ctx: &mut Scratch) {
         "got: {message}"
     );
 }
+
+#[test_context(Scratch)]
+#[tokio::test]
+async fn sparse_structs_become_sparse_vectors(ctx: &mut Scratch) {
+    let path = ctx.sql_parquet(
+        "sv",
+        "SELECT 1 AS id, \
+         {'indices': [3,1]::UINTEGER[], 'values': [1.5,0.5]::FLOAT[]} AS sv",
+    );
+
+    let spec = discover_spec(&path, None).await;
+    let field = &spec.collections["sv"].fields["sv"];
+    assert_eq!(field.ty.to_string(), "f32_sparse_vector");
+}

--- a/topk-cli/tests/import/e2e.rs
+++ b/topk-cli/tests/import/e2e.rs
@@ -31,7 +31,8 @@ async fn all_types(ctx: &mut Ctx) {
          ['p','q']::VARCHAR[] AS ls, [0.1,0.2,0.3]::DOUBLE[] AS vf, \
          [0.1,0.2,0.3]::DOUBLE[] AS vf16src, [0.1,0.2,0.3]::DOUBLE[] AS vf8src, \
          [1,2,3]::INTEGER[] AS vint, [1,2,3]::INTEGER[] AS vint2, \
-         '{\"1\": 0.5, \"3\": 1.5}' AS sv",
+         '{\"1\": 0.5, \"3\": 1.5}' AS sv, \
+         {'indices': [3,1]::UINTEGER[], 'values': [1.5,0.5]::FLOAT[]} AS svlists",
     );
     let collection = ctx.collection("types");
     let toml = format!(
@@ -53,6 +54,7 @@ vf8 = {{ from = \"vf8src\", type = \"f8_vector\", dim = 3 }}
 vu8 = {{ from = \"vint\", type = \"u8_vector\", dim = 3 }}
 vi8 = {{ from = \"vint2\", type = \"i8_vector\", dim = 3 }}
 sv = {{ type = \"f32_sparse_vector\" }}
+svlists = {{ type = \"f32_sparse_vector\" }}
 "
     );
     ok(&["import", "-f", &ctx.spec_file(&toml), "--yes"], &[]);
@@ -70,7 +72,9 @@ sv = {{ type = \"f32_sparse_vector\" }}
     for v in ["vcos", "vf16", "vf8"] {
         assert_eq!(field(d, v).as_array().unwrap().len(), 3, "{v}");
     }
-    assert!(d.contains_key("sv"), "sparse vector must be stored");
+    // A json map and a struct of parallel lists are the same sparse vector.
+    assert_eq!(field(d, "sv"), json!({"1": 0.5, "3": 1.5}));
+    assert_eq!(field(d, "svlists"), json!({"1": 0.5, "3": 1.5}));
 
     let coll = ctx.client().collections().get(&collection).await.unwrap();
     assert!(matches!(


### PR DESCRIPTION
Add support for alternative sparse vector syntax. Standard is `{ int: float }` and the alternative is `{ indices: int[], values: float[] }`.