### PR TITLE
[es] cardinality agg

### DIFF
--- a/topk-es/src/api/aggs.rs
+++ b/topk-es/src/api/aggs.rs
@@ -26,7 +26,19 @@ pub enum AggType {
     Min(MetricAggBody),
     Max(MetricAggBody),
     ValueCount(MetricAggBody),
+    Cardinality(CardinalityAggBody),
     DateHistogram(DateHistogramBody),
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CardinalityAggBody {
+    pub field: FieldName,
+
+    // Accepted, not honoured: `count_distinct` exposes no accuracy dial to feed it.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub precision_threshold: Option<u32>,
 }
 
 #[derive(Clone, Deserialize)]

--- a/topk-es/src/engine/agg.rs
+++ b/topk-es/src/engine/agg.rs
@@ -91,7 +91,7 @@ pub fn collect(
 fn metric(schema: &Schema, ty: &AggType, value: Option<f64>) -> AggResult {
     // Over an empty match set ES sums and counts to 0; avg/min/max stay null.
     let value = match (value, ty) {
-        (None, AggType::Sum(_) | AggType::ValueCount(_)) => Some(0.0),
+        (None, AggType::Sum(_) | AggType::ValueCount(_) | AggType::Cardinality(_)) => Some(0.0),
         (value, _) => value,
     };
     let iso = match ty {
@@ -321,6 +321,7 @@ impl TryFrom<AggType> for AggregateExpr {
             AggType::Min(m) => Ok(AggregateExpr::min(m.field)),
             AggType::Max(m) => Ok(AggregateExpr::max(m.field)),
             AggType::ValueCount(m) => Ok(AggregateExpr::count(Some(m.field.into()))),
+            AggType::Cardinality(m) => Ok(AggregateExpr::count_distinct(m.field)),
             AggType::Terms(_) | AggType::DateHistogram(_) => Err(Error::Unsupported(
                 "Nested bucket sub-aggregations are not supported".into(),
             )),

--- a/topk-es/src/engine/compile.rs
+++ b/topk-es/src/engine/compile.rs
@@ -22,6 +22,7 @@ fn validate_agg_fields(schema: &Schema, clause: &AggClause) -> Result<(), Error>
         AggType::Sum(m) | AggType::Avg(m) | AggType::Min(m) | AggType::Max(m) => {
             ensure_aggregatable(schema, m.field.as_str())?
         }
+        AggType::Cardinality(m) => ensure_aggregatable(schema, m.field.as_str())?,
         AggType::DateHistogram(h) => ensure_aggregatable(schema, h.field.as_str())?,
         AggType::ValueCount(_) => {}
     }

--- a/topk-es/tests/aggs.rs
+++ b/topk-es/tests/aggs.rs
@@ -7,6 +7,120 @@ use test_macros::rstest_ctx;
 
 #[test_context(BooksContext)]
 #[tokio::test]
+async fn test_cardinality_counts_distinct_values(books: &BooksContext) {
+    let resp = books
+        .search(json!({
+            "size": 0,
+            "aggs": { "genres": { "cardinality": { "field": "genre" } } }
+        }))
+        .await
+        .expect("search should succeed");
+
+    assert_eq!(resp.agg_value("genres"), 5.0, "{}", resp.agg("genres"));
+}
+
+#[test_context(BooksContext)]
+#[tokio::test]
+async fn test_cardinality_accepts_precision_threshold(books: &BooksContext) {
+    let resp = books
+        .search(json!({
+            "size": 0,
+            "aggs": {
+                "genres": { "cardinality": { "field": "genre", "precision_threshold": 100 } }
+            }
+        }))
+        .await
+        .expect("search should succeed");
+
+    assert_eq!(resp.agg_value("genres"), 5.0, "{}", resp.agg("genres"));
+}
+
+#[test_context(BooksContext)]
+#[tokio::test]
+async fn test_cardinality_as_terms_sub_agg(books: &BooksContext) {
+    let resp = books
+        .search(json!({
+            "size": 0,
+            "aggs": {
+                "by_genre": {
+                    "terms": { "field": "genre" },
+                    "aggs": { "authors": { "cardinality": { "field": "author" } } }
+                }
+            }
+        }))
+        .await
+        .expect("search should succeed");
+
+    let bucket = |genre: &str| {
+        resp.buckets("by_genre")
+            .iter()
+            .find(|b| b["key"] == genre)
+            .unwrap_or_else(|| panic!("{genre} bucket"))
+            .clone()
+    };
+
+    let fiction = bucket("fiction");
+    assert_eq!(fiction["doc_count"], 4, "{fiction}");
+    assert_eq!(fiction["authors"]["value"], 4.0, "{fiction}");
+
+    // Tolkien wrote two of the three: distinct authors, not doc count.
+    let fantasy = bucket("fantasy");
+    assert_eq!(fantasy["doc_count"], 3, "{fantasy}");
+    assert_eq!(fantasy["authors"]["value"], 2.0, "{fantasy}");
+}
+
+// Analyzed text is not aggregatable, and validation recurses into sub-aggs.
+#[test_context(BooksContext)]
+#[tokio::test]
+async fn test_cardinality_sub_agg_on_analyzed_text_rejected(books: &BooksContext) {
+    books
+        .search(json!({
+            "size": 0,
+            "aggs": {
+                "by_genre": {
+                    "terms": { "field": "genre" },
+                    "aggs": { "titles": { "cardinality": { "field": "title" } } }
+                }
+            }
+        }))
+        .await
+        .expect_err("analyzed text is not aggregatable");
+}
+
+// ES answers 0, not null, for a cardinality over nothing.
+#[test_context(BooksContext)]
+#[tokio::test]
+async fn test_cardinality_over_empty_match_set_is_zero(books: &BooksContext) {
+    let resp = books
+        .search(json!({
+            "size": 0,
+            "query": { "term": { "genre": "nonexistent" } },
+            "aggs": { "genres": { "cardinality": { "field": "genre" } } }
+        }))
+        .await
+        .expect("search should succeed");
+
+    assert_eq!(resp.agg_value("genres"), 0.0, "{}", resp.agg("genres"));
+}
+
+#[test_context(TestScope)]
+#[tokio::test]
+async fn test_cardinality_on_analyzed_text_rejected(scope: &TestScope) {
+    scope
+        .create_with_properties(json!({ "body": { "type": "text" } }))
+        .await;
+
+    scope
+        .search(json!({
+            "size": 0,
+            "aggs": { "n": { "cardinality": { "field": "body" } } }
+        }))
+        .await
+        .expect_err("analyzed text is not aggregatable");
+}
+
+#[test_context(BooksContext)]
+#[tokio::test]
 async fn test_terms_agg_with_avg_sub_agg(books: &BooksContext) {
     let resp = books
         .search(json!({


### PR DESCRIPTION
adds the `cardinality` aggregation, counting distinct values of a field via `count_distinct`